### PR TITLE
Implement Schibsted display font and density controls

### DIFF
--- a/THIRD_PARTY_LICENSES/@fontsource-variable__schibsted-grotesk@5.2.8/LICENSE
+++ b/THIRD_PARTY_LICENSES/@fontsource-variable__schibsted-grotesk@5.2.8/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 The Hubot Sans Project Authors (https://github.com/github/hubot-sans), with Reserved Font Name "Hubot" HubotSans-Italic[wdth,wght].ttf: Copyright 2021 The Hubot Sans Project Authors (https://github.com/github/hubot-sans), with Reserved Font Name "Hubot"
+Copyright 2023 The Schibsted-Grotesk Project Authors (https://github.com/schibsted/schibsted-grotesk) SchibstedGrotesk-Italic[wght].ttf: Copyright 2023 The Schibsted-Grotesk Project Authors (https://github.com/schibsted/schibsted-grotesk)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `c673746962bc159333efaf01fc2c192e87349e5da44de9ef44598f52cac298e8`
+- pnpm lockfile SHA-256: `6b47c0520344127a65e2909e7bb108f8a32272a57e2bffc7a862c0cf10a0c8e3`
 - Production package entries: 507
 - Bundled license directories: 463 (44 package entries have no standalone license file or are workspace links)
 
@@ -45,8 +45,8 @@ Each package remains licensed under its own license terms. The table below is pr
 | @aws/lambda-invoke-store | 0.2.4 | Apache-2.0 | THIRD_PARTY_LICENSES/@aws__lambda-invoke-store@0.2.4/ | git+https://github.com/awslabs/aws-lambda-invoke-store.git |
 | @braintree/sanitize-url | 7.1.2 | MIT | THIRD_PARTY_LICENSES/@braintree__sanitize-url@7.1.2/ | git+https://github.com/braintree/sanitize-url.git |
 | @chevrotain/types | 11.1.2 | Apache-2.0 | THIRD_PARTY_LICENSES/@chevrotain__types@11.1.2/ | git://github.com/Chevrotain/chevrotain.git |
-| @fontsource-variable/hubot-sans | 5.2.8 | OFL-1.1 | THIRD_PARTY_LICENSES/@fontsource-variable__hubot-sans@5.2.8/ | git+https://github.com/fontsource/font-files.git |
 | @fontsource-variable/mona-sans | 5.2.8 | OFL-1.1 | THIRD_PARTY_LICENSES/@fontsource-variable__mona-sans@5.2.8/ | git+https://github.com/fontsource/font-files.git |
+| @fontsource-variable/schibsted-grotesk | 5.2.8 | OFL-1.1 | THIRD_PARTY_LICENSES/@fontsource-variable__schibsted-grotesk@5.2.8/ | git+https://github.com/fontsource/font-files.git |
 | @grammyjs/types | 3.27.3 | MIT | THIRD_PARTY_LICENSES/@grammyjs__types@3.27.3/ | git+https://github.com/grammyjs/types.git |
 | @hono/node-server | 1.19.13 | MIT | THIRD_PARTY_LICENSES/@hono__node-server@1.19.13/ | https://github.com/honojs/node-server.git |
 | @iconify/types | 2.0.0 | MIT | THIRD_PARTY_LICENSES/@iconify__types@2.0.0/ | https://github.com/iconify/iconify.git |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1054.0",
-    "@fontsource-variable/hubot-sans": "^5.2.8",
     "@fontsource-variable/mona-sans": "^5.2.8",
-    "@open-cowork/ui": "workspace:*",
+    "@fontsource-variable/schibsted-grotesk": "^5.2.8",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@open-cowork/ui": "workspace:*",
     "@opencode-ai/sdk": "1.15.5",
     "@tanstack/react-virtual": "^3.13.24",
     "ajv": "^8.20.0",

--- a/apps/desktop/src/main/cloud/web-font-assets.ts
+++ b/apps/desktop/src/main/cloud/web-font-assets.ts
@@ -16,12 +16,12 @@ const CLOUD_WEB_FONT_ASSETS = new Map<string, Buffer>([
     readFileSync(require.resolve('@fontsource-variable/mona-sans/files/mona-sans-latin-wght-italic.woff2')),
   ],
   [
-    'hubot-sans-latin-wght-normal.woff2',
-    readFileSync(require.resolve('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-normal.woff2')),
+    'schibsted-grotesk-latin-wght-normal.woff2',
+    readFileSync(require.resolve('@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-normal.woff2')),
   ],
   [
-    'hubot-sans-latin-wght-italic.woff2',
-    readFileSync(require.resolve('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-italic.woff2')),
+    'schibsted-grotesk-latin-wght-italic.woff2',
+    readFileSync(require.resolve('@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-italic.woff2')),
   ],
 ])
 

--- a/apps/desktop/src/renderer/components/sidebar/SettingsAppearancePanel.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SettingsAppearancePanel.tsx
@@ -1,4 +1,4 @@
-import { getThemeTokens, getUiThemeOptions, MONO_FONT_OPTIONS, type AppearancePreferences, type ColorScheme, type MonoFont, type UiFont, type UiTheme, UI_ACCENT_PRESETS, UI_FONT_OPTIONS, type UiAccentPresetId } from '../../helpers/theme'
+import { DENSITY_OPTIONS, getThemeTokens, getUiThemeOptions, MONO_FONT_OPTIONS, type AppearancePreferences, type ColorScheme, type Density, type MonoFont, type UiFont, type UiTheme, UI_ACCENT_PRESETS, UI_FONT_OPTIONS, type UiAccentPresetId } from '../../helpers/theme'
 import { t } from '../../helpers/i18n'
 import { Badge, Card, SegmentedControl, Select } from '../ui'
 import { fieldLabelCls, sectionLabelCls } from './settings-panel-styles'
@@ -163,6 +163,20 @@ export function AppearancePreview({
             }))}
           />
         </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <span className={sectionLabelCls}>{t('settings.appearance.density', 'Density')}</span>
+        <SegmentedControl
+          label={t('settings.appearance.density', 'Density')}
+          value={appearance.density}
+          onChange={(value) => onUpdate({ density: value as Density })}
+          className="settings-wide-control"
+          options={DENSITY_OPTIONS.map((option) => ({
+            value: option.id,
+            label: option.label,
+          }))}
+        />
       </div>
 
       <div className="rounded-2xl border border-border-subtle p-4 bg-base">

--- a/apps/desktop/src/renderer/helpers/theme.test.ts
+++ b/apps/desktop/src/renderer/helpers/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyAppearancePreferences, getAppearancePreferences, UI_FONT_OPTIONS } from './theme'
+import { applyAppearancePreferences, getAppearancePreferences, saveAppearancePreferences, UI_FONT_OPTIONS } from './theme'
 
 describe('appearance theme defaults', () => {
   it('defaults first-run appearance to Mercury with the Azure accent', () => {
@@ -21,14 +21,14 @@ describe('appearance theme defaults', () => {
 })
 
 describe('appearance typography defaults', () => {
-  it('defaults the interface font to Mona Sans and exposes the display font token', () => {
+  it('defaults the interface font to Mona Sans and exposes the Schibsted display font token', () => {
     expect(getAppearancePreferences().uiFont).toBe('mona')
     expect(UI_FONT_OPTIONS[0]).toEqual({ id: 'mona', label: 'Mona Sans' })
 
     applyAppearancePreferences()
 
     expect(document.documentElement.style.getPropertyValue('--font-ui')).toContain('Mona Sans')
-    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Hubot Sans')
+    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Schibsted Grotesk')
   })
 
   it('keeps existing interface font overrides available', () => {
@@ -38,6 +38,25 @@ describe('appearance typography defaults', () => {
 
     expect(getAppearancePreferences().uiFont).toBe('rounded')
     expect(document.documentElement.style.getPropertyValue('--font-ui')).toContain('SF Pro Rounded')
-    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Hubot Sans')
+    expect(document.documentElement.style.getPropertyValue('--font-display')).toContain('Schibsted Grotesk')
+  })
+})
+
+describe('appearance density', () => {
+  it('defaults to regular density and persists compact/comfy choices', () => {
+    expect(getAppearancePreferences().density).toBe('regular')
+
+    applyAppearancePreferences()
+    expect(document.documentElement.dataset.density).toBe('regular')
+
+    const compact = saveAppearancePreferences({ density: 'compact' })
+    expect(compact.density).toBe('compact')
+    expect(document.documentElement.dataset.density).toBe('compact')
+    expect(window.localStorage.getItem('open-cowork-density')).toBe('compact')
+
+    const comfy = saveAppearancePreferences({ density: 'comfy' })
+    expect(comfy.density).toBe('comfy')
+    expect(document.documentElement.dataset.density).toBe('comfy')
+    expect(window.localStorage.getItem('open-cowork-density')).toBe('comfy')
   })
 })

--- a/apps/desktop/src/renderer/helpers/theme.ts
+++ b/apps/desktop/src/renderer/helpers/theme.ts
@@ -17,6 +17,7 @@ export type { UiTheme, UiAccentPresetId }
 export type ColorScheme = 'system' | 'dark' | 'light'
 export type UiFont = 'mona' | 'system' | 'rounded' | 'serif'
 export type MonoFont = 'sfmono' | 'jetbrains' | 'fira'
+export type Density = 'compact' | 'regular' | 'comfy'
 
 export type AppearancePreferences = {
   colorScheme: ColorScheme
@@ -24,6 +25,7 @@ export type AppearancePreferences = {
   accent: UiAccentPresetId
   uiFont: UiFont
   monoFont: MonoFont
+  density: Density
 }
 
 const STORAGE_KEYS = {
@@ -32,6 +34,7 @@ const STORAGE_KEYS = {
   accent: 'open-cowork-ui-accent',
   uiFont: 'open-cowork-ui-font',
   monoFont: 'open-cowork-mono-font',
+  density: 'open-cowork-density',
 }
 
 const LEGACY_THEME_KEYS = ['open-cowork-theme', 'cowork-theme']
@@ -54,7 +57,7 @@ const UI_FONT_STACKS: Record<UiFont, string> = {
   serif: "'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif",
 }
 
-const DISPLAY_FONT_STACK = "'Hubot Sans Variable', 'Hubot Sans', var(--font-ui)"
+const DISPLAY_FONT_STACK = "'Schibsted Grotesk Variable', 'Schibsted Grotesk', var(--font-ui)"
 
 const MONO_FONT_STACKS: Record<MonoFont, string> = {
   sfmono: "'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace",
@@ -74,6 +77,12 @@ export const MONO_FONT_OPTIONS: Array<{ id: MonoFont; label: string }> = [
   { id: 'sfmono', label: 'SF Mono' },
   { id: 'jetbrains', label: 'JetBrains Mono' },
   { id: 'fira', label: 'Fira Code' },
+]
+
+export const DENSITY_OPTIONS: Array<{ id: Density; label: string }> = [
+  { id: 'compact', label: 'Compact' },
+  { id: 'regular', label: 'Regular' },
+  { id: 'comfy', label: 'Comfy' },
 ]
 
 let mediaCleanup: (() => void) | null = null
@@ -116,6 +125,13 @@ function readMonoFont(): MonoFont {
   return stored === 'jetbrains' || stored === 'fira' || stored === 'sfmono'
     ? stored
     : 'sfmono'
+}
+
+function readDensity(): Density {
+  const stored = localStorage.getItem(STORAGE_KEYS.density)
+  return stored === 'compact' || stored === 'regular' || stored === 'comfy'
+    ? stored
+    : 'regular'
 }
 
 function resolveColorScheme(colorScheme: ColorScheme) {
@@ -194,6 +210,7 @@ export function getAppearancePreferences(): AppearancePreferences {
     accent: readAccent(),
     uiFont: readUiFont(),
     monoFont: readMonoFont(),
+    density: readDensity(),
   }
 }
 
@@ -201,6 +218,7 @@ export function applyAppearancePreferences(preferences = getAppearancePreference
   const root = document.documentElement
   root.setAttribute('data-ui-theme', preferences.uiTheme)
   root.setAttribute('data-ui-accent', preferences.accent)
+  root.setAttribute('data-density', preferences.density)
   root.style.setProperty('--font-ui', UI_FONT_STACKS[preferences.uiFont])
   root.style.setProperty('--font-display', DISPLAY_FONT_STACK)
   root.style.setProperty('--font-mono', MONO_FONT_STACKS[preferences.monoFont])
@@ -218,6 +236,7 @@ export function saveAppearancePreferences(preferences: Partial<AppearancePrefere
   localStorage.setItem(STORAGE_KEYS.accent, next.accent)
   localStorage.setItem(STORAGE_KEYS.uiFont, next.uiFont)
   localStorage.setItem(STORAGE_KEYS.monoFont, next.monoFont)
+  localStorage.setItem(STORAGE_KEYS.density, next.density)
   applyAppearancePreferences(next)
   return next
 }

--- a/apps/desktop/src/renderer/styles/generated/design-tokens.css
+++ b/apps/desktop/src/renderer/styles/generated/design-tokens.css
@@ -20,7 +20,7 @@
   --color-info: #6f8cc4;
   --color-accent-foreground: #ffffff;
   --font-ui: 'Mona Sans Variable', 'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-display: 'Hubot Sans Variable', 'Hubot Sans', var(--font-ui);
+  --font-display: 'Schibsted Grotesk Variable', 'Schibsted Grotesk', var(--font-ui);
   --font-editorial: 'Iowan Old Style', 'New York', Georgia, serif;
   --font-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace;
   --text-2xs: 11px;
@@ -108,12 +108,14 @@
   --studio-inspector-w: 360px;
   --studio-composer-min-h: 148px;
   --studio-task-lane-w: 320px;
-  --density-compact-gap: 8px;
-  --density-compact-pad: 12px;
-  --density-regular-gap: 12px;
-  --density-regular-pad: 16px;
-  --density-spacious-gap: 16px;
-  --density-spacious-pad: 24px;
+  --density-compact-gap: 13px;
+  --density-compact-pad: 7px;
+  --density-regular-gap: 18px;
+  --density-regular-pad: 10px;
+  --density-comfy-gap: 24px;
+  --density-comfy-pad: 14px;
+  --row-pad: 10px;
+  --gap: 18px;
   --coworker-lead: var(--color-accent);
   --coworker-strategist: var(--color-info);
   --coworker-builder: var(--color-green);
@@ -140,4 +142,16 @@
   --primitive-dialog-w-lg: calc((var(--space-12) * 15) + var(--space-10));
   --measure: 840px;
   --measure-wide: 1200px;
+}
+:root[data-density="compact"] {
+  --row-pad: 7px;
+  --gap: 13px;
+}
+:root[data-density="regular"] {
+  --row-pad: 10px;
+  --gap: 18px;
+}
+:root[data-density="comfy"] {
+  --row-pad: 14px;
+  --gap: 24px;
 }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -20,20 +20,20 @@
 }
 
 @font-face {
-  font-family: 'Hubot Sans Variable';
+  font-family: 'Schibsted Grotesk Variable';
   font-style: normal;
   font-display: block;
   font-weight: 200 900;
-  src: url('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-normal.woff2') format('woff2-variations');
+  src: url('@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-normal.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
 }
 
 @font-face {
-  font-family: 'Hubot Sans Variable';
+  font-family: 'Schibsted Grotesk Variable';
   font-style: italic;
   font-display: block;
   font-weight: 200 900;
-  src: url('@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-italic.woff2') format('woff2-variations');
+  src: url('@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-italic.woff2') format('woff2-variations');
   unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
 }
 
@@ -186,7 +186,7 @@ body::after {
 
 .font-display {
   font-family: var(--font-display);
-  letter-spacing: var(--tracking-tight);
+  letter-spacing: var(--tracking-display);
 }
 
 .tabular {
@@ -905,9 +905,9 @@ body::after {
   color: var(--color-text);
 }
 
-.ui-card--sm { padding: var(--space-3); }
-.ui-card--md { padding: var(--space-4); }
-.ui-card--lg { padding: var(--space-6); }
+.ui-card--sm { padding: calc(var(--row-pad) + var(--space-1)); }
+.ui-card--md { padding: calc(var(--row-pad) + var(--space-2)); }
+.ui-card--lg { padding: calc(var(--row-pad) + var(--space-4)); }
 
 .ui-card--interactive {
   cursor: pointer;
@@ -932,7 +932,7 @@ body::after {
 .ui-card.chat-tool-row {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: calc(var(--gap) * 0.5);
 }
 
 .studio-shell {
@@ -2454,6 +2454,7 @@ body::after {
 
 .ui-polish-list-row {
   position: relative;
+  padding-block: var(--row-pad);
   transition:
     background var(--dur-1) var(--ease-out),
     border-color var(--dur-1) var(--ease-out),

--- a/apps/website/src/browser-real-e2e.spec.ts
+++ b/apps/website/src/browser-real-e2e.spec.ts
@@ -25,8 +25,8 @@ const BUILT_REACT_CLIENT_PATH = fileURLToPath(new URL('../dist/client/open-cowor
 const FONT_ASSET_SPECS = {
   'mona-sans-latin-wght-normal.woff2': '@fontsource-variable/mona-sans/files/mona-sans-latin-wght-normal.woff2',
   'mona-sans-latin-wght-italic.woff2': '@fontsource-variable/mona-sans/files/mona-sans-latin-wght-italic.woff2',
-  'hubot-sans-latin-wght-normal.woff2': '@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-normal.woff2',
-  'hubot-sans-latin-wght-italic.woff2': '@fontsource-variable/hubot-sans/files/hubot-sans-latin-wght-italic.woff2',
+  'schibsted-grotesk-latin-wght-normal.woff2': '@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-normal.woff2',
+  'schibsted-grotesk-latin-wght-italic.woff2': '@fontsource-variable/schibsted-grotesk/files/schibsted-grotesk-latin-wght-italic.woff2',
 } as const
 
 type ChromiumLauncher = {
@@ -366,7 +366,7 @@ test('cloud web workbench passes a real Chromium desktop and mobile smoke', asyn
     await page.goto(pageUrl, { waitUntil: 'load' })
     await page.evaluate(() => document.fonts?.ready)
     assert.ok(fontRequests.some((path) => path.endsWith('/mona-sans-latin-wght-normal.woff2')), 'Mona Sans font route was requested')
-    assert.ok(fontRequests.some((path) => path.endsWith('/hubot-sans-latin-wght-normal.woff2')), 'Hubot Sans font route was requested')
+    assert.ok(fontRequests.some((path) => path.endsWith('/schibsted-grotesk-latin-wght-normal.woff2')), 'Schibsted Grotesk font route was requested')
     assert.deepEqual(reactClientRequests, ['/assets/open-cowork-cloud-react.js'])
     if (builtReactClient) {
       try {
@@ -425,6 +425,10 @@ test('cloud web workbench passes a real Chromium desktop and mobile smoke', asyn
         await page.evaluate(() => document.documentElement.style.getPropertyValue('--color-accent')),
         UI_ACCENT_PRESETS[DEFAULT_UI_ACCENT_PRESET_ID].accent,
       )
+      await page.locator('#cloud-theme-density').selectOption('compact')
+      await page.waitForFunction(() => document.documentElement.dataset.density === 'compact')
+      assert.equal(await page.evaluate(() => document.documentElement.dataset.density), 'compact')
+      assert.equal(await page.locator('#cloud-theme-density').inputValue(), 'compact')
     }
     assert.equal(await page.locator('[data-cloud-react-shell]').getAttribute('data-cloud-react-shell'), 'ssr')
     try {

--- a/apps/website/src/client-contract.ts
+++ b/apps/website/src/client-contract.ts
@@ -75,6 +75,7 @@ export type CloudWebClientBootstrap = {
     defaultPreset: string
     defaultScheme?: 'dark' | 'light'
     defaultAccent?: string
+    defaultDensity?: 'compact' | 'regular' | 'comfy'
     tenantBrandingLocked: boolean
     presets: Array<{
       id: string

--- a/apps/website/src/cloud-theme-client.ts
+++ b/apps/website/src/cloud-theme-client.ts
@@ -2,14 +2,18 @@ import { DEFAULT_UI_ACCENT_PRESET_ID, UI_THEME_PRESETS, accentActionFillToken, a
 import type { CloudWebClientBootstrap } from './client-contract.ts'
 import {
   CLOUD_THEME_ACCENT_STORAGE_KEY,
+  CLOUD_THEME_DENSITY_STORAGE_KEY,
   CLOUD_THEME_SCHEME_STORAGE_KEY,
   CLOUD_THEME_STORAGE_KEY,
+  DEFAULT_CLOUD_THEME_DENSITY,
   DEFAULT_CLOUD_THEME_ACCENT_PRESET,
   DEFAULT_CLOUD_THEME_PRESET,
   DEFAULT_CLOUD_THEME_SCHEME,
+  isCloudDensity,
   isCloudThemeAccentPreset,
   isCloudThemePreset,
   isCloudThemeScheme,
+  type CloudDensity,
 } from './cloud-theme.ts'
 
 const TOKEN_CSS_VARS: Array<[keyof ThemeTokens, string[]]> = [
@@ -74,6 +78,10 @@ export function applyCloudThemePreset(presetId: string, scheme: 'dark' | 'light'
   root.style.setProperty('--accent-action-fill', accentActionFillToken(tokens.accent, tokens.accent2))
 }
 
+export function applyCloudDensity(density: string | null | undefined) {
+  document.documentElement.dataset.density = isCloudDensity(density) ? density : DEFAULT_CLOUD_THEME_DENSITY
+}
+
 function storedCloudThemePreset(defaultPreset = DEFAULT_CLOUD_THEME_PRESET) {
   try {
     const stored = localStorage.getItem(CLOUD_THEME_STORAGE_KEY)
@@ -125,6 +133,23 @@ function persistCloudThemeAccent(accentId: UiAccentPresetId) {
   }
 }
 
+function storedCloudDensity(defaultDensity: CloudDensity = DEFAULT_CLOUD_THEME_DENSITY) {
+  try {
+    const stored = localStorage.getItem(CLOUD_THEME_DENSITY_STORAGE_KEY)
+    return isCloudDensity(stored) ? stored : defaultDensity
+  } catch {
+    return defaultDensity
+  }
+}
+
+function persistCloudDensity(density: CloudDensity) {
+  try {
+    localStorage.setItem(CLOUD_THEME_DENSITY_STORAGE_KEY, density)
+  } catch {
+    // Local persistence is best-effort only; the selected density still applies for this page.
+  }
+}
+
 const themeControlDocuments = new WeakSet<Document>()
 
 function installThemeControlChangeListener(ownerDocument: Document) {
@@ -132,7 +157,14 @@ function installThemeControlChangeListener(ownerDocument: Document) {
   ownerDocument.addEventListener('change', (event) => {
     const select = event.target as HTMLSelectElement | null
     if (!select || select.tagName !== 'SELECT') return
-    if (!['cloud-theme-preset', 'cloud-theme-scheme', 'cloud-theme-accent'].includes(select.id)) return
+    if (!['cloud-theme-preset', 'cloud-theme-scheme', 'cloud-theme-accent', 'cloud-theme-density'].includes(select.id)) return
+    if (select.id === 'cloud-theme-density') {
+      const density = isCloudDensity(select.value) ? select.value : DEFAULT_CLOUD_THEME_DENSITY
+      select.value = density
+      persistCloudDensity(density)
+      applyCloudDensity(density)
+      return
+    }
     if (select.disabled || select.dataset.tenantBrandingLocked === 'true') return
     const presetSelect = ownerDocument.getElementById('cloud-theme-preset') as HTMLSelectElement | null
     const schemeSelect = ownerDocument.getElementById('cloud-theme-scheme') as HTMLSelectElement | null
@@ -155,6 +187,7 @@ export function installCloudThemePresetControls(bootstrap: CloudWebClientBootstr
   const select = document.getElementById('cloud-theme-preset') as HTMLSelectElement | null
   const schemeSelect = document.getElementById('cloud-theme-scheme') as HTMLSelectElement | null
   const accentSelect = document.getElementById('cloud-theme-accent') as HTMLSelectElement | null
+  const densitySelect = document.getElementById('cloud-theme-density') as HTMLSelectElement | null
   if (!select) return
   const locked = Boolean(bootstrap.theme?.tenantBrandingLocked)
   for (const control of [select, schemeSelect, accentSelect]) {
@@ -162,6 +195,14 @@ export function installCloudThemePresetControls(bootstrap: CloudWebClientBootstr
     control.disabled = locked
     control.dataset.tenantBrandingLocked = locked ? 'true' : 'false'
   }
+  const bootstrapDensity = isCloudDensity(bootstrap.theme?.defaultDensity)
+    ? bootstrap.theme.defaultDensity
+    : DEFAULT_CLOUD_THEME_DENSITY
+  const initialDensity = storedCloudDensity(bootstrapDensity)
+  if (densitySelect) densitySelect.value = initialDensity
+  applyCloudDensity(initialDensity)
+  installThemeControlChangeListener(document)
+
   if (locked) {
     select.title = 'Theme is managed by this cloud workspace'
     if (schemeSelect) schemeSelect.title = select.title
@@ -176,5 +217,4 @@ export function installCloudThemePresetControls(bootstrap: CloudWebClientBootstr
   if (schemeSelect) schemeSelect.value = initialScheme
   if (accentSelect) accentSelect.value = initialAccent
   applyCloudThemePreset(initialPreset, initialScheme, initialAccent)
-  installThemeControlChangeListener(document)
 }

--- a/apps/website/src/cloud-theme.test.ts
+++ b/apps/website/src/cloud-theme.test.ts
@@ -4,12 +4,14 @@ import { createRequire } from 'node:module'
 import { UI_THEME_PRESETS, accentActionFillToken } from '@open-cowork/shared'
 import {
   CLOUD_THEME_ACCENT_STORAGE_KEY,
+  CLOUD_THEME_DENSITY_STORAGE_KEY,
   CLOUD_THEME_SCHEME_STORAGE_KEY,
   CLOUD_THEME_STORAGE_KEY,
   cloudAccentPresetOptions,
+  cloudDensityOptions,
   cloudThemePresetOptions,
 } from './cloud-theme.ts'
-import { applyCloudThemePreset, installCloudThemePresetControls } from './cloud-theme-client.ts'
+import { applyCloudDensity, applyCloudThemePreset, installCloudThemePresetControls } from './cloud-theme-client.ts'
 import type { CloudWebClientBootstrap } from './client-contract.ts'
 
 const require = createRequire(import.meta.url)
@@ -40,6 +42,7 @@ function bootstrap(tenantBrandingLocked: boolean): CloudWebClientBootstrap {
       defaultPreset: 'mercury',
       defaultScheme: 'dark',
       defaultAccent: 'azure',
+      defaultDensity: 'regular',
       tenantBrandingLocked,
       presets: cloudThemePresetOptions(),
       accents: cloudAccentPresetOptions(),
@@ -63,7 +66,10 @@ function withThemeDom(run: (dom: ThemeDom) => void) {
   const accents = cloudAccentPresetOptions()
     .map((preset) => `<option value="${preset.id}">${preset.label}</option>`)
     .join('')
-  const dom = new JSDOM(`<select id="cloud-theme-preset">${options}</select><select id="cloud-theme-scheme"><option value="dark">Mercury</option><option value="light">Day</option></select><select id="cloud-theme-accent">${accents}</select>`, { url: 'https://cloud.example.test/' })
+  const densities = cloudDensityOptions()
+    .map((density) => `<option value="${density.id}">${density.label}</option>`)
+    .join('')
+  const dom = new JSDOM(`<select id="cloud-theme-preset">${options}</select><select id="cloud-theme-scheme"><option value="dark">Mercury</option><option value="light">Day</option></select><select id="cloud-theme-accent">${accents}</select><select id="cloud-theme-density">${densities}</select>`, { url: 'https://cloud.example.test/' })
   ;(globalThis as { document?: Document }).document = dom.window.document
   ;(globalThis as { localStorage?: Storage }).localStorage = dom.window.localStorage
   try {
@@ -84,17 +90,21 @@ test('cloud theme switcher applies and persists shared preset tokens when unlock
   localStorage.setItem(CLOUD_THEME_STORAGE_KEY, 'tokyostorm')
   localStorage.setItem(CLOUD_THEME_SCHEME_STORAGE_KEY, 'light')
   localStorage.setItem(CLOUD_THEME_ACCENT_STORAGE_KEY, 'teal')
+  localStorage.setItem(CLOUD_THEME_DENSITY_STORAGE_KEY, 'compact')
   installCloudThemePresetControls(bootstrap(false))
   const select = document.getElementById('cloud-theme-preset') as HTMLSelectElement
   const scheme = document.getElementById('cloud-theme-scheme') as HTMLSelectElement
   const accent = document.getElementById('cloud-theme-accent') as HTMLSelectElement
+  const density = document.getElementById('cloud-theme-density') as HTMLSelectElement
   assert.equal(select.disabled, false)
   assert.equal(select.value, 'tokyostorm')
   assert.equal(scheme.value, 'light')
   assert.equal(accent.value, 'teal')
+  assert.equal(density.value, 'compact')
   assert.equal(document.documentElement.dataset.uiTheme, 'tokyostorm')
   assert.equal(document.documentElement.dataset.colorScheme, 'light')
   assert.equal(document.documentElement.dataset.uiAccent, 'teal')
+  assert.equal(document.documentElement.dataset.density, 'compact')
   assert.equal(document.documentElement.style.getPropertyValue('--color-base'), UI_THEME_PRESETS.tokyostorm.light.base)
   assert.equal(document.documentElement.style.getPropertyValue('--color-accent'), '#3f9a8f')
   assert.equal(document.documentElement.style.getPropertyValue('--accent-2'), '#5bb4a8')
@@ -113,6 +123,11 @@ test('cloud theme switcher applies and persists shared preset tokens when unlock
   assert.equal(document.documentElement.style.getPropertyValue('--accent-2'), '#e87b9c')
   assert.equal(document.documentElement.style.getPropertyValue('--accent-text'), '#e87b9c')
   assert.equal(document.documentElement.style.getPropertyValue('--accent-action-foreground'), '#000000')
+
+  density.value = 'comfy'
+  density.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
+  assert.equal(localStorage.getItem(CLOUD_THEME_DENSITY_STORAGE_KEY), 'comfy')
+  assert.equal(document.documentElement.dataset.density, 'comfy')
 }))
 
 test('cloud theme switcher survives React hydration replacing the select node', () => withThemeDom((dom) => {
@@ -123,21 +138,29 @@ test('cloud theme switcher survives React hydration replacing the select node', 
   const accents = cloudAccentPresetOptions()
     .map((preset) => `<option value="${preset.id}">${preset.label}</option>`)
     .join('')
-  document.body.innerHTML = `<select id="cloud-theme-preset">${options}</select><select id="cloud-theme-scheme"><option value="dark">Mercury</option><option value="light">Day</option></select><select id="cloud-theme-accent">${accents}</select>`
+  const densities = cloudDensityOptions()
+    .map((density) => `<option value="${density.id}">${density.label}</option>`)
+    .join('')
+  document.body.innerHTML = `<select id="cloud-theme-preset">${options}</select><select id="cloud-theme-scheme"><option value="dark">Mercury</option><option value="light">Day</option></select><select id="cloud-theme-accent">${accents}</select><select id="cloud-theme-density">${densities}</select>`
 
   const select = document.getElementById('cloud-theme-preset') as HTMLSelectElement
   const scheme = document.getElementById('cloud-theme-scheme') as HTMLSelectElement
   const accent = document.getElementById('cloud-theme-accent') as HTMLSelectElement
+  const density = document.getElementById('cloud-theme-density') as HTMLSelectElement
   select.value = 'frappe'
   scheme.value = 'light'
   accent.value = 'amber'
   select.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
+  density.value = 'compact'
+  density.dispatchEvent(new dom.window.Event('change', { bubbles: true }))
 
   assert.equal(localStorage.getItem(CLOUD_THEME_STORAGE_KEY), 'frappe')
   assert.equal(localStorage.getItem(CLOUD_THEME_SCHEME_STORAGE_KEY), 'light')
   assert.equal(localStorage.getItem(CLOUD_THEME_ACCENT_STORAGE_KEY), 'amber')
+  assert.equal(localStorage.getItem(CLOUD_THEME_DENSITY_STORAGE_KEY), 'compact')
   assert.equal(document.documentElement.dataset.uiTheme, 'frappe')
   assert.equal(document.documentElement.dataset.colorScheme, 'light')
+  assert.equal(document.documentElement.dataset.density, 'compact')
   assert.equal(document.documentElement.style.getPropertyValue('--color-base'), UI_THEME_PRESETS.frappe.light.base)
   assert.equal(document.documentElement.style.getPropertyValue('--color-accent'), '#e0913a')
   assert.equal(document.documentElement.style.getPropertyValue('--accent-text'), '#966127')
@@ -149,11 +172,14 @@ test('cloud theme switcher preserves tenant branding when locked', () => withThe
   const select = document.getElementById('cloud-theme-preset') as HTMLSelectElement
   const scheme = document.getElementById('cloud-theme-scheme') as HTMLSelectElement
   const accent = document.getElementById('cloud-theme-accent') as HTMLSelectElement
+  const density = document.getElementById('cloud-theme-density') as HTMLSelectElement
   assert.equal(select.disabled, true)
   assert.equal(scheme.disabled, true)
   assert.equal(accent.disabled, true)
+  assert.equal(density.disabled, false)
   assert.equal(select.dataset.tenantBrandingLocked, 'true')
   assert.equal(document.documentElement.style.getPropertyValue('--color-base'), '')
+  assert.equal(document.documentElement.dataset.density, 'regular')
 }))
 
 test('cloud theme applies preset tokens directly', () => withThemeDom(() => {
@@ -166,4 +192,11 @@ test('cloud theme applies preset tokens directly', () => withThemeDom(() => {
   assert.equal(document.documentElement.style.getPropertyValue('--accent-2'), '#a594f5')
   assert.equal(document.documentElement.style.getPropertyValue('--accent-text'), '#6c61bb')
   assert.equal(document.documentElement.style.getPropertyValue('--focus'), focusTokenForAccent('#8b7cf0'))
+}))
+
+test('cloud density applies directly with a regular fallback', () => withThemeDom(() => {
+  applyCloudDensity('compact')
+  assert.equal(document.documentElement.dataset.density, 'compact')
+  applyCloudDensity('wide')
+  assert.equal(document.documentElement.dataset.density, 'regular')
 }))

--- a/apps/website/src/cloud-theme.ts
+++ b/apps/website/src/cloud-theme.ts
@@ -4,9 +4,12 @@ import { escapeHtml } from './html-utils.ts'
 export const CLOUD_THEME_STORAGE_KEY = 'open-cowork-cloud-ui-theme'
 export const CLOUD_THEME_SCHEME_STORAGE_KEY = 'open-cowork-cloud-color-scheme'
 export const CLOUD_THEME_ACCENT_STORAGE_KEY = 'open-cowork-cloud-ui-accent'
+export const CLOUD_THEME_DENSITY_STORAGE_KEY = 'open-cowork-cloud-density'
 export const DEFAULT_CLOUD_THEME_PRESET = 'mercury'
 export const DEFAULT_CLOUD_THEME_SCHEME = 'dark'
 export const DEFAULT_CLOUD_THEME_ACCENT_PRESET = DEFAULT_UI_ACCENT_PRESET_ID
+export const DEFAULT_CLOUD_THEME_DENSITY = 'regular'
+export type CloudDensity = 'compact' | 'regular' | 'comfy'
 
 export function cloudThemePresetOptions() {
   return Object.entries(UI_THEME_PRESETS).map(([id, preset]) => ({
@@ -24,6 +27,14 @@ export function cloudAccentPresetOptions() {
     accent: preset.accent,
     accent2: preset.accent2,
   }))
+}
+
+export function cloudDensityOptions(): Array<{ id: CloudDensity; label: string }> {
+  return [
+    { id: 'compact', label: 'Compact' },
+    { id: 'regular', label: 'Regular' },
+    { id: 'comfy', label: 'Comfy' },
+  ]
 }
 
 export function cloudThemePresetSelectMarkup(tenantBrandingLocked: boolean) {
@@ -48,6 +59,12 @@ export function cloudThemePresetSelectMarkup(tenantBrandingLocked: boolean) {
               ${cloudAccentPresetOptions().map((preset) => `<option value="${escapeHtml(preset.id)}"${preset.id === DEFAULT_CLOUD_THEME_ACCENT_PRESET ? ' selected' : ''}>${escapeHtml(preset.label)}</option>`).join('')}
             </select>
           </label>
+          <label class="cloud-theme-switcher">
+            <span>Density</span>
+            <select id="cloud-theme-density" aria-label="Interface density">
+              ${cloudDensityOptions().map((option) => `<option value="${escapeHtml(option.id)}"${option.id === DEFAULT_CLOUD_THEME_DENSITY ? ' selected' : ''}>${escapeHtml(option.label)}</option>`).join('')}
+            </select>
+          </label>
         </div>`
 }
 
@@ -61,4 +78,8 @@ export function isCloudThemeScheme(value: string | null | undefined): value is '
 
 export function isCloudThemeAccentPreset(value: string | null | undefined) {
   return Boolean(value && Object.prototype.hasOwnProperty.call(UI_ACCENT_PRESETS, value))
+}
+
+export function isCloudDensity(value: string | null | undefined): value is CloudDensity {
+  return value === 'compact' || value === 'regular' || value === 'comfy'
 }

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -415,6 +415,7 @@ test('cloud website exposes shared theme presets with tenant branding precedence
   assert.equal(bootstrap.theme.defaultPreset, 'mercury')
   assert.equal(bootstrap.theme.defaultScheme, 'dark')
   assert.equal(bootstrap.theme.defaultAccent, 'azure')
+  assert.equal(bootstrap.theme.defaultDensity, 'regular')
   assert.equal(bootstrap.theme.tenantBrandingLocked, false)
   assert.equal(bootstrap.theme.presets.length, 18)
   assert.equal(bootstrap.theme.accents.length, 6)
@@ -422,9 +423,11 @@ test('cloud website exposes shared theme presets with tenant branding precedence
   assert.match(html, /id="cloud-theme-preset"/)
   assert.match(html, /id="cloud-theme-scheme"/)
   assert.match(html, /id="cloud-theme-accent"/)
+  assert.match(html, /id="cloud-theme-density"/)
   assert.match(html, /<option value="mercury" selected>Mercury<\/option>/)
   assert.match(html, /<option value="dark" selected>Mercury<\/option>/)
   assert.match(html, /<option value="azure" selected>Azure<\/option>/)
+  assert.match(html, /<option value="regular" selected>Regular<\/option>/)
 
   const defaultedBranding = cloudWebsiteHtml({
     role: 'owner',
@@ -436,6 +439,7 @@ test('cloud website exposes shared theme presets with tenant branding precedence
   assert.ok(defaultedBrandingMatch)
   assert.equal(JSON.parse(defaultedBrandingMatch[1]).theme.tenantBrandingLocked, false)
   assert.doesNotMatch(defaultedBranding, /<select(?=[^>]*id="cloud-theme-preset")(?=[^>]*data-tenant-branding-locked="true")(?=[^>]* disabled)[^>]*>/)
+  assert.doesNotMatch(defaultedBranding, /<select(?=[^>]*id="cloud-theme-density")(?=[^>]* disabled)[^>]*>/)
 
   const branded = cloudWebsiteHtml({
     role: 'owner',
@@ -449,6 +453,7 @@ test('cloud website exposes shared theme presets with tenant branding precedence
   assert.ok(brandedMatch)
   assert.equal(JSON.parse(brandedMatch[1]).theme.tenantBrandingLocked, true)
   assert.match(branded, /<select(?=[^>]*id="cloud-theme-preset")(?=[^>]*data-tenant-branding-locked="true")(?=[^>]* disabled)[^>]*>/)
+  assert.doesNotMatch(branded, /<select(?=[^>]*id="cloud-theme-density")(?=[^>]* disabled)[^>]*>/)
 })
 
 test('cloud website keeps existing admin dashboard surfaces available', () => {

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -17,7 +17,7 @@ import { CloudReactSsrShell } from './react-shell.ts'
 import { CLOUD_WEB_ROUTE_API_MATRIX } from './route-api-matrix.ts'
 import { routeAdminSurfaceMarkup, routeGroupsMarkup, routePanelAttrs, routeParityMarkup } from './route-markup.ts'
 import { CLOUD_WEB_REACT_CLIENT_ASSET_PATH } from './react-client-asset.ts'
-import { DEFAULT_CLOUD_THEME_ACCENT_PRESET, DEFAULT_CLOUD_THEME_PRESET, DEFAULT_CLOUD_THEME_SCHEME, cloudAccentPresetOptions, cloudThemePresetOptions, cloudThemePresetSelectMarkup } from './cloud-theme.ts'
+import { DEFAULT_CLOUD_THEME_ACCENT_PRESET, DEFAULT_CLOUD_THEME_DENSITY, DEFAULT_CLOUD_THEME_PRESET, DEFAULT_CLOUD_THEME_SCHEME, cloudAccentPresetOptions, cloudThemePresetOptions, cloudThemePresetSelectMarkup } from './cloud-theme.ts'
 import { CLOUD_WEB_WORKBENCH_PARITY_MATRIX } from './workbench-parity.ts'
 import { CLOUD_SESSION_EVENT_TYPES, type PublicBrandingConfig } from '@open-cowork/shared'
 
@@ -40,6 +40,7 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
       defaultPreset: DEFAULT_CLOUD_THEME_PRESET,
       defaultScheme: DEFAULT_CLOUD_THEME_SCHEME,
       defaultAccent: DEFAULT_CLOUD_THEME_ACCENT_PRESET,
+      defaultDensity: DEFAULT_CLOUD_THEME_DENSITY,
       tenantBrandingLocked,
       presets: themePresets,
       accents: accentPresets,

--- a/apps/website/src/style-chat.ts
+++ b/apps/website/src/style-chat.ts
@@ -418,7 +418,7 @@ export function cloudWebsiteChatStyles() {
       max-width: 880px;
       border: var(--border-width-1) solid var(--color-border);
       border-radius: var(--radius-xl) var(--radius-xl) var(--radius-xl) var(--radius-xs);
-      padding: var(--space-3) var(--space-4);
+      padding: var(--row-pad) var(--space-4);
       background: color-mix(in srgb, var(--color-elevated) 72%, transparent);
       color: var(--text);
       box-shadow: var(--shadow-1), var(--specular);
@@ -448,7 +448,7 @@ export function cloudWebsiteChatStyles() {
     .message-bubble[data-role="assistant"][data-streaming="true"] {
       border-radius: var(--radius-xl) var(--radius-xl) var(--radius-xl) var(--radius-xs);
       background: color-mix(in srgb, var(--color-elevated) 58%, transparent);
-      padding: var(--space-3) var(--space-4);
+      padding: var(--row-pad) var(--space-4);
     }
     .message-bubble[data-streaming="true"] p:last-of-type {
       background: linear-gradient(100deg, var(--text) 30%, var(--accent) 50%, var(--text) 70%);

--- a/apps/website/src/style-components.ts
+++ b/apps/website/src/style-components.ts
@@ -169,12 +169,12 @@ export function cloudWebsiteComponentStyles() {
     .panel {
       min-width: 0;
       display: grid;
-      gap: var(--space-3);
+      gap: var(--gap);
       border: var(--border-width-1) solid var(--color-border);
       border-radius: var(--radius-lg);
       background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
       color: var(--text);
-      padding: var(--space-4);
+      padding: calc(var(--row-pad) + var(--space-2));
       box-shadow: var(--shadow-2), var(--specular);
     }
     .panel h3 {
@@ -182,7 +182,7 @@ export function cloudWebsiteComponentStyles() {
       font-family: var(--font-display);
       font-size: var(--text-md);
       font-weight: 650;
-      letter-spacing: var(--tracking-tight);
+      letter-spacing: var(--tracking-display);
       line-height: var(--lh-md);
     }
     .parity-grid,
@@ -190,18 +190,18 @@ export function cloudWebsiteComponentStyles() {
       grid-column: 1 / -1;
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: var(--space-2);
+      gap: var(--gap);
       min-width: 0;
     }
     .parity-card,
     .surface-card {
       min-width: 0;
       display: grid;
-      gap: var(--space-2);
+      gap: calc(var(--gap) * 0.5);
       border: var(--border-width-1) solid var(--color-border);
       border-radius: var(--radius-sm);
       background: color-mix(in srgb, var(--color-surface) 76%, transparent);
-      padding: var(--space-3);
+      padding: calc(var(--row-pad) + var(--space-1));
     }
     .agent-card,
     .capability-card {
@@ -209,12 +209,12 @@ export function cloudWebsiteComponentStyles() {
       min-width: 0;
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
-      gap: var(--space-3);
+      gap: var(--gap);
       align-items: start;
       border: var(--border-width-1) solid var(--color-border);
       border-radius: var(--radius-lg);
       background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
-      padding: var(--space-3);
+      padding: calc(var(--row-pad) + var(--space-1));
       box-shadow: var(--shadow-2), var(--specular);
       transition:
         background var(--dur-1) var(--ease-out),
@@ -327,11 +327,11 @@ export function cloudWebsiteComponentStyles() {
       box-shadow: var(--shadow-2), var(--specular);
       min-width: 0;
     }
-        .table-row {
-          display: grid;
-          grid-template-columns: minmax(180px, 1.4fr) minmax(90px, 0.6fr) minmax(110px, 0.7fr) minmax(120px, 0.7fr);
-          gap: var(--space-3);
-          min-height: calc(var(--control-h-sm) + var(--space-2));
+    .table-row {
+      display: grid;
+      grid-template-columns: minmax(180px, 1.4fr) minmax(90px, 0.6fr) minmax(110px, 0.7fr) minmax(120px, 0.7fr);
+      gap: var(--gap);
+      min-height: calc(var(--control-h-sm) + (var(--row-pad) * 2));
       align-items: center;
       padding: 0 var(--space-3);
       border-top: var(--border-width-1) solid var(--color-border-subtle);
@@ -415,13 +415,13 @@ export function cloudWebsiteComponentStyles() {
     }
     .row {
       position: relative;
-      min-height: calc(var(--control-h-md) + var(--space-3));
+      min-height: calc(var(--control-h-md) + (var(--row-pad) * 2));
       border: var(--border-width-1) solid var(--color-border);
       border-radius: var(--radius-sm);
-      padding: var(--space-2) var(--space-3);
+      padding: var(--row-pad) var(--space-3);
       display: grid;
       grid-template-columns: minmax(0, 1fr) auto;
-      gap: var(--space-3);
+      gap: var(--gap);
       align-items: center;
       background: var(--color-surface);
       min-width: 0;

--- a/apps/website/src/style-layout.ts
+++ b/apps/website/src/style-layout.ts
@@ -17,10 +17,10 @@ export function cloudWebsiteLayoutStyles() {
       max-height: 100vh;
       background: color-mix(in srgb, var(--color-base) 88%, var(--color-elevated) 12%);
       border-right: var(--border-width-1) solid var(--color-border-subtle);
-      padding: var(--space-3);
+      padding: var(--row-pad);
       display: flex;
       flex-direction: column;
-      gap: var(--space-3);
+      gap: var(--gap);
       box-shadow: inset -1px 0 0 var(--color-border-subtle);
       overflow-x: hidden;
       overflow-y: auto;
@@ -59,7 +59,7 @@ export function cloudWebsiteLayoutStyles() {
       color: var(--text);
       font-family: var(--font-display);
       font-weight: 650;
-      letter-spacing: var(--tracking-tight);
+      letter-spacing: var(--tracking-display);
     }
     .brand-title {
       overflow: hidden;
@@ -92,7 +92,7 @@ export function cloudWebsiteLayoutStyles() {
       border-radius: var(--radius-lg);
       background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
       box-shadow: var(--surface-highlight);
-      padding: var(--space-2);
+      padding: var(--row-pad);
       min-width: 0;
     }
     .workspace-card-row {
@@ -172,7 +172,7 @@ export function cloudWebsiteLayoutStyles() {
       justify-content: space-between;
       border-color: transparent;
       background: transparent;
-      padding: var(--space-1) var(--space-2);
+      padding: var(--row-pad) var(--space-2);
       text-align: left;
     }
     .sidebar-thread-row:hover:not(:disabled) {

--- a/apps/website/src/style-primitives.ts
+++ b/apps/website/src/style-primitives.ts
@@ -197,9 +197,9 @@ export function cloudWebsitePrimitiveStyles() {
       box-shadow: var(--shadow-2), var(--specular);
       color: var(--color-text);
     }
-    .ui-card--sm { padding: var(--space-3); }
-    .ui-card--md { padding: var(--space-4); }
-    .ui-card--lg { padding: var(--space-6); }
+    .ui-card--sm { padding: calc(var(--row-pad) + var(--space-1)); }
+    .ui-card--md { padding: calc(var(--row-pad) + var(--space-2)); }
+    .ui-card--lg { padding: calc(var(--row-pad) + var(--space-4)); }
     .ui-card--interactive {
       display: block;
       width: 100%;

--- a/apps/website/src/styles.ts
+++ b/apps/website/src/styles.ts
@@ -33,19 +33,19 @@ function cloudWebsiteFontFaces() {
   unicode-range: ${FONT_UNICODE_RANGE};
 }
 @font-face {
-  font-family: 'Hubot Sans Variable';
+  font-family: 'Schibsted Grotesk Variable';
   font-style: normal;
   font-display: block;
   font-weight: 200 900;
-  src: url('/assets/fonts/hubot-sans-latin-wght-normal.woff2') format('woff2-variations');
+  src: url('/assets/fonts/schibsted-grotesk-latin-wght-normal.woff2') format('woff2-variations');
   unicode-range: ${FONT_UNICODE_RANGE};
 }
 @font-face {
-  font-family: 'Hubot Sans Variable';
+  font-family: 'Schibsted Grotesk Variable';
   font-style: italic;
   font-display: block;
   font-weight: 200 900;
-  src: url('/assets/fonts/hubot-sans-latin-wght-italic.woff2') format('woff2-variations');
+  src: url('/assets/fonts/schibsted-grotesk-latin-wght-italic.woff2') format('woff2-variations');
   unicode-range: ${FONT_UNICODE_RANGE};
 }`
 }

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -240,7 +240,7 @@ the checklist cannot drift from the source contract.
 - Responsive desktop and mobile views have no horizontal overflow, clipped
   controls, or unreachable keyboard focus targets.
 - `/assets/fonts/*.woff2` requests return `200 font/woff2` and computed fonts
-  resolve to Mona Sans / Hubot Sans in the real-browser smoke.
+  resolve to Mona Sans / Schibsted Grotesk in the real-browser smoke.
 - `/assets/open-cowork-cloud-react.js` returns the Vite-built React client
   asset, and the real-browser smoke verifies that the nonce'd module route is
   requested and can mount the controller for `#open-cowork-cloud-react-root`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,7 +161,7 @@ metadata for provider setup tooling. Helm deployments can set the equivalent
 `cloud.branding` and `gateway.branding` values.
 
 Cloud Web defaults to the shared Desktop Mercury graphite palette, Mona Sans /
-Hubot Sans font stacks, and the structural token scale from
+Schibsted Grotesk font stacks, and the structural token scale from
 `packages/shared/src/design-tokens.ts`. Public branding may override color and
 brand presentation keys such as `background`, `surface`, `elevated`, `text`,
 `mutedText`, `accent`, `accent2`, `accentHover`, `accentForeground`, semantic

--- a/docs/design-refinement-and-cloud-react-proposal.md
+++ b/docs/design-refinement-and-cloud-react-proposal.md
@@ -10,7 +10,7 @@
 
 ## 1. Why this, and what's really going on
 
-The two apps look different, but **not because they use different design tokens** — they already share the same vocabulary (`--color-*`, `--space-*`, `--radius-*`, Mona Sans / Hubot Sans). The real gaps are:
+The two apps look different, but **not because they use different design tokens** — they already share the same vocabulary (`--color-*`, `--space-*`, `--radius-*`, Mona Sans / Schibsted Grotesk). The real gaps are:
 
 - **Aesthetic ceiling (both apps).** The shared "Mercury" language is *decorated but soft*: ultra-faint borders (`rgba(180,194,250,0.07)`), low-alpha tinted surfaces (`rgba(141,164,245,0.04)`), and a full-bleed radial gradient. Surfaces blend into the background, so the UI reads "pretty but mushy" rather than crisp and intentional. Codex's polish comes from the opposite instinct: **clear hairlines, calm flat surfaces, functional color, tight typographic hierarchy.** We can adopt that *discipline* without abandoning the indigo palette or the presets.
 - **Interaction ceiling (cloud only).** Cloud Web is server-rendered HTML strings + 12 concatenated vanilla-JS client scripts. It can match Desktop *visually* but not *behaviorally* — rich client state, optimistic updates, virtualized timelines, command palette, etc. are all reimplemented by hand against `innerHTML`. React closes this for good.
@@ -66,7 +66,7 @@ Scale is `1,2,3,4,5,6,8,10,12` (×4px) — solid but gappy above 24px. Fill the 
 Scale (`11→38px`) is already near-modular (~1.25 at the top). Refine optics, not sizes:
 
 - Add **letter-spacing tokens** for large display text: `--tracking-tight: -0.01em` (xl/2xl), `-0.02em` (3xl/hero) — tightens headings the way Codex does.
-- Enforce `--font-display` (Hubot Sans) on page/section titles; body stays Mona Sans.
+- Enforce `--font-display` (Schibsted Grotesk) on page/section titles; body stays Mona Sans.
 - Bump weight contrast: titles 600–650, body 400, metadata 450 muted. Variable fonts (200–900) already support this.
 
 ### 3.4 Motion polish

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -144,7 +144,7 @@ execution behavior.
 | Token family | Role |
 | --- | --- |
 | `--studio-shell-*` | shared shell, topbar, inspector, composer, and task-lane dimensions |
-| `--density-*` | compact, regular, and spacious gap/padding values for operational surfaces |
+| `--density-*` | compact, regular, and comfy row padding/gap values for operational surfaces; emitted as `--row-pad` and `--gap` via `:root[data-density]` |
 | `--coworker-*` | semantic agent/coworker identity colors for lead, strategist, builder, reviewer, operator, and neutral identities |
 | `--lane-*` | planning, delegated, review, approval, and artifact lane colors |
 | `--review-*` | proposed, accepted, and blocked review outcome colors |
@@ -160,7 +160,7 @@ OpenCode and the existing Open Cowork projection layer.
 | Shared package | `packages/shared/src/design-tokens.ts` | Canonical typed token values, default dark brand theme, public branding bridge, and CSS emitter. |
 | Shared React UI | `packages/ui/src/` | Token-backed `WorkbenchLayout`, `ActionCluster`, `DiffView`, Studio shell/coworker/composer/lane/card primitives, and base primitive components consumed by Desktop and Cloud Web. |
 | Desktop | `apps/desktop/src/renderer/styles/generated/design-tokens.css` | Generated `:root` CSS variables imported by `globals.css`; do not hand-edit. |
-| Cloud Web | `apps/website/src/styles.ts` and `apps/website/src/style-shared-ui.ts` | Inline shell CSS imports `emitRootTokensCss()`, serves Mona Sans / Hubot Sans from `/assets/fonts/*.woff2`, overlays public branding variables, and styles the shared workbench/review primitives used by the Vite React client. |
+| Cloud Web | `apps/website/src/styles.ts` and `apps/website/src/style-shared-ui.ts` | Inline shell CSS imports `emitRootTokensCss()`, serves Mona Sans / Schibsted Grotesk from `/assets/fonts/*.woff2`, overlays public branding variables, and styles the shared workbench/review primitives used by the Vite React client. |
 | Drift gate | `tests/design-tokens-sync.test.ts` | Fails when generated Desktop tokens, shared tokens, font package assumptions, or default public branding drift. |
 
 Run `pnpm design-tokens:build` after editing `DESIGN_TOKENS`. CI also runs

--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -213,7 +213,7 @@ Cloud Web theming is intentionally narrow. Downstream overlays can change
 `cloud.publicBranding` names, logo/legal/support URLs, dashboard copy, token
 labels, and public theme colors, including the expanded dark-token keys
 documented in [Design Tokens](design-tokens.md). They should not fork Cloud Web
-layout CSS, add a separate build pipeline, replace Mona/Hubot font serving, or
+layout CSS, add a separate build pipeline, replace Mona/Schibsted font serving, or
 change the Cloud Web cloud-client-only architecture. The shared structural
 tokens in `packages/shared/src/design-tokens.ts` keep Desktop and Cloud Web
 aligned across spacing, radius, typography scale, shadows, and control density.

--- a/docs/iconography.md
+++ b/docs/iconography.md
@@ -64,5 +64,5 @@ icon set stays tree-shakeable because no `* as Icons` namespace import is used.
 ## Licensing
 
 `lucide-react` is recorded in `THIRD_PARTY_NOTICES.md` from the package
-manifest. The bundled font packages for Mona Sans and Hubot Sans are also
+manifest. The bundled font packages for Mona Sans and Schibsted Grotesk are also
 recorded there under OFL-1.1.

--- a/docs/prototypes/agent-builder-showcase.html
+++ b/docs/prototypes/agent-builder-showcase.html
@@ -6,7 +6,7 @@
 <title>Agent Builder · character-sheet layout (prototype)</title>
 <style>
 @import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/mona-sans/index.css');
-@import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/hubot-sans/index.css');
+@import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/schibsted-grotesk/index.css');
 
 /* ── Mercury tokens + polish layer (matches the approved showcase) ── */
 :root{
@@ -26,7 +26,7 @@
   --border-subtle:color-mix(in srgb,var(--color-accent) 6%,transparent);
   --border-strong:color-mix(in srgb,var(--color-accent) 24%,transparent);
   --font-ui:'Mona Sans Variable','Mona Sans',-apple-system,BlinkMacSystemFont,sans-serif;
-  --font-display:'Hubot Sans Variable','Hubot Sans',var(--font-ui);
+  --font-display:'Schibsted Grotesk Variable','Schibsted Grotesk',var(--font-ui);
   --font-mono:'SF Mono','JetBrains Mono',ui-monospace,monospace;
   --r-sm:8px; --r-md:10px; --r-lg:14px; --r-xl:18px; --r-2xl:22px; --r-full:9999px;
   --ease-spring:cubic-bezier(.16,1,.3,1); --ease-out:cubic-bezier(.2,0,0,1);

--- a/docs/prototypes/mercury-polish-showcase.html
+++ b/docs/prototypes/mercury-polish-showcase.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Mercury · Polish Showcase</title>
 
-<!-- Real product fonts (Mona Sans UI / Hubot Sans display), graceful system fallback if offline -->
+<!-- Real product fonts (Mona Sans UI / Schibsted Grotesk display), graceful system fallback if offline -->
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
 <style>
 @import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/mona-sans/index.css');
-@import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/hubot-sans/index.css');
+@import url('https://cdn.jsdelivr.net/npm/@fontsource-variable/schibsted-grotesk/index.css');
 
 /* ============================================================================
    TOKENS
@@ -45,7 +45,7 @@
   --color-border-strong:color-mix(in srgb, var(--color-accent) 22%, transparent);
 
   --font-ui:'Mona Sans Variable','Mona Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
-  --font-display:'Hubot Sans Variable','Hubot Sans',var(--font-ui);
+  --font-display:'Schibsted Grotesk Variable','Schibsted Grotesk',var(--font-ui);
   --font-mono:'SF Mono','JetBrains Mono','Fira Code',ui-monospace,monospace;
 
   --text-2xs:11px; --text-xs:12px; --text-sm:13px; --text-md:14px;

--- a/packages/shared/src/design-tokens.ts
+++ b/packages/shared/src/design-tokens.ts
@@ -704,7 +704,7 @@ export const DESIGN_TOKENS = {
   color: DEFAULT_DARK_BRAND_THEME,
   fontFamily: {
     ui: "'Mona Sans Variable', 'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-    display: "'Hubot Sans Variable', 'Hubot Sans', var(--font-ui)",
+    display: "'Schibsted Grotesk Variable', 'Schibsted Grotesk', var(--font-ui)",
     editorial: "'Iowan Old Style', 'New York', Georgia, serif",
     mono: "'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace",
   },
@@ -815,12 +815,12 @@ export const DESIGN_TOKENS = {
     taskLaneW: '320px',
   },
   density: {
-    compactGap: '8px',
-    compactPad: '12px',
-    regularGap: '12px',
-    regularPad: '16px',
-    spaciousGap: '16px',
-    spaciousPad: '24px',
+    compactGap: '13px',
+    compactPad: '7px',
+    regularGap: '18px',
+    regularPad: '10px',
+    comfyGap: '24px',
+    comfyPad: '14px',
   },
   coworker: {
     lead: 'var(--color-accent)',
@@ -863,6 +863,18 @@ export const DESIGN_TOKENS = {
     wide: '1200px',
   },
 } as const
+
+export const DESIGN_DENSITY_IDS = ['compact', 'regular', 'comfy'] as const
+export type DesignDensityId = typeof DESIGN_DENSITY_IDS[number]
+
+const DENSITY_TOKEN_NAMES = {
+  compact: { gap: 'compactGap', pad: 'compactPad' },
+  regular: { gap: 'regularGap', pad: 'regularPad' },
+  comfy: { gap: 'comfyGap', pad: 'comfyPad' },
+} as const satisfies Record<DesignDensityId, {
+  gap: keyof typeof DESIGN_TOKENS.density
+  pad: keyof typeof DESIGN_TOKENS.density
+}>
 
 function tokenEntries(tokens = DESIGN_TOKENS): Array<[string, string]> {
   return [
@@ -924,6 +936,8 @@ function tokenEntries(tokens = DESIGN_TOKENS): Array<[string, string]> {
     ...Object.entries(tokens.controlHeight).map(([name, value]) => [`--control-h-${name}`, value] as [string, string]),
     ...Object.entries(tokens.studio).map(([name, value]) => [`--studio-${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`, value] as [string, string]),
     ...Object.entries(tokens.density).map(([name, value]) => [`--density-${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`, value] as [string, string]),
+    ['--row-pad', tokens.density.regularPad],
+    ['--gap', tokens.density.regularGap],
     ...Object.entries(tokens.coworker).map(([name, value]) => [`--coworker-${name}`, value] as [string, string]),
     ...Object.entries(tokens.lane).map(([name, value]) => [`--lane-${name}`, value] as [string, string]),
     ...Object.entries(tokens.review).map(([name, value]) => [`--review-${name}`, value] as [string, string]),
@@ -940,10 +954,23 @@ function tokenEntries(tokens = DESIGN_TOKENS): Array<[string, string]> {
   ]
 }
 
+function densitySelectorEntries(tokens = DESIGN_TOKENS): string[] {
+  return DESIGN_DENSITY_IDS.flatMap((density) => {
+    const names = DENSITY_TOKEN_NAMES[density]
+    return [
+      `:root[data-density="${density}"] {`,
+      `  --row-pad: ${tokens.density[names.pad]};`,
+      `  --gap: ${tokens.density[names.gap]};`,
+      '}',
+    ]
+  })
+}
+
 export function emitRootTokensCss(tokens = DESIGN_TOKENS): string {
   return [
     ':root {',
     ...tokenEntries(tokens).map(([name, value]) => `  ${name}: ${value};`),
     '}',
+    ...densitySelectorEntries(tokens),
   ].join('\n')
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,10 +56,10 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1054.0
         version: 3.1054.0
-      '@fontsource-variable/hubot-sans':
+      '@fontsource-variable/mona-sans':
         specifier: ^5.2.8
         version: 5.2.8
-      '@fontsource-variable/mona-sans':
+      '@fontsource-variable/schibsted-grotesk':
         specifier: ^5.2.8
         version: 5.2.8
       '@modelcontextprotocol/sdk':
@@ -1128,11 +1128,11 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fontsource-variable/hubot-sans@5.2.8':
-    resolution: {integrity: sha512-snt3rHAg6IrE0DKltYvjsIoeB+GSUpQHY3PAkMGUzxp8gN31kTl8yFuyuK6RcknIjtCVo7v0S6i31Oif3QxtjA==}
-
   '@fontsource-variable/mona-sans@5.2.8':
     resolution: {integrity: sha512-8OWdTcP8KvRxkU1Skkk+tX3D5XHN9buejxSDwrT7teRfGnpKBYxQUApV/+zS8TzeHiSU8H5Tc0HfBr57ahgcvA==}
+
+  '@fontsource-variable/schibsted-grotesk@5.2.8':
+    resolution: {integrity: sha512-nZAorDrFue4dXZbI613WdvAhu5DPH1UJYNn5fWl7Poa+nl/s9o3VUcQImIiVZpQnYG/jkPVzHsTE7WZbSDvvkw==}
 
   '@grammyjs/types@3.27.3':
     resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
@@ -5909,9 +5909,9 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@fontsource-variable/hubot-sans@5.2.8': {}
-
   '@fontsource-variable/mona-sans@5.2.8': {}
+
+  '@fontsource-variable/schibsted-grotesk@5.2.8': {}
 
   '@grammyjs/types@3.27.3': {}
 

--- a/tests/cloud-http-server.test.ts
+++ b/tests/cloud-http-server.test.ts
@@ -2049,11 +2049,16 @@ test('cloud HTTP server serves only allow-listed Cloud Web font assets', async (
   const fixture = createFixture()
   const baseUrl = await fixture.server.listen()
   try {
-    const font = await fetch(`${baseUrl}/assets/fonts/mona-sans-latin-wght-normal.woff2`)
-    assert.equal(font.status, 200)
-    assert.equal(font.headers.get('content-type'), 'font/woff2')
-    assert.equal(font.headers.get('cache-control'), 'public, max-age=86400')
-    assert.ok((await font.arrayBuffer()).byteLength > 1024, 'font response has woff2 bytes')
+    for (const fontName of [
+      'mona-sans-latin-wght-normal.woff2',
+      'schibsted-grotesk-latin-wght-normal.woff2',
+    ]) {
+      const font = await fetch(`${baseUrl}/assets/fonts/${fontName}`)
+      assert.equal(font.status, 200)
+      assert.equal(font.headers.get('content-type'), 'font/woff2')
+      assert.equal(font.headers.get('cache-control'), 'public, max-age=86400')
+      assert.ok((await font.arrayBuffer()).byteLength > 1024, `${fontName} response has woff2 bytes`)
+    }
 
     const unknown = await fetch(`${baseUrl}/assets/fonts/not-a-font.woff2`)
     assert.equal(unknown.status, 404)

--- a/tests/design-tokens-sync.test.ts
+++ b/tests/design-tokens-sync.test.ts
@@ -89,12 +89,19 @@ test('shared design tokens generate the desktop root token CSS', () => {
   }
 })
 
+test('shared design tokens emit the canonical density selectors', () => {
+  const css = emitRootTokensCss()
+  assert.ok(css.includes(':root[data-density="compact"] {\n  --row-pad: 7px;\n  --gap: 13px;\n}'))
+  assert.ok(css.includes(':root[data-density="regular"] {\n  --row-pad: 10px;\n  --gap: 18px;\n}'))
+  assert.ok(css.includes(':root[data-density="comfy"] {\n  --row-pad: 14px;\n  --gap: 24px;\n}'))
+})
+
 test('desktop font package dependencies are present for cloud font serving', () => {
   const packageJson = JSON.parse(readFileSync('apps/desktop/package.json', 'utf8')) as {
     dependencies?: Record<string, string>
   }
   assert.ok(packageJson.dependencies?.['@fontsource-variable/mona-sans'], 'Mona Sans font package is a desktop dependency')
-  assert.ok(packageJson.dependencies?.['@fontsource-variable/hubot-sans'], 'Hubot Sans font package is a desktop dependency')
+  assert.ok(packageJson.dependencies?.['@fontsource-variable/schibsted-grotesk'], 'Schibsted Grotesk font package is a desktop dependency')
 })
 
 test('design docs describe the shared Cloud Web and Desktop token contract', () => {


### PR DESCRIPTION
## Summary
- switch the shared/Desktop/Cloud display face from Hubot Sans to self-hosted Schibsted Grotesk
- add compact/regular/comfy density selectors, persistence, and UI controls on Desktop and Cloud Web
- consume density spacing in cards, rows, panels, chat bubbles, and Cloud layout surfaces
- update font serving tests, token drift tests, docs, lockfile, and third-party notices

Closes #793
Part of #791

## Verification
- pnpm --filter @open-cowork/shared build
- pnpm design-tokens:check
- pnpm --filter @open-cowork/desktop test:renderer -- src/renderer/helpers/theme.test.ts
- pnpm --filter @open-cowork/website test
- node scripts/run-node-tests.mjs tests/design-tokens-sync.test.ts tests/cloud-http-server.test.ts
- pnpm --filter @open-cowork/website build
- pnpm --filter @open-cowork/desktop build:electron
- pnpm --filter @open-cowork/desktop build
- pnpm --filter @open-cowork/website test:browser:real
- pnpm typecheck
- pnpm lint
- pnpm test:cloud-web
- pnpm docs:build
- pnpm test
- pnpm build
- git diff --check
- python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local