### PR TITLE
Align sidebar navigation with Studio layout

### DIFF
--- a/apps/desktop/src/main/cloud-workspace-adapter.ts
+++ b/apps/desktop/src/main/cloud-workspace-adapter.ts
@@ -142,6 +142,7 @@ function toSessionInfo(record: SessionRecord): SessionInfo {
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     kind: 'interactive',
+    projectSource: record.projectSource || null,
   }
 }
 

--- a/apps/desktop/src/main/cloud-workspace-cache.ts
+++ b/apps/desktop/src/main/cloud-workspace-cache.ts
@@ -2,6 +2,7 @@ import electron from 'electron'
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import type {
+  CloudProjectSourceSummary,
   SessionArtifact,
   SessionInfo,
   SessionView,
@@ -91,6 +92,17 @@ function normalizeWorkspaceId(value: unknown) {
     : null
 }
 
+function readCacheString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function readCacheRepositoryUrl(value: unknown) {
+  const raw = readCacheString(value)
+  if (!raw) return null
+  const stripped = raw.split(/[?#]/, 1)[0]?.trim() || raw
+  return stripped.replace(/^([a-z][a-z0-9+.-]*:\/\/)([^/@]+@)/i, '$1')
+}
+
 function normalizeSessionInfo(value: unknown): SessionInfo | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   const record = value as Partial<SessionInfo>
@@ -111,7 +123,33 @@ function normalizeSessionInfo(value: unknown): SessionInfo | null {
     composerAgentName: record.composerAgentName ?? null,
     composerModelId: record.composerModelId ?? null,
     composerReasoningVariant: record.composerReasoningVariant ?? null,
+    projectSource: normalizeProjectSourceSummary(record.projectSource),
   }
+}
+
+function normalizeProjectSourceSummary(value: unknown): CloudProjectSourceSummary | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const record = value as Partial<CloudProjectSourceSummary>
+  if (record.kind === 'git') {
+    const repositoryUrl = readCacheRepositoryUrl(record.repositoryUrl)
+    if (!repositoryUrl) return null
+    return {
+      kind: 'git',
+      repositoryUrl,
+      ref: readCacheString(record.ref),
+      subdirectory: readCacheString(record.subdirectory),
+    }
+  }
+  if (record.kind === 'snapshot') {
+    const snapshotId = readCacheString(record.snapshotId)
+    if (!snapshotId) return null
+    return {
+      kind: 'snapshot',
+      snapshotId,
+      title: readCacheString(record.title),
+    }
+  }
+  return null
 }
 
 function normalizeEventCursors(value: unknown): Record<string, number> {

--- a/apps/desktop/src/main/cloud/cloud-config.ts
+++ b/apps/desktop/src/main/cloud/cloud-config.ts
@@ -259,6 +259,13 @@ export function evaluateCloudProjectSourcePolicy(
         policyCode: 'project_source.git.raw_credentials',
       }
     }
+    if (url.search || url.hash) {
+      return {
+        allowed: false,
+        reason: 'Git repository URLs must not include query strings or fragments.',
+        policyCode: 'project_source.git.url_components',
+      }
+    }
     if (url.protocol === 'file:' && !policy.projectSources.git.allowFileUrls) {
       return { allowed: false, reason: 'Local file Git URLs are disabled for this cloud profile.', policyCode: 'project_source.git.file_url_disabled' }
     }

--- a/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/in-memory-control-plane-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto'
-import { normalizeWorkflowSteps, type CoordinationWatch, type WorkflowDraft, type WorkflowRun, type WorkflowRunStatus, type WorkflowStatus, type WorkflowSummary, type WorkflowTriggerType } from '@open-cowork/shared'
+import { normalizeCloudProjectSource, normalizeWorkflowSteps, summarizeCloudProjectSource, type CloudProjectSourceSummary, type CoordinationWatch, type WorkflowDraft, type WorkflowRun, type WorkflowRunStatus, type WorkflowStatus, type WorkflowSummary, type WorkflowTriggerType } from '@open-cowork/shared'
 import type { CloudBillingEntitlements, CloudSubscriptionStatus } from '../config-types.ts'
 import { publicQuotaMessage, quotaExceeded, type QuotaPolicyCode } from './control-plane-errors.ts'
 import type {
@@ -399,6 +399,7 @@ export type SessionRecord = {
   title: string | null
   createdAt: string
   updatedAt: string
+  projectSource?: CloudProjectSourceSummary | null
 }
 
 export type ListSessionsPageInput = {
@@ -2931,7 +2932,16 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
         right.record.updatedAt.localeCompare(left.record.updatedAt)
         || left.record.sessionId.localeCompare(right.record.sessionId)
       ))
-      .map((session) => clone(session.record))
+      .map((session) => this.sessionRecordWithProjectSource(session.record))
+  }
+
+  private sessionRecordWithProjectSource(record: SessionRecord): SessionRecord {
+    const stored = this.sessions.get(key(record.tenantId, record.sessionId))
+    const source = normalizeCloudProjectSource(stored?.projection?.view?.projectSource)
+    return {
+      ...clone(record),
+      projectSource: summarizeCloudProjectSource(source),
+    }
   }
 
   listSessionsPage(input: ListSessionsPageInput): ListSessionsPageRecord {
@@ -2960,7 +2970,7 @@ export class InMemoryControlPlaneStore implements ControlPlaneStore {
     const page = filtered.slice(0, limit)
     const hasMore = filtered.length > limit
     return {
-      items: page.map((session) => clone(session)),
+      items: page.map((session) => this.sessionRecordWithProjectSource(session)),
       nextCursor: hasMore && page.length > 0 ? encodeSessionPageCursor(page[page.length - 1]!, input) : null,
       totalEstimate: filtered.length,
     }

--- a/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
+++ b/apps/desktop/src/main/cloud/postgres-control-plane-store.ts
@@ -143,6 +143,7 @@ import {
   leaseFromRow,
   projectionFromRow,
   sessionFromRow,
+  sessionFromRowWithProjectSource,
   settingFromRow,
   workspaceEventFromRow,
 } from './postgres-domains/sessions.ts'
@@ -182,9 +183,7 @@ const CHANNEL_METADATA_MAX_BYTES = 16_384
 const BYOK_PROVIDER_ID_MAX_LENGTH = 64
 const BYOK_SECRET_TEXT_MAX_LENGTH = 4096
 function loadPgPool(connectionString: string): PgPool {
-  const pg = require('pg') as {
-    Pool: new (options: { connectionString: string }) => PgPool
-  }
+  const pg = require('pg') as { Pool: new (options: { connectionString: string }) => PgPool }
   return new pg.Pool({ connectionString })
 }
 
@@ -2094,12 +2093,16 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
   async listSessions(tenantId: string, userId: string) {
     await this.requireTenantUser(tenantId, userId)
     const result = await this.pool.query(
-      `SELECT * FROM cloud_sessions
-       WHERE tenant_id = $1 AND user_id = $2
-       ORDER BY updated_at DESC, session_id`,
+      `SELECT s.*, p.view -> 'projectSource' AS projection_project_source
+       FROM cloud_sessions s
+       LEFT JOIN cloud_session_projections p
+         ON p.tenant_id = s.tenant_id
+        AND p.session_id = s.session_id
+       WHERE s.tenant_id = $1 AND s.user_id = $2
+       ORDER BY s.updated_at DESC, s.session_id`,
       [tenantId, userId],
     )
-    return result.rows.map(sessionFromRow)
+    return result.rows.map(sessionFromRowWithProjectSource)
   }
 
   async listSessionsPage(input: ListSessionsPageInput) {
@@ -2107,40 +2110,44 @@ export class PostgresControlPlaneStore implements ControlPlaneStore, WorkflowWeb
     const limit = Math.max(1, Math.min(500, Math.floor(input.limit ?? 100)))
     const cursor = decodeSessionPageCursor(input.cursor, input)
     const params: unknown[] = [input.tenantId, input.userId]
-    const where = ['tenant_id = $1', 'user_id = $2']
+    const where = ['s.tenant_id = $1', 's.user_id = $2']
     if (input.status) {
       params.push(input.status)
-      where.push(`status = $${params.length}`)
+      where.push(`s.status = $${params.length}`)
     }
     if (input.profileName) {
       params.push(input.profileName)
-      where.push(`profile_name = $${params.length}`)
+      where.push(`s.profile_name = $${params.length}`)
     }
     const query = input.query?.trim().toLowerCase()
     if (query) {
       params.push(`%${query}%`)
       where.push(`(
-        lower(COALESCE(title, '')) LIKE $${params.length}
-        OR lower(session_id) LIKE $${params.length}
-        OR lower(opencode_session_id) LIKE $${params.length}
-        OR lower(profile_name) LIKE $${params.length}
+        lower(COALESCE(s.title, '')) LIKE $${params.length}
+        OR lower(s.session_id) LIKE $${params.length}
+        OR lower(s.opencode_session_id) LIKE $${params.length}
+        OR lower(s.profile_name) LIKE $${params.length}
       )`)
     }
     if (cursor) {
       params.push(cursor.updatedAt, cursor.sessionId)
       const updatedAtParam = params.length - 1
       const sessionIdParam = params.length
-      where.push(`(updated_at < $${updatedAtParam} OR (updated_at = $${updatedAtParam} AND session_id > $${sessionIdParam}))`)
+      where.push(`(s.updated_at < $${updatedAtParam} OR (s.updated_at = $${updatedAtParam} AND s.session_id > $${sessionIdParam}))`)
     }
     params.push(limit + 1)
     const result = await this.pool.query(
-      `SELECT * FROM cloud_sessions
+      `SELECT s.*, p.view -> 'projectSource' AS projection_project_source
+       FROM cloud_sessions s
+       LEFT JOIN cloud_session_projections p
+         ON p.tenant_id = s.tenant_id
+        AND p.session_id = s.session_id
        WHERE ${where.join(' AND ')}
-       ORDER BY updated_at DESC, session_id
+       ORDER BY s.updated_at DESC, s.session_id
        LIMIT $${params.length}`,
       params,
     )
-    const rows = result.rows.map(sessionFromRow)
+    const rows = result.rows.map(sessionFromRowWithProjectSource)
     const items = rows.slice(0, limit)
     return {
       items,

--- a/apps/desktop/src/main/cloud/postgres-domains/sessions.ts
+++ b/apps/desktop/src/main/cloud/postgres-domains/sessions.ts
@@ -1,3 +1,4 @@
+import { normalizeCloudProjectSource, summarizeCloudProjectSource } from '@open-cowork/shared'
 import type {
   ControlPlaneSessionStatus,
   ControlPlaneCommandStatus,
@@ -24,6 +25,15 @@ export function sessionFromRow(row: QueryRow): SessionRecord {
     status: String(row.status) as ControlPlaneSessionStatus,
     createdAt: iso(row.created_at),
     updatedAt: iso(row.updated_at),
+  }
+}
+
+export function sessionFromRowWithProjectSource(row: QueryRow): SessionRecord {
+  const session = sessionFromRow(row)
+  const source = normalizeCloudProjectSource(row.projection_project_source)
+  return {
+    ...session,
+    projectSource: summarizeCloudProjectSource(source),
   }
 }
 

--- a/apps/desktop/src/main/cloud/session-service.ts
+++ b/apps/desktop/src/main/cloud/session-service.ts
@@ -31,6 +31,7 @@ import {
   type SessionImportItemCounts,
   type SessionImportRequest,
   normalizeCloudProjectSource,
+  summarizeCloudProjectSource,
   normalizeWorkflowSteps,
 } from '@open-cowork/shared'
 import {
@@ -1349,9 +1350,18 @@ export class CloudSessionService {
     await this.ensurePrincipal(principal)
     const session = await this.store.getSession(principal.tenantId, principal.userId, sessionId)
     if (!session) throw new CloudServiceError(404, 'Cloud session was not found.')
+    const projection = await this.store.getSessionProjection(principal.tenantId, sessionId)
     return {
-      session,
-      projection: await this.store.getSessionProjection(principal.tenantId, sessionId),
+      session: this.withProjectionProjectSource(session, projection),
+      projection,
+    }
+  }
+
+  private withProjectionProjectSource(session: SessionRecord, projection: SessionProjectionRecord | null): SessionRecord {
+    const source = normalizeCloudProjectSource(projection?.view?.projectSource)
+    return {
+      ...session,
+      projectSource: summarizeCloudProjectSource(source),
     }
   }
 
@@ -3890,9 +3900,10 @@ export class CloudSessionService {
   private async getTenantSessionView(tenantId: string, sessionId: string): Promise<CloudSessionView> {
     const session = await this.store.getSessionForTenant(tenantId, sessionId)
     if (!session) throw new CloudServiceError(404, 'Cloud session was not found.')
+    const projection = await this.store.getSessionProjection(tenantId, sessionId)
     return {
-      session,
-      projection: await this.store.getSessionProjection(tenantId, sessionId),
+      session: this.withProjectionProjectSource(session, projection),
+      projection,
     }
   }
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -692,15 +692,15 @@ export function App() {
         </div>
       ) : null}
       <div className="flex flex-1 min-h-0">
-        {!sidebarCollapsed && (
-          <Sidebar
-            currentView={view}
-            onViewChange={navigateView}
-            searchRequestNonce={sidebarSearchNonce}
-            settingsRequestNonce={sidebarSettingsNonce}
-            branding={config.branding.sidebar}
-          />
-        )}
+        <Sidebar
+          currentView={view}
+          onViewChange={navigateView}
+          searchRequestNonce={sidebarSearchNonce}
+          settingsRequestNonce={sidebarSettingsNonce}
+          branding={config.branding.sidebar}
+          collapsed={sidebarCollapsed}
+          onExpandSidebar={ensureSidebarVisible}
+        />
         <main className="flex-1 flex flex-col min-h-0 min-w-0">
           <ViewErrorBoundary resetKey={view} onBackHome={() => navigateView('home')}>
             {view === 'home' && (

--- a/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.test.tsx
@@ -137,6 +137,93 @@ describe('Sidebar', () => {
     expect(screen.queryByText('Acme AI')).toBeNull()
   })
 
+  it('collapses and reopens the Manage navigation group', () => {
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Team' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Playbooks' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Manage/ }))
+
+    expect(screen.queryByRole('button', { name: 'Team' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Playbooks' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Manage/ }))
+
+    expect(screen.getByRole('button', { name: 'Team' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Playbooks' })).toBeTruthy()
+  })
+
+  it('renders a compact rail without unmounting navigation actions', () => {
+    const onExpandSidebar = vi.fn()
+    render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        collapsed
+        onExpandSidebar={onExpandSidebar}
+      />,
+    )
+
+    expect(screen.getByRole('complementary', { name: 'Sidebar navigation' })).toHaveAttribute('data-sidebar-collapsed', 'true')
+    expect(screen.getByRole('button', { name: 'New Chat' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Home' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: 'Manage' })).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('button', { name: 'Team' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Diagnostics' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Settings' }).parentElement).toHaveClass('flex-col')
+    expect(screen.queryByText('Recent work')).toBeNull()
+    expect(screen.queryByText('Tool Status')).toBeNull()
+    expect(screen.queryByText('New Chat')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Search projects and chats/ }))
+    expect(onExpandSidebar).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-expand the compact rail for an already handled search request', () => {
+    const onExpandSidebar = vi.fn()
+    const { rerender } = render(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        searchRequestNonce={1}
+        onExpandSidebar={onExpandSidebar}
+      />,
+    )
+
+    expect(onExpandSidebar).not.toHaveBeenCalled()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        searchRequestNonce={1}
+        collapsed
+        onExpandSidebar={onExpandSidebar}
+      />,
+    )
+
+    expect(onExpandSidebar).not.toHaveBeenCalled()
+
+    rerender(
+      <Sidebar
+        currentView="home"
+        onViewChange={vi.fn()}
+        searchRequestNonce={2}
+        collapsed
+        onExpandSidebar={onExpandSidebar}
+      />,
+    )
+
+    expect(onExpandSidebar).toHaveBeenCalledTimes(1)
+  })
+
   it('shows a live approvals alert count in the Studio nav', () => {
     const baseView = useSessionStore.getInitialState().currentView
     const sessions = [{ id: 'active-session', title: 'Active chat', createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }]

--- a/apps/desktop/src/renderer/components/layout/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import { t } from '../../helpers/i18n'
 import type { AppNavigationTarget, AppView } from '../../app-types'
 import { useSessionStore } from '../../stores/session'
 import { supportAllows, supportEntry, useWorkspaceSupportStore } from '../../stores/workspace-support'
-import { Icon } from '../ui'
+import { Icon, type IconName } from '../ui'
 import { buildDesktopApprovalQueueItems } from '../studio/approval-queue-model'
 
 interface Props {
@@ -22,11 +22,34 @@ interface Props {
   searchRequestNonce?: number
   settingsRequestNonce?: number
   branding?: BrandingSidebarConfig
+  collapsed?: boolean
+  onExpandSidebar?: () => void
 }
 
 const SettingsPanel = lazy(() =>
   import('../sidebar/SettingsPanel').then((module) => ({ default: module.SettingsPanel })),
 )
+
+type SidebarNavItem = {
+  view: AppNavigationTarget
+  icon: IconName
+  labelKey: string
+  fallback: string
+}
+
+const PRIMARY_NAV_ITEMS: SidebarNavItem[] = [
+  { view: 'home', icon: 'home', labelKey: 'sidebar.home', fallback: 'Home' },
+  { view: 'projects', icon: 'folder', labelKey: 'sidebar.projects', fallback: 'Projects' },
+  { view: 'approvals', icon: 'circle-help', labelKey: 'sidebar.approvals', fallback: 'Approvals' },
+]
+
+const MANAGE_NAV_ITEMS: SidebarNavItem[] = [
+  { view: 'team', icon: 'users', labelKey: 'sidebar.team', fallback: 'Team' },
+  { view: 'playbooks', icon: 'workflow', labelKey: 'sidebar.playbooks', fallback: 'Playbooks' },
+  { view: 'channels', icon: 'activity', labelKey: 'sidebar.channels', fallback: 'Channels' },
+  { view: 'tools', icon: 'blocks', labelKey: 'sidebar.toolsSkills', fallback: 'Tools & Skills' },
+  { view: 'artifacts', icon: 'file', labelKey: 'sidebar.artifacts', fallback: 'Artifacts' },
+]
 
 function safeLogoDataUrl(value: string | undefined) {
   const trimmed = value?.trim()
@@ -539,16 +562,100 @@ function WorkspaceSwitcher() {
   )
 }
 
+function SidebarNavButton({
+  item,
+  currentView,
+  collapsed,
+  onViewChange,
+  badge,
+}: {
+  item: SidebarNavItem
+  currentView: AppView
+  collapsed: boolean
+  onViewChange: (view: AppNavigationTarget) => void
+  badge?: number
+}) {
+  const label = t(item.labelKey, item.fallback)
+  const active = currentView === item.view
+
+  return (
+    <button
+      type="button"
+      onClick={() => onViewChange(item.view)}
+      aria-label={collapsed ? label : undefined}
+      aria-current={active ? 'page' : undefined}
+      title={collapsed ? label : undefined}
+      className={`sidebar-nav-item sidebar-nav-primary ${collapsed ? 'justify-center px-0' : ''} ${active ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}
+    >
+      <Icon name={item.icon} size={16} />
+      {!collapsed ? <span className="truncate">{label}</span> : null}
+      {!collapsed && badge && badge > 0 ? (
+        <span className="nav-alert-count" aria-label={`${badge} pending approvals and questions`}>
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  )
+}
+
+function SidebarPresenceFooter({
+  collapsed,
+  onSettings,
+  showSettings,
+}: {
+  collapsed: boolean
+  onSettings: () => void
+  showSettings: boolean
+}) {
+  const activeWorkspaceId = useSessionStore((state) => state.activeWorkspaceId)
+  const workspaceLabel = activeWorkspaceId === LOCAL_WORKSPACE_FALLBACK.id
+    ? t('workspace.localShort', 'Local')
+    : t('workspace.cloudShort', 'Cloud')
+
+  return (
+    <div className={`shrink-0 border-t border-border-subtle ${collapsed ? 'px-2 py-2' : 'px-3 py-2.5'}`}>
+      <div className={`flex ${collapsed ? 'flex-col items-center justify-center gap-1.5' : 'items-center gap-2.5'}`}>
+        <span
+          aria-hidden="true"
+          className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-border-subtle bg-surface-active font-display text-[11px] font-bold text-text"
+        >
+          OC
+        </span>
+        {!collapsed ? (
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[12px] font-medium text-text">{t('sidebar.presenceName', 'You')}</div>
+            <div className="truncate text-[10px] text-text-muted">{workspaceLabel} · {t('workspace.status.online', 'Online')}</div>
+          </div>
+        ) : null}
+        <button
+          type="button"
+          onClick={onSettings}
+          aria-label={t('sidebar.settings', 'Settings')}
+          aria-expanded={showSettings}
+          title={t('sidebar.settings', 'Settings')}
+          className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-text-muted transition-colors hover:bg-surface-hover hover:text-text-secondary"
+        >
+          <Icon name="settings-2" size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function Sidebar({
   currentView,
   onViewChange,
   searchRequestNonce = 0,
   settingsRequestNonce = 0,
   branding,
+  collapsed = false,
+  onExpandSidebar,
 }: Props) {
   const [showSettings, setShowSettings] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [showSearch, setShowSearch] = useState(false)
+  const [manageOpen, setManageOpen] = useState(true)
+  const lastHandledSearchRequestNonce = useRef(0)
   const activeWorkspaceId = useSessionStore((state) => state.activeWorkspaceId)
   const sessionsByWorkspace = useSessionStore((state) => state.sessionsByWorkspace)
   const sessionStateById = useSessionStore((state) => state.sessionStateById)
@@ -561,13 +668,17 @@ export function Sidebar({
     currentSessionId,
     currentView: sessionView,
   }).length, [activeWorkspaceId, sessionsByWorkspace, sessionStateById, currentSessionId, sessionView])
+  const manageActive = MANAGE_NAV_ITEMS.some((item) => item.view === currentView)
 
   useEffect(() => {
     if (searchRequestNonce === 0) return
+    if (searchRequestNonce === lastHandledSearchRequestNonce.current) return
+    lastHandledSearchRequestNonce.current = searchRequestNonce
+    if (collapsed) onExpandSidebar?.()
     setShowSettings(false)
     setShowSearch(true)
     setSearchQuery('')
-  }, [searchRequestNonce])
+  }, [collapsed, onExpandSidebar, searchRequestNonce])
 
   useEffect(() => {
     if (settingsRequestNonce === 0) return
@@ -576,21 +687,38 @@ export function Sidebar({
     setShowSettings(true)
   }, [settingsRequestNonce])
 
+  useEffect(() => {
+    if (manageActive) setManageOpen(true)
+  }, [manageActive])
+
   return (
     <>
       <aside
-        className="flex min-h-0 w-[252px] shrink-0 flex-col overflow-hidden border-e border-border-subtle transition-[width] duration-200"
+        className={`flex min-h-0 shrink-0 flex-col border-e border-border-subtle transition-[width] duration-200 ${collapsed ? 'w-16 overflow-visible' : 'w-[252px] overflow-hidden'}`}
         style={{ background: 'color-mix(in srgb, var(--color-base) 92%, var(--color-elevated) 8%)' }}
+        aria-label={t('sidebar.navigation', 'Sidebar navigation')}
+        data-sidebar-collapsed={collapsed ? 'true' : 'false'}
         data-workbench-pane="threads"
       >
-          <SidebarBrandTop top={branding?.top} />
-          <WorkspaceSwitcher />
-          <div className="shrink-0 p-3 pb-1 flex gap-2">
-            <div className="flex-1">
-              <NewThreadButton onClick={() => onViewChange('chat')} />
+          {!collapsed ? <SidebarBrandTop top={branding?.top} /> : (
+            <div className="px-2 pt-3 pb-2">
+              <div className="grid h-10 w-10 place-items-center rounded-lg border border-border-subtle bg-elevated text-[12px] font-bold text-text">OC</div>
+            </div>
+          )}
+          {!collapsed ? <WorkspaceSwitcher /> : null}
+          <div className={`shrink-0 flex gap-2 ${collapsed ? 'flex-col px-3 pb-2' : 'p-3 pb-1'}`}>
+            <div className={collapsed ? '' : 'flex-1'}>
+              <NewThreadButton onClick={() => onViewChange('chat')} compact={collapsed} />
             </div>
             <button
-              onClick={() => setShowSearch(!showSearch)}
+              onClick={() => {
+                if (collapsed) {
+                  onExpandSidebar?.()
+                  setShowSearch(true)
+                  return
+                }
+                setShowSearch(!showSearch)
+              }}
               aria-label={t('sidebar.searchTitle', 'Search projects and chats (⌘K)')}
               aria-expanded={showSearch}
               className={`w-9 h-9 flex items-center justify-center rounded-lg border border-border-subtle transition-colors cursor-pointer ${showSearch ? 'bg-surface-active text-text' : 'text-text-muted hover:bg-surface-hover hover:text-text-secondary'}`}
@@ -600,7 +728,7 @@ export function Sidebar({
             </button>
           </div>
 
-          {showSearch && (
+          {showSearch && !collapsed && (
             <div className="shrink-0 px-3 pb-1">
               <input
                 autoFocus
@@ -615,68 +743,59 @@ export function Sidebar({
             </div>
           )}
 
-          <div className="min-h-0 max-h-[40vh] overflow-y-auto px-2 pt-2 pb-1">
-            <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{t('sidebar.primary', 'Studio')}</div>
-            <button onClick={() => onViewChange('home')}
-              aria-current={currentView === 'home' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'home' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="home" size={16} />
-              {t('sidebar.home', 'Home')}
-            </button>
-            <button onClick={() => onViewChange('projects')}
-              aria-current={currentView === 'projects' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'projects' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="folder" size={16} />
-              {t('sidebar.projects', 'Projects')}
-            </button>
-            <button onClick={() => onViewChange('approvals')}
-              aria-current={currentView === 'approvals' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'approvals' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="circle-help" size={16} />
-              {t('sidebar.approvals', 'Approvals')}
-              {approvalsQueueCount > 0 ? (
-                <span className="nav-alert-count" aria-label={`${approvalsQueueCount} pending approvals and questions`}>
-                  {approvalsQueueCount}
-                </span>
+          <div className={`min-h-0 overflow-y-auto px-2 pt-2 pb-1 ${collapsed ? 'max-h-none' : 'max-h-[40vh]'}`}>
+            {!collapsed ? <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{t('sidebar.primary', 'Studio')}</div> : null}
+            {PRIMARY_NAV_ITEMS.map((item) => (
+              <SidebarNavButton
+                key={item.view}
+                item={item}
+                currentView={currentView}
+                collapsed={collapsed}
+                onViewChange={onViewChange}
+                badge={item.view === 'approvals' ? approvalsQueueCount : undefined}
+              />
+            ))}
+            <div className={`pt-3 ${collapsed ? 'px-0' : 'px-2'}`}>
+              <button
+                type="button"
+                onClick={() => setManageOpen((current) => !current)}
+                aria-expanded={manageOpen}
+                aria-label={collapsed ? t('sidebar.manage', 'Manage') : undefined}
+                title={collapsed ? t('sidebar.manage', 'Manage') : undefined}
+                className={`sidebar-nav-item sidebar-nav-primary w-full ${collapsed ? 'justify-center px-0' : ''} ${manageActive ? 'bg-surface-active text-text' : 'text-text-muted hover:bg-surface-hover hover:text-text-secondary'}`}
+              >
+                <Icon name={manageOpen ? 'chevron-down' : 'chevron-right'} size={16} />
+                {!collapsed ? (
+                  <>
+                    <span className="truncate font-semibold uppercase tracking-widest text-[10px]">{t('sidebar.manage', 'Manage')}</span>
+                    <span className="min-w-0 flex-1 truncate text-end text-[10px] normal-case tracking-normal text-text-muted">
+                      {manageActive
+                        ? t(MANAGE_NAV_ITEMS.find((item) => item.view === currentView)?.labelKey || 'sidebar.manage', MANAGE_NAV_ITEMS.find((item) => item.view === currentView)?.fallback || 'Manage')
+                        : t('sidebar.manageHint', 'Team · Playbooks · Tools')}
+                    </span>
+                  </>
+                ) : null}
+              </button>
+              {manageOpen ? (
+                <div className={collapsed ? 'mt-1' : 'mt-1'}>
+                  {MANAGE_NAV_ITEMS.map((item) => (
+                    <SidebarNavButton
+                      key={item.view}
+                      item={item}
+                      currentView={currentView}
+                      collapsed={collapsed}
+                      onViewChange={onViewChange}
+                    />
+                  ))}
+                </div>
               ) : null}
-            </button>
-            <div className="px-2 pb-1 pt-3 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{t('sidebar.manage', 'Manage')}</div>
-            <button onClick={() => onViewChange('team')}
-              aria-current={currentView === 'team' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'team' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="users" size={16} />
-              {t('sidebar.team', 'Team')}
-            </button>
-            <button onClick={() => onViewChange('playbooks')}
-              aria-current={currentView === 'playbooks' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'playbooks' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="workflow" size={16} />
-              {t('sidebar.playbooks', 'Playbooks')}
-            </button>
-            <button onClick={() => onViewChange('channels')}
-              aria-current={currentView === 'channels' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'channels' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="activity" size={16} />
-              {t('sidebar.channels', 'Channels')}
-            </button>
-            <button onClick={() => onViewChange('tools')}
-              aria-current={currentView === 'tools' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'tools' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="blocks" size={16} />
-              {t('sidebar.toolsSkills', 'Tools & Skills')}
-            </button>
-            <button onClick={() => onViewChange('artifacts')}
-              aria-current={currentView === 'artifacts' ? 'page' : undefined}
-              className={`sidebar-nav-item sidebar-nav-primary ${currentView === 'artifacts' ? 'bg-surface-active text-text' : 'text-text-secondary hover:bg-surface-hover hover:text-text'}`}>
-              <Icon name="file" size={16} />
-              {t('sidebar.artifacts', 'Artifacts')}
-            </button>
+            </div>
           </div>
 
           {/* Recent project chats — ThreadList owns its own scroll container so it
               can virtualize rows without fighting the parent over the
               scroll element reference. */}
-          <div className="flex min-h-[120px] flex-1 flex-col overflow-hidden px-2 py-2">
+          {!collapsed ? <div className="flex min-h-[120px] flex-1 flex-col overflow-hidden px-2 py-2">
             <button
               type="button"
               onClick={() => onViewChange('projects')}
@@ -686,10 +805,10 @@ export function Sidebar({
               {t('sidebar.recentWork', 'Recent work')}
             </button>
             <ThreadList onSelect={() => onViewChange('chat')} searchQuery={searchQuery} />
-          </div>
+          </div> : <div className="flex-1" />}
 
           {/* Tool status */}
-          <div className="max-h-[28vh] shrink-0 overflow-y-auto border-t border-border-subtle px-2 py-2">
+          {!collapsed ? <div className="max-h-[28vh] shrink-0 overflow-y-auto border-t border-border-subtle px-2 py-2">
             <SidebarLowerBranding lower={branding?.lower} />
             <button onClick={() => onViewChange('health')}
               aria-current={currentView === 'health' ? 'page' : undefined}
@@ -700,15 +819,19 @@ export function Sidebar({
             </button>
             <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">{t('sidebar.toolStatus', 'Tool Status')}</div>
             <McpStatus />
-          </div>
+          </div> : (
+            <div className="shrink-0 border-t border-border-subtle px-2 py-2">
+              <button onClick={() => onViewChange('health')}
+                aria-current={currentView === 'health' ? 'page' : undefined}
+                aria-label={t('sidebar.diagnostics', 'Diagnostics')}
+                title={t('sidebar.diagnostics', 'Diagnostics')}
+                className={`sidebar-nav-item sidebar-nav-primary justify-center px-0 ${currentView === 'health' ? 'bg-surface-active text-text' : 'text-text-muted hover:bg-surface-hover hover:text-text-secondary'}`}>
+                <Icon name="heart-pulse" size={16} />
+              </button>
+            </div>
+          )}
 
-          {/* Settings */}
-          <button onClick={() => setShowSettings(true)}
-            aria-expanded={showSettings}
-            className="flex shrink-0 items-center gap-2.5 px-4 py-3 text-[13px] text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-colors cursor-pointer border-t border-border-subtle">
-            <Icon name="settings-2" size={16} />
-            {t('sidebar.settings', 'Settings')}
-          </button>
+          <SidebarPresenceFooter collapsed={collapsed} showSettings={showSettings} onSettings={() => setShowSettings(true)} />
       </aside>
       {showSettings ? (
         <Suspense fallback={<div className="fixed inset-0 z-[60] grid place-items-center text-[12px] text-text-muted">{t('settings.loading', 'Loading settings...')}</div>}>

--- a/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/NewThreadButton.tsx
@@ -28,7 +28,7 @@ function reportThreadError(error: unknown, view: string) {
   }
 }
 
-export function NewThreadButton({ onClick }: { onClick?: () => void }) {
+export function NewThreadButton({ onClick, compact = false }: { onClick?: () => void; compact?: boolean }) {
   const addSession = useSessionStore((s) => s.addSession)
   const setCurrentSession = useSessionStore((s) => s.setCurrentSession)
   const addGlobalError = useSessionStore((s) => s.addGlobalError)
@@ -199,18 +199,20 @@ export function NewThreadButton({ onClick }: { onClick?: () => void }) {
         onClick={() => setShowMenu(!showMenu)}
         variant="secondary"
         size="sm"
-        fullWidth
+        fullWidth={!compact}
         leftIcon="plus"
-        className="new-thread-trigger"
+        aria-label={t('sidebar.newChat', 'New Chat')}
+        title={compact ? t('sidebar.newChat', 'New Chat') : undefined}
+        className={`new-thread-trigger ${compact ? 'h-9 w-9 justify-center px-0' : ''}`}
       >
-        {t('sidebar.newChat', 'New Chat')}
+        {compact ? null : t('sidebar.newChat', 'New Chat')}
       </Button>
 
       {showMenu && (
         <>
           <ModalBackdrop onDismiss={() => setShowMenu(false)} className="fixed inset-0 z-40" />
           <div
-            className="absolute start-0 end-0 top-full mt-1 z-50 rounded-xl overflow-hidden theme-popover"
+            className={`absolute start-0 top-full mt-1 z-50 rounded-xl overflow-hidden theme-popover ${compact ? 'w-72' : 'end-0'}`}
           >
             <Card
               interactive

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.test.tsx
@@ -71,6 +71,91 @@ beforeEach(() => {
 })
 
 describe('ThreadList', () => {
+  it('groups chats by project and keeps sandbox chats separate', () => {
+    const groupedSessions: SessionInfo[] = [
+      {
+        id: 'client-main',
+        title: 'Client launch',
+        directory: '/Users/joe/Work/client-app',
+        createdAt: '2026-05-08T00:00:00.000Z',
+        updatedAt: '2026-05-08T00:00:00.000Z',
+      },
+      {
+        id: 'client-follow-up',
+        title: 'Client follow-up',
+        directory: '/Users/joe/Work/client-app',
+        createdAt: '2026-05-09T00:00:00.000Z',
+        updatedAt: '2026-05-09T00:00:00.000Z',
+      },
+      {
+        id: 'api-chat',
+        title: 'API review',
+        directory: '/Users/joe/Work/server-api',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        updatedAt: '2026-05-10T00:00:00.000Z',
+      },
+      {
+        id: 'sandbox-chat',
+        title: 'Loose chat',
+        directory: '/Users/joe/Open Cowork Sandbox/thread-2026-06-14-abc123',
+        createdAt: '2026-05-11T00:00:00.000Z',
+        updatedAt: '2026-05-11T00:00:00.000Z',
+      },
+    ]
+    useSessionStore.setState({
+      sessions: groupedSessions,
+      sessionsByWorkspace: { local: groupedSessions },
+      currentSessionId: 'client-main',
+    })
+
+    const { container } = render(<ThreadList />)
+
+    const groupHeaders = Array.from(container.querySelectorAll('.thread-group-header'))
+      .map((header) => header.textContent || '')
+
+    expect(groupHeaders).toHaveLength(3)
+    expect(groupHeaders.some((text) => text.includes('client-app') && text.includes('2'))).toBe(true)
+    expect(groupHeaders.some((text) => text.includes('server-api') && text.includes('1'))).toBe(true)
+    expect(groupHeaders.some((text) => text.includes('Sandbox') && text.includes('1'))).toBe(true)
+    expect(screen.getByRole('button', { name: /Client launch/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Loose chat/ })).toBeInTheDocument()
+  })
+
+  it('groups remote cloud chats by project source instead of sandbox', () => {
+    const cloudSessions: SessionInfo[] = [
+      {
+        id: 'cloud-api-main',
+        title: 'API cloud chat',
+        directory: null,
+        createdAt: '2026-05-08T00:00:00.000Z',
+        updatedAt: '2026-05-08T00:00:00.000Z',
+        projectSource: { kind: 'git', repositoryUrl: 'https://github.com/acme/api.git' },
+      },
+      {
+        id: 'cloud-chat-only',
+        title: 'Cloud chat only',
+        directory: null,
+        createdAt: '2026-05-09T00:00:00.000Z',
+        updatedAt: '2026-05-09T00:00:00.000Z',
+      },
+    ]
+    useSessionStore.setState({
+      activeWorkspaceId: 'cloud-workspace',
+      sessions: cloudSessions,
+      sessionsByWorkspace: { 'cloud-workspace': cloudSessions },
+      currentSessionId: 'cloud-api-main',
+    })
+
+    const { container } = render(<ThreadList />)
+
+    const groupHeaders = Array.from(container.querySelectorAll('.thread-group-header'))
+      .map((header) => header.textContent || '')
+
+    expect(groupHeaders.some((text) => text.includes('api') && text.includes('1'))).toBe(true)
+    expect(groupHeaders.some((text) => text.includes('Chat-only') && text.includes('1'))).toBe(true)
+    expect(groupHeaders.some((text) => text.includes('Sandbox'))).toBe(false)
+  })
+
   it('opens an accessible thread action menu from the keyboard context-menu command', async () => {
     render(<ThreadList />)
 

--- a/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/ThreadList.tsx
@@ -9,7 +9,8 @@ import { t } from '../../helpers/i18n'
 import { writeTextToClipboard } from '../../helpers/clipboard'
 import { ViewErrorBoundary } from '../layout/ViewErrorBoundary'
 import { ModalBackdrop } from '../layout/ModalBackdrop'
-import type { SessionImportInventory, SessionImportSelection, WorkspaceInfo } from '@open-cowork/shared'
+import type { CloudProjectSourceSummary, SessionImportInventory, SessionImportSelection, WorkspaceInfo } from '@open-cowork/shared'
+import type { Session } from '../../stores/session'
 
 // Kick in virtualization only above this count. Below it, plain
 // rendering is a wash (~8ms mount for 50 rows) and avoids the
@@ -20,6 +21,112 @@ const VIRTUALIZE_THRESHOLD = 50
 // real — the virtualizer corrects on measurement. Rows shrink when
 // a thread has no directory / change summary below the title.
 const ESTIMATED_ROW_HEIGHT = 48
+const ESTIMATED_GROUP_HEADER_HEIGHT = 32
+
+type ThreadGroup = {
+  id: string
+  label: string
+  description: string
+  kind: 'sandbox' | 'project'
+  sessions: Session[]
+}
+
+type ThreadListItem =
+  | { type: 'group'; group: ThreadGroup }
+  | { type: 'session'; session: Session; rowIndex: number }
+
+function pathSegments(directory: string) {
+  return directory.split('/').map((segment) => segment.trim()).filter(Boolean)
+}
+
+function compactPathLabel(directory: string) {
+  const segments = pathSegments(directory)
+  return segments.slice(-2).join('/') || directory
+}
+
+function projectSourceGroupForSession(session: Session, source: CloudProjectSourceSummary): Omit<ThreadGroup, 'sessions'> {
+  if (source.kind === 'git') {
+    const repo = source.repositoryUrl || t('sidebar.gitRepository', 'Git repository')
+    const label = repo.split('/').filter(Boolean).pop()?.replace(/\.git$/, '') || repo
+    return {
+      id: `project:git:${source.repositoryUrl || session.id}:${source.ref || ''}:${source.subdirectory || ''}`,
+      label,
+      description: [source.repositoryUrl, source.subdirectory].filter(Boolean).join(' · ') || t('sidebar.gitRepository', 'Git repository'),
+      kind: 'project',
+    }
+  }
+  return {
+    id: `project:snapshot:${source.snapshotId || session.id}`,
+    label: source.title || t('sidebar.uploadedSnapshot', 'Uploaded snapshot'),
+    description: source.snapshotId ? t('sidebar.snapshotDescription', 'Uploaded project snapshot') : t('sidebar.cloudProject', 'Cloud project'),
+    kind: 'project',
+  }
+}
+
+function threadGroupForSession(session: Session, activeWorkspaceIsLocal: boolean): Omit<ThreadGroup, 'sessions'> {
+  if (session.projectSource) return projectSourceGroupForSession(session, session.projectSource)
+
+  const directory = session.directory?.trim()
+  if (!directory) {
+    if (!activeWorkspaceIsLocal) {
+      return {
+        id: 'chat-only',
+        label: t('sidebar.chatOnly', 'Chat-only'),
+        description: t('sidebar.chatOnlyDescription', 'No project source'),
+        kind: 'sandbox',
+      }
+    }
+    return {
+      id: 'sandbox',
+      label: t('sidebar.sandbox', 'Sandbox'),
+      description: t('sidebar.sandboxDescription', 'Chat-only work'),
+      kind: 'sandbox',
+    }
+  }
+
+  const segments = pathSegments(directory)
+  const lastSegment = segments[segments.length - 1] || directory
+  const sandboxPath = segments.some((segment) => segment === 'Open Cowork Sandbox') || /^thread-\d{4}-\d{2}-\d{2}-/.test(lastSegment)
+  if (sandboxPath) {
+    return {
+      id: 'sandbox',
+      label: t('sidebar.sandbox', 'Sandbox'),
+      description: compactPathLabel(directory),
+      kind: 'sandbox',
+    }
+  }
+
+  return {
+    id: `project:${directory}`,
+    label: lastSegment,
+    description: compactPathLabel(directory),
+    kind: 'project',
+  }
+}
+
+function groupedThreadItems(sessions: Session[], activeWorkspaceIsLocal: boolean): ThreadListItem[] {
+  const groups = new Map<string, ThreadGroup>()
+  for (const session of sessions) {
+    const groupInfo = threadGroupForSession(session, activeWorkspaceIsLocal)
+    const existing = groups.get(groupInfo.id)
+    if (existing) {
+      existing.sessions.push(session)
+    } else {
+      groups.set(groupInfo.id, { ...groupInfo, sessions: [session] })
+    }
+  }
+
+  const items: ThreadListItem[] = []
+  let rowIndex = 0
+  for (const group of groups.values()) {
+    items.push({ type: 'group', group })
+    for (const session of group.sessions) {
+      items.push({ type: 'session', session, rowIndex })
+      rowIndex += 1
+    }
+  }
+  return items
+}
 
 export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; searchQuery?: string }) {
   const sessions = useSessionStore((s) => s.sessions)
@@ -64,12 +171,13 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
       ? interactiveSessions.filter(s => (s.title || s.id).toLowerCase().includes(searchQuery.toLowerCase()))
       : interactiveSessions
   ), [interactiveSessions, searchQuery])
+  const groupedItems = useMemo(() => groupedThreadItems(filtered, activeWorkspaceIsLocal), [activeWorkspaceIsLocal, filtered])
 
   const virtualize = filtered.length > VIRTUALIZE_THRESHOLD
   const virtualizer = useVirtualizer({
-    count: virtualize ? filtered.length : 0,
+    count: virtualize ? groupedItems.length : 0,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    estimateSize: (index) => groupedItems[index]?.type === 'group' ? ESTIMATED_GROUP_HEADER_HEIGHT : ESTIMATED_ROW_HEIGHT,
     overscan: 8,
   })
 
@@ -77,7 +185,7 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
     if (!virtualize) return
     const frame = window.requestAnimationFrame(() => virtualizer.measure())
     return () => window.cancelAnimationFrame(frame)
-  }, [filtered.length, virtualize, virtualizer])
+  }, [groupedItems.length, virtualize, virtualizer])
 
   // When the active thread changes, keep it visible. Plays nice with
   // both virtualized and non-virtualized modes — in non-virtualized
@@ -85,12 +193,12 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
   // virtualized mode we ask the virtualizer to scroll by index.
   useEffect(() => {
     if (!currentSessionId) return
-    const index = filtered.findIndex((session) => session.id === currentSessionId)
+    const index = groupedItems.findIndex((item) => item.type === 'session' && item.session.id === currentSessionId)
     if (index < 0) return
     if (virtualize) {
       virtualizer.scrollToIndex(index, { align: 'auto' })
     }
-  }, [currentSessionId, filtered, virtualize, virtualizer])
+  }, [currentSessionId, groupedItems, virtualize, virtualizer])
 
   // Close menu on click outside
   useEffect(() => {
@@ -398,6 +506,27 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
     )
   }
 
+  const renderGroup = (group: ThreadGroup) => (
+    <div key={`group:${group.id}`} className="thread-group-header px-2 pb-1 pt-2">
+      <div className="flex min-w-0 items-center justify-between gap-2 rounded-md px-1.5 py-1 text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span aria-hidden="true" className="text-[11px] leading-none">{group.kind === 'sandbox' ? 'S' : 'P'}</span>
+          <span className="truncate">{group.label}</span>
+        </span>
+        <span className="shrink-0 rounded border border-border-subtle px-1 py-px text-[9px] normal-case tracking-normal text-text-muted">
+          {group.sessions.length}
+        </span>
+      </div>
+      <div className="truncate px-1.5 text-[9px] text-text-muted">{group.description}</div>
+    </div>
+  )
+
+  const renderItem = (item: ThreadListItem) => (
+    item.type === 'group'
+      ? renderGroup(item.group)
+      : renderRow(item.session, item.rowIndex)
+  )
+
   return (
     <div ref={scrollRef} className="min-h-[96px] flex-1 overflow-y-auto">
       {virtualize ? (
@@ -405,11 +534,11 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
           style={{ height: virtualizer.getTotalSize(), width: '100%', position: 'relative' }}
         >
           {virtualizer.getVirtualItems().map((vRow) => {
-            const session = filtered[vRow.index]
-            if (!session) return null
+            const item = groupedItems[vRow.index]
+            if (!item) return null
             return (
               <div
-                key={session.id}
+                key={item.type === 'group' ? `group:${item.group.id}` : item.session.id}
                 data-index={vRow.index}
                 ref={virtualizer.measureElement}
                 style={{
@@ -420,14 +549,14 @@ export function ThreadList({ onSelect, searchQuery }: { onSelect?: () => void; s
                   transform: `translateY(${vRow.start}px)`,
                 }}
               >
-                {renderRow(session)}
+                {renderItem(item)}
               </div>
             )
           })}
         </div>
       ) : (
         <div className="flex flex-col gap-px">
-          {filtered.map((session, index) => renderRow(session, index))}
+          {groupedItems.map(renderItem)}
         </div>
       )}
 

--- a/apps/desktop/src/renderer/hooks/useAppGlobalEvents.ts
+++ b/apps/desktop/src/renderer/hooks/useAppGlobalEvents.ts
@@ -157,15 +157,18 @@ export function useAppGlobalEvents({
   }, [view, currentSessionId, toggleSidebar, runtimeReady, createAndActivateSession, openSidebarSearch, setView])
 
   useEffect(() => {
+    const handleToggleSidebar = () => toggleSidebar()
     const handleOpenSearch = () => openSidebarSearch()
     const handleOpenSettings = () => openSidebarSettings()
+    window.addEventListener('open-cowork:toggle-sidebar', handleToggleSidebar)
     window.addEventListener('open-cowork:toggle-search', handleOpenSearch)
     window.addEventListener('open-cowork:open-settings', handleOpenSettings)
     return () => {
+      window.removeEventListener('open-cowork:toggle-sidebar', handleToggleSidebar)
       window.removeEventListener('open-cowork:toggle-search', handleOpenSearch)
       window.removeEventListener('open-cowork:open-settings', handleOpenSettings)
     }
-  }, [openSidebarSearch, openSidebarSettings])
+  }, [openSidebarSearch, openSidebarSettings, toggleSidebar])
 
   useEffect(() => {
     // Both signals land us in the same UI state (signed-out banner, any

--- a/apps/desktop/tests/navigation-wiring.smoke.test.ts
+++ b/apps/desktop/tests/navigation-wiring.smoke.test.ts
@@ -249,10 +249,11 @@ test('search shortcut reveals the sidebar search when the sidebar is collapsed',
   try {
     await waitForAppShell(page, 30_000)
 
-    await page.locator('.drag button').first().click()
-    await page.getByRole('button', { name: 'Home', exact: true }).first().waitFor({ state: 'hidden', timeout: 10_000 })
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('open-cowork:toggle-sidebar')))
+    await page.locator('aside[data-sidebar-collapsed="true"]').waitFor({ timeout: 10_000 })
 
     await page.evaluate(() => window.dispatchEvent(new CustomEvent('open-cowork:toggle-search')))
+    await page.locator('aside[data-sidebar-collapsed="false"]').waitFor({ timeout: 10_000 })
     await page.getByPlaceholder(/Search projects and chats/i).waitFor({ timeout: 10_000 })
   } finally {
     await cleanup()
@@ -265,10 +266,11 @@ test('settings shortcut reveals the sidebar settings when the sidebar is collaps
   try {
     await waitForAppShell(page, 30_000)
 
-    await page.locator('.drag button').first().click()
-    await page.getByRole('button', { name: 'Home', exact: true }).first().waitFor({ state: 'hidden', timeout: 10_000 })
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent('open-cowork:toggle-sidebar')))
+    await page.locator('aside[data-sidebar-collapsed="true"]').waitFor({ timeout: 10_000 })
 
     await page.evaluate(() => window.dispatchEvent(new CustomEvent('open-cowork:open-settings')))
+    await page.locator('aside[data-sidebar-collapsed="false"]').waitFor({ timeout: 10_000 })
     await page.getByRole('dialog', { name: 'Settings' }).waitFor({ timeout: 10_000 })
     await page.getByRole('button', { name: 'Close dialog' }).waitFor({ timeout: 10_000 })
   } finally {

--- a/apps/website/src/app-shell.ts
+++ b/apps/website/src/app-shell.ts
@@ -34,8 +34,9 @@ export type CloudWebRoute = {
 }
 
 export type CloudWebRouteGroup = {
-  id: CloudWebSurface
+  id: 'studio' | 'manage' | 'admin'
   label: string
+  collapsible?: boolean
   routes: CloudWebRoute[]
 }
 
@@ -68,7 +69,7 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
   },
   {
     id: 'agents',
-    label: 'Coworkers',
+    label: 'Team',
     surface: 'workbench',
     requiresAuth: true,
     requiresAdmin: false,
@@ -198,13 +199,20 @@ export const CLOUD_WEB_ROUTES: CloudWebRoute[] = [
 
 export const CLOUD_WEB_ROUTE_GROUPS: CloudWebRouteGroup[] = [
   {
-    id: 'workbench',
+    id: 'studio',
     label: 'Studio',
-    routes: CLOUD_WEB_ROUTES.filter((route) => route.surface === 'workbench'),
+    routes: CLOUD_WEB_ROUTES.filter((route) => route.id === 'chat' || route.id === 'threads' || route.id === 'approvals'),
+  },
+  {
+    id: 'manage',
+    label: 'Manage',
+    collapsible: true,
+    routes: CLOUD_WEB_ROUTES.filter((route) => route.id === 'agents' || route.id === 'workflows' || route.id === 'channels' || route.id === 'capabilities' || route.id === 'artifacts' || route.id === 'settings'),
   },
   {
     id: 'admin',
     label: 'Admin',
+    collapsible: true,
     routes: CLOUD_WEB_ROUTES.filter((route) => route.surface === 'admin'),
   },
 ]

--- a/apps/website/src/browser-e2e.test.ts
+++ b/apps/website/src/browser-e2e.test.ts
@@ -87,6 +87,26 @@ test('cloud web browser gates admin controls for member workspaces', async () =>
   }
 })
 
+test('cloud web browser expands the collapsed rail before focusing chat search', async () => {
+  const harness = await createCloudWebBrowserHarness({ role: 'admin', sessionCount: 2, hydratedViewCount: 2 }).start()
+  try {
+    const railToggle = harness.document.querySelector('[data-sidebar-rail-toggle]') as HTMLButtonElement
+    assert.ok(railToggle)
+    railToggle.dispatchEvent(new harness.window.MouseEvent('click', { bubbles: true, cancelable: true }))
+    await waitFor(() => assert.equal(harness.document.body.dataset.sidebarRail, 'collapsed'))
+    assert.equal(harness.document.querySelector('[data-route-link="chat"]')?.getAttribute('aria-label'), 'Home')
+    assert.equal(harness.document.querySelector('[data-route-link="agents"]')?.getAttribute('aria-label'), 'Team')
+
+    harness.clickText('button', 'Search')
+    await waitFor(() => {
+      assert.equal(harness.document.body.dataset.sidebarRail, 'expanded')
+      assert.equal(harness.document.activeElement?.id, 'sidebar-thread-query')
+    })
+  } finally {
+    harness.close()
+  }
+})
+
 test('cloud web browser disables member invite controls outside invite signup mode', async () => {
   const harness = await createCloudWebBrowserHarness({ role: 'admin', signupMode: 'disabled' }).start()
   try {
@@ -352,7 +372,7 @@ test('cloud web browser exposes desktop parity boundaries and workbench state vo
       assert.equal(inspectorToggle.getAttribute('aria-expanded'), 'false')
     })
 
-    harness.clickText('[data-route-link]', 'Coworkers')
+    harness.clickText('[data-route-link]', 'Team')
     await waitFor(() => assert.equal(harness.document.body.dataset.route, 'agents'))
     assert.ok(harness.document.querySelector('#workbench-agent-list .agent-card'))
     assert.match(harness.document.querySelector('#workbench-agent-list')?.textContent || '', /Leads ·/)

--- a/apps/website/src/react-shell-controller.tsx
+++ b/apps/website/src/react-shell-controller.tsx
@@ -236,6 +236,7 @@ type RouteDomCache = {
   panels: Map<string, HTMLElement[]>
   links: Map<string, HTMLElement[]>
   adminNav: HTMLDetailsElement[]
+  manageNav: HTMLDetailsElement[]
 }
 
 function pushRouteElement<T extends HTMLElement>(map: Map<string, T[]>, routeId: string | undefined, element: T) {
@@ -254,6 +255,22 @@ function buildRouteDomCache(): RouteDomCache {
     panels,
     links,
     adminNav: Array.from(document.querySelectorAll<HTMLDetailsElement>('[data-admin-nav]')),
+    manageNav: Array.from(document.querySelectorAll<HTMLDetailsElement>('[data-manage-nav]')),
+  }
+}
+
+function setSidebarRailCollapsed(collapsed: boolean) {
+  document.body.dataset.sidebarRail = collapsed ? 'collapsed' : 'expanded'
+  try {
+    window.localStorage.setItem('open-cowork-cloud-sidebar-rail', collapsed ? 'collapsed' : 'expanded')
+  } catch {
+    // Browser storage can be unavailable in hardened contexts; the current
+    // document state is still enough for this session.
+  }
+  for (const toggle of document.querySelectorAll<HTMLButtonElement>('[data-sidebar-rail-toggle]')) {
+    toggle.setAttribute('aria-pressed', collapsed ? 'true' : 'false')
+    toggle.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar')
+    toggle.title = collapsed ? 'Expand sidebar' : 'Collapse sidebar'
   }
 }
 
@@ -338,9 +355,12 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
             const label = `${linkRoute.label} - admin permissions required`
             if (link.dataset.locked !== 'true') link.dataset.locked = 'true'
             if (link.getAttribute('aria-label') !== label) link.setAttribute('aria-label', label)
+            if (link.title !== label) link.title = label
           } else {
+            const label = linkRoute?.label || routeId
             if (link.dataset.locked !== 'false') link.dataset.locked = 'false'
-            if (link.hasAttribute('aria-label')) link.removeAttribute('aria-label')
+            if (link.getAttribute('aria-label') !== label) link.setAttribute('aria-label', label)
+            if (link.title !== label) link.title = label
           }
         }
       }
@@ -353,6 +373,10 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
     for (const details of cache.adminNav) {
       const open = route.surface === 'admin'
       if (details.open !== open) details.open = open
+    }
+    for (const details of cache.manageNav) {
+      const routeInManage = Boolean(details.querySelector(`[data-route-link="${route.id}"]`))
+      if (routeInManage && !details.open) details.open = true
     }
     activeRouteIdRef.current = route.id
     if (document.body.dataset.route !== route.id) document.body.dataset.route = route.id
@@ -432,6 +456,7 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
     setText('org-meta', signedIn && email ? `${email} - ${role} - ${profile}` : signedIn ? `${role} - ${profile}` : 'Sign in to open your cloud workspace')
     setText('profile-name', profile)
     setText('role-name', role)
+    setText('presence-meta', signedIn && email ? `${email} - ${profile}` : `${profile} - ${signedIn ? 'online' : 'signed out'}`)
     setText('workspace-label', signedIn ? org : 'Studio workspace')
     setText('workspace-meta', signedIn && email ? `${email} - ${profile}` : 'Sign in to sync chats')
     setText('profile-summary', profile)
@@ -454,6 +479,16 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
   }, [bootstrap.defaultRoute, navigate])
 
   useEffect(() => {
+    let preferred = 'expanded'
+    try {
+      preferred = window.localStorage.getItem('open-cowork-cloud-sidebar-rail') || preferred
+    } catch {
+      preferred = 'expanded'
+    }
+    setSidebarRailCollapsed(preferred === 'collapsed')
+  }, [])
+
+  useEffect(() => {
     const handler = (event: MouseEvent) => {
       const target = event.target as HTMLElement | null
       if (!target) return
@@ -462,6 +497,18 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
       if (routeLink) {
         event.preventDefault()
         navigate(routeLink.dataset.routeLink || bootstrap.defaultRoute)
+        return
+      }
+
+      if (target.closest('[data-sidebar-rail-toggle]')) {
+        event.preventDefault()
+        setSidebarRailCollapsed(document.body.dataset.sidebarRail !== 'collapsed')
+        return
+      }
+
+      if (target.closest('[data-presence-settings-link="true"]')) {
+        event.preventDefault()
+        navigate('settings')
         return
       }
 
@@ -501,7 +548,12 @@ export function CloudReactShellController({ bootstrap }: { bootstrap: CloudWebCl
           navigate('threads')
           window.requestAnimationFrame(() => document.getElementById('thread-query')?.focus())
         } else {
-          document.getElementById('sidebar-thread-query')?.focus()
+          if (document.body.dataset.sidebarRail === 'collapsed') {
+            setSidebarRailCollapsed(false)
+            window.requestAnimationFrame(() => document.getElementById('sidebar-thread-query')?.focus())
+          } else {
+            document.getElementById('sidebar-thread-query')?.focus()
+          }
         }
         return
       }

--- a/apps/website/src/react-workbench.test.ts
+++ b/apps/website/src/react-workbench.test.ts
@@ -8,6 +8,7 @@ import {
   CloudChatTimeline,
   CloudSelectedArtifactHistory,
   CloudRuntimeStatus,
+  CloudSidebarThreadList,
   CloudThreadList,
 } from './react-workbench.ts'
 import { CLOUD_DELIVERABLE_APPROVAL_COPY, CloudConversationMeta } from './react-workbench-context.ts'
@@ -55,6 +56,69 @@ test('React workbench components render cloud-safe thread, timeline, runtime, an
   assert.doesNotMatch(html, /signedUrl/)
   assert.doesNotMatch(html, /objectKey/)
   assert.doesNotMatch(html, /leaked-secret/)
+})
+
+test('React Cloud sidebar groups chats by project source', () => {
+  const projectSession = makeSession(10)
+  const projectFollowUp = makeSession(20)
+  const chatOnlySession = makeSession(1)
+  const sessions = [projectSession, projectFollowUp, chatOnlySession]
+  const views = Object.fromEntries(sessions.map((session) => [session.sessionId, makeSessionView(session, 10, 0)]))
+
+  const html = renderToStaticMarkup(createElement(CloudSidebarThreadList, {
+    sessions,
+    views,
+    selectedSessionId: projectSession.sessionId,
+  }))
+
+  assert.match(html, /class="sidebar-thread-project"/)
+  assert.match(html, /repo/)
+  assert.match(html, />2<\/small>/)
+  assert.match(html, /chat-only/)
+  assert.match(html, />1<\/small>/)
+  assert.match(html, /data-selected="true"/)
+})
+
+test('React Cloud sidebar groups chats from session list project metadata without loaded views', () => {
+  const projectSession = {
+    ...makeSession(10),
+    projectSource: { kind: 'git' as const, repositoryUrl: 'https://github.com/acme/api.git' },
+  }
+  const projectFollowUp = {
+    ...makeSession(20),
+    projectSource: { kind: 'git' as const, repositoryUrl: 'https://github.com/acme/api.git' },
+  }
+  const chatOnlySession = makeSession(1)
+
+  const html = renderToStaticMarkup(createElement(CloudSidebarThreadList, {
+    sessions: [projectSession, projectFollowUp, chatOnlySession],
+    views: {},
+    selectedSessionId: projectSession.sessionId,
+  }))
+
+  assert.match(html, /api/)
+  assert.match(html, />2<\/small>/)
+  assert.match(html, /chat-only/)
+  assert.match(html, />1<\/small>/)
+  assert.match(html, /data-selected="true"/)
+})
+
+test('React Cloud sidebar keeps distinct repos with the same basename in separate groups', () => {
+  const acmeSession = makeSession(10)
+  const contosoSession = makeSession(20)
+  const sessions = [acmeSession, contosoSession]
+  const views = Object.fromEntries(sessions.map((session) => [session.sessionId, makeSessionView(session, 10, 0)]))
+  views[acmeSession.sessionId].projection.view.projectSource = { kind: 'git', repositoryUrl: 'https://github.com/acme/api.git' }
+  views[contosoSession.sessionId].projection.view.projectSource = { kind: 'git', repositoryUrl: 'https://github.com/contoso/api.git' }
+
+  const html = renderToStaticMarkup(createElement(CloudSidebarThreadList, {
+    sessions,
+    views,
+  }))
+
+  assert.equal(html.match(/class="sidebar-thread-project"/g)?.length, 2)
+  assert.equal(html.match(/>1<\/small>/g)?.length, 2)
+  assert.doesNotMatch(html, />2<\/small>/)
 })
 
 test('React workbench renders delegated handoff badges, task context, and approval-gated deliverables', () => {

--- a/apps/website/src/react-workbench.ts
+++ b/apps/website/src/react-workbench.ts
@@ -7,10 +7,12 @@ import {
 import {
   CLOUD_WEB_THREAD_PAGE_SIZE,
   cloudWebThreadProjectLabel,
+  cloudWebThreadProjectSource,
   cloudWebThreadProjection,
   cloudWebThreadStatus,
   filterCloudWebThreads,
   type CloudWebThreadFilters,
+  type CloudWebThreadProjection,
   type CloudWebThreadSession,
   type CloudWebThreadView,
 } from './thread-workbench.ts'
@@ -242,7 +244,7 @@ function threadRows({ sessions, views, filters, selectedSessionId, limit = CLOUD
           'aria-pressed': selectedSessionId === session.sessionId ? 'true' : 'false',
           onClick: () => onSelect?.(session.sessionId),
         }, session.title || session.sessionId),
-        h('small', null, `${session.profileName || projection?.profileName || 'default'} - ${cloudWebThreadProjectLabel(projection)}`)),
+        h('small', null, `${session.profileName || projection?.profileName || 'default'} - ${cloudWebThreadProjectLabel(session, projection)}`)),
       h('span', { role: 'cell' }, h('span', { className: 'pill', 'data-kind': statusPillKind(status) }, status)))
     })
     : [h('div', { className: 'table-row empty-row', role: 'row', key: 'empty' },
@@ -260,11 +262,37 @@ export function CloudThreadList(props: CloudThreadListProps) {
     rows)
 }
 
+function cloudSidebarThreadGroupKey(session: CloudWebThreadSession, projection: CloudWebThreadProjection | null) {
+  const source = cloudWebThreadProjectSource(session, projection)
+  if (!source) return 'chat-only'
+  const kind = source.kind || 'project'
+  const identity = [
+    source.repositoryUrl || (source as Record<string, unknown>).snapshotId || source.title,
+    source.ref,
+    source.subdirectory,
+  ].filter(Boolean).join(':')
+  return identity ? `${kind}:${String(identity)}` : `${kind}:${session.sessionId}`
+}
+
 export function CloudSidebarThreadList({ sessions, views, filters, selectedSessionId, onSelect, limit = 50 }: CloudThreadListProps) {
   const rows = filterCloudWebThreads(sessions, views, filters, limit)
+  const groups = new Map<string, { label: string, entries: Array<{ session: CloudWebThreadSession; index: number }> }>()
+  rows.forEach((session, index) => {
+    const projection = cloudWebThreadProjection(views[session.sessionId])
+    const projectLabel = cloudWebThreadProjectLabel(session, projection)
+    const key = cloudSidebarThreadGroupKey(session, projection)
+    const group = groups.get(key)
+    if (group) group.entries.push({ session, index })
+    else groups.set(key, { label: projectLabel || 'chat-only', entries: [{ session, index }] })
+  })
+
   return h('div', { className: 'react-sidebar-thread-list' },
-    rows.length
-      ? rows.map((session, index) => {
+    groups.size
+      ? Array.from(groups.entries()).map(([groupKey, group]) => h('section', { className: 'sidebar-thread-project', key: groupKey },
+        h('div', { className: 'sidebar-thread-project__head' },
+          h('span', null, group.label),
+          h('small', null, `${group.entries.length}`)),
+        group.entries.map(({ session, index }) => {
         const projection = cloudWebThreadProjection(views[session.sessionId])
         const status = cloudWebThreadStatus(session, projection)
         return h('button', {
@@ -280,7 +308,7 @@ export function CloudSidebarThreadList({ sessions, views, filters, selectedSessi
           h('strong', null, session.title || session.sessionId),
           h('small', null, `${status} - ${session.profileName || projection?.profileName || 'default'}`)),
         h('span', { className: 'pill', 'data-kind': statusPillKind(status) }, status))
-      })
+      })))
       : h('p', { className: 'empty' }, 'No chats loaded.'))
 }
 

--- a/apps/website/src/render.test.ts
+++ b/apps/website/src/render.test.ts
@@ -91,6 +91,15 @@ test('cloud website renders Studio and admin shell surfaces', () => {
   assert.match(html, /Tools &amp; Skills/)
   assert.match(html, /Artifacts/)
   assert.match(html, /Settings/)
+  assert.match(html, /class="brand-copy"/)
+  assert.match(html, /data-sidebar-rail-toggle="true"/)
+  assert.match(html, /data-manage-nav/)
+  assert.match(html, /aria-label="Home"/)
+  assert.match(html, /aria-label="Manage"/)
+  assert.match(html, /aria-label="Admin controls"/)
+  assert.match(html, /Chats by project/)
+  assert.match(html, /class="sidebar-presence-footer"/)
+  assert.match(html, /data-presence-settings-link="true"/)
   assert.match(html, /Admin controls/)
   assert.match(html, /data-admin-nav/)
   assert.match(html, /Org/)
@@ -147,8 +156,11 @@ test('cloud website renders Studio and admin shell surfaces', () => {
   assert.match(html, /--accent-gradient: linear-gradient\(150deg,var\(--accent-2\),var\(--accent\)\);/)
   assert.match(html, /--accent-action-fill: linear-gradient\(rgba\(255,255,255,0\.01\),rgba\(255,255,255,0\.01\)\), var\(--accent-gradient\);/)
   assert.match(html, /--cloud-shell-sidebar-w: 248px;/)
+  assert.match(html, /--cloud-shell-sidebar-rail-w: 64px;/)
   assert.match(html, /font-variant-numeric: tabular-nums;/)
   assert.match(html, /\.nav-links a\[data-active="true"\]/)
+  assert.match(html, /body\[data-sidebar-rail="collapsed"\] \.shell/)
+  assert.match(html, /\.sidebar-thread-project__head/)
   assert.match(html, /box-shadow: var\(--ring-selected\);/)
   assert.match(html, /\.admin-nav:not\(\[open\]\) \.nav-links/)
   assert.match(html, /class="cloud-theme-switcher"/)
@@ -191,8 +203,8 @@ test('cloud website renders Studio and admin shell surfaces', () => {
 
 test('cloud website app shell exposes typed route metadata', () => {
   assert.equal(DEFAULT_CLOUD_WEB_ROUTE, 'chat')
-  assert.deepEqual(CLOUD_WEB_ROUTE_GROUPS.map((group) => group.id), ['workbench', 'admin'])
-  assert.deepEqual(CLOUD_WEB_ROUTE_GROUPS.map((group) => group.label), ['Studio', 'Admin'])
+  assert.deepEqual(CLOUD_WEB_ROUTE_GROUPS.map((group) => group.id), ['studio', 'manage', 'admin'])
+  assert.deepEqual(CLOUD_WEB_ROUTE_GROUPS.map((group) => group.label), ['Studio', 'Manage', 'Admin'])
   assert.equal(findCloudWebRoute('chat')?.requiresAuth, false)
   assert.equal(findCloudWebRoute('threads')?.surface, 'workbench')
   assert.equal(findCloudWebRoute('approvals')?.requiresAuth, true)
@@ -991,7 +1003,7 @@ test('cloud website thread helper handles status filters and thousands-sized lis
         view: {
           status: 'running',
           pendingApprovals: [{ id: 'approval-1' }],
-          projectSource: { kind: 'git', repositoryUrl: 'https://github.com/acme/app.git' },
+          projectSource: { kind: 'git' as const, repositoryUrl: 'https://github.com/acme/app.git' },
         },
       },
     },
@@ -1000,7 +1012,7 @@ test('cloud website thread helper handles status filters and thousands-sized lis
         view: {
           status: 'running',
           pendingQuestions: [{ id: 'question-1' }],
-          projectSource: { kind: 'snapshot', title: 'Browser upload' },
+          projectSource: { kind: 'snapshot' as const, title: 'Browser upload' },
         },
       },
     },

--- a/apps/website/src/render.ts
+++ b/apps/website/src/render.ts
@@ -58,10 +58,11 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
     <aside class="nav">
       <div class="brand">
         ${brandLogoMarkup(branding)}
-        <div>
+        <div class="brand-copy">
           <div class="brand-title">${escapeHtml(branding.productName)}</div>
           <div class="meta" id="profile-name">${escapeHtml(policy.profileName)}</div>
         </div>
+        <button class="sidebar-rail-toggle" type="button" data-sidebar-rail-toggle="true" aria-pressed="false" aria-label="Collapse sidebar" title="Collapse sidebar"><span aria-hidden="true">|||</span></button>
       </div>
       <div class="workspace-card">
         <div class="workspace-card-row">
@@ -74,23 +75,21 @@ export function cloudWebsiteHtml(policy: WebsiteBootstrapPolicy, publicBranding?
         <button class="primary" type="button" data-new-thread-shortcut="true" data-chat-control="true">New chat</button>
         <button type="button" data-thread-search-focus="true">Search</button>
       </div>
+      <nav class="nav-sections nav-sections-primary" aria-label="Cloud Web sections">${routeGroupsMarkup(['studio'])}</nav>
       <label class="sidebar-search signed-in-only">
         <span>Search chats</span>
         <input id="sidebar-thread-query" autocomplete="off" placeholder="Search chats...">
       </label>
       <div class="sidebar-thread-pane signed-in-only" aria-label="Recent chats" data-workbench-pane="threads">
-        <div class="sidebar-pane-header">
-          <span>Chats</span>
-          <small><span id="sidebar-thread-count">0</span></small>
-        </div>
+        <div class="sidebar-pane-header"><span>Chats by project</span><small><span id="sidebar-thread-count">0</span></small></div>
         <div class="sidebar-thread-list" id="sidebar-thread-list"></div>
       </div>
-      <nav class="nav-sections" aria-label="Cloud Web sections">
-        ${routeGroupsMarkup()}
-      </nav>
-      <div class="role-card">
-        <div class="meta">Role</div>
-        <strong id="role-name">${adminDefault ? 'admin' : 'member'}</strong>
+      <nav class="nav-sections nav-sections-manage" aria-label="Cloud Web management sections">${routeGroupsMarkup(['manage'])}</nav>
+      <nav class="nav-sections nav-sections-admin" aria-label="Cloud Web admin sections">${routeGroupsMarkup(['admin'])}</nav>
+      <div class="sidebar-presence-footer">
+        <span class="sidebar-presence-avatar" aria-hidden="true">OC</span>
+        <div class="sidebar-presence-copy"><strong id="role-name">${adminDefault ? 'admin' : 'member'}</strong><span id="presence-meta">Cloud Web · ${escapeHtml(policy.profileName)}</span></div>
+        <a href="#settings" class="sidebar-presence-settings signed-in-only" data-presence-settings-link="true" aria-label="Open settings" title="Open settings"><span aria-hidden="true">S</span></a>
       </div>
       <div class="sidebar-utility signed-in-only" aria-label="Workspace actions">
         <button type="button" class="ghost" data-refresh-dashboard="true">Refresh</button>

--- a/apps/website/src/route-markup.ts
+++ b/apps/website/src/route-markup.ts
@@ -1,7 +1,29 @@
 import { cloudWebAdminSurfaceForRoute } from './admin-surface-matrix.ts'
-import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute, type CloudWebRouteId } from './app-shell.ts'
+import { CLOUD_WEB_ROUTE_GROUPS, CLOUD_WEB_ROUTES, DEFAULT_CLOUD_WEB_ROUTE, type CloudWebRoute, type CloudWebRouteGroup, type CloudWebRouteId } from './app-shell.ts'
 import { escapeHtml } from './html-utils.ts'
 import { cloudWebWorkbenchParityForRoute, type CloudWebWorkbenchParityAvailability } from './workbench-parity.ts'
+
+const ROUTE_NAV_ICONS: Record<CloudWebRouteId, string> = {
+  threads: 'P',
+  chat: '+',
+  approvals: '?',
+  agents: 'T',
+  capabilities: '*',
+  workflows: 'W',
+  channels: 'C',
+  artifacts: 'A',
+  settings: 'S',
+  org: 'O',
+  members: 'M',
+  policy: 'P',
+  byok: 'K',
+  connections: 'N',
+  billing: '$',
+  gateway: 'G',
+  audit: 'L',
+  usage: 'U',
+  diagnostics: 'D',
+}
 
 function routeNavMarkup(route: CloudWebRoute) {
   const authClass = route.requiresAuth ? ' signed-in-only' : ''
@@ -9,15 +31,27 @@ function routeNavMarkup(route: CloudWebRoute) {
   const alertBadge = route.id === 'approvals'
     ? '<span class="nav-alert-count" id="approvals-alert-count" aria-live="polite"></span>'
     : ''
-  return `<a href="#${escapeHtml(route.id)}" data-route-link="${escapeHtml(route.id)}" data-route-surface="${escapeHtml(route.surface)}" data-requires-auth="${route.requiresAuth ? 'true' : 'false'}" data-requires-admin="${route.requiresAdmin ? 'true' : 'false'}" class="${authClass.trim()}${adminClass}">${escapeHtml(route.label)}${alertBadge}</a>`
+  const label = escapeHtml(route.label)
+  return `<a href="#${escapeHtml(route.id)}" data-route-link="${escapeHtml(route.id)}" data-route-surface="${escapeHtml(route.surface)}" data-requires-auth="${route.requiresAuth ? 'true' : 'false'}" data-requires-admin="${route.requiresAdmin ? 'true' : 'false'}" aria-label="${label}" title="${label}" class="${authClass.trim()}${adminClass}"><span class="nav-icon" data-icon="${escapeHtml(ROUTE_NAV_ICONS[route.id])}" aria-hidden="true"></span><span class="nav-label">${label}</span>${alertBadge}</a>`
 }
 
-export function routeGroupsMarkup() {
-  return CLOUD_WEB_ROUTE_GROUPS.map((group) => {
+export function routeGroupsMarkup(groupIds?: Array<CloudWebRouteGroup['id']>) {
+  const groups = groupIds
+    ? CLOUD_WEB_ROUTE_GROUPS.filter((group) => groupIds.includes(group.id))
+    : CLOUD_WEB_ROUTE_GROUPS
+  return groups.map((group) => {
     const links = group.routes.map(routeNavMarkup).join('')
     if (group.id === 'admin') {
+      const label = `${escapeHtml(group.label)} controls`
       return `<details class="nav-group admin-nav" data-admin-nav data-nav-group="${escapeHtml(group.id)}">
-          <summary><span>${escapeHtml(group.label)} controls</span></summary>
+          <summary aria-label="${label}" title="${label}"><span>${label}</span></summary>
+          <div class="nav-links">${links}</div>
+        </details>`
+    }
+    if (group.collapsible) {
+      const label = escapeHtml(group.label)
+      return `<details class="nav-group manage-nav" data-manage-nav data-nav-group="${escapeHtml(group.id)}" open>
+          <summary aria-label="${label}" title="${label}"><span>${label}</span><small>Team · Playbooks · Tools</small></summary>
           <div class="nav-links">${links}</div>
         </details>`
     }

--- a/apps/website/src/style-layout.ts
+++ b/apps/website/src/style-layout.ts
@@ -29,7 +29,7 @@ export function cloudWebsiteLayoutStyles() {
     }
     .brand {
       display: grid;
-      grid-template-columns: var(--control-h-lg) minmax(0, 1fr);
+      grid-template-columns: var(--control-h-lg) minmax(0, 1fr) var(--control-h-sm);
       align-items: center;
       gap: var(--space-3);
       min-width: 0;
@@ -208,10 +208,11 @@ export function cloudWebsiteLayoutStyles() {
       gap: var(--space-2);
     }
     .admin-nav {
-      margin-top: auto;
+      margin-top: 0;
       border-top: var(--border-width-1) solid var(--color-border-subtle);
       padding-top: var(--space-3);
     }
+    .manage-nav summary,
     .admin-nav summary {
       min-height: var(--control-h-md);
       border: var(--border-width-1) solid var(--color-border);
@@ -232,17 +233,29 @@ export function cloudWebsiteLayoutStyles() {
         border-color var(--dur-1) var(--ease-out),
         color var(--dur-1) var(--ease-out);
     }
+    .manage-nav summary small {
+      overflow: hidden;
+      color: var(--muted);
+      font-size: var(--text-2xs);
+      font-weight: 600;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .manage-nav summary::-webkit-details-marker,
     .admin-nav summary::-webkit-details-marker {
       display: none;
     }
+    .manage-nav summary:hover,
     .admin-nav summary:hover {
       background: var(--color-surface-hover);
       color: var(--text);
     }
+    .manage-nav summary:focus-visible,
     .admin-nav summary:focus-visible {
       outline: 0;
       box-shadow: var(--ring-focus);
     }
+    .manage-nav summary::after,
     .admin-nav summary::after {
       content: '+';
       color: var(--muted);
@@ -250,18 +263,22 @@ export function cloudWebsiteLayoutStyles() {
       font-size: var(--text-sm);
       line-height: var(--lh-sm);
     }
+    .manage-nav[open] summary,
     .admin-nav[open] summary {
       background: var(--color-surface-active);
       border-color: var(--color-border-strong);
       color: var(--text);
     }
+    .manage-nav[open] summary::after,
     .admin-nav[open] summary::after {
       content: '-';
       color: var(--accent-text);
     }
+    .manage-nav .nav-links,
     .admin-nav .nav-links {
       margin-top: var(--space-2);
     }
+    .manage-nav:not([open]) .nav-links,
     .admin-nav:not([open]) .nav-links {
       display: none;
     }
@@ -286,6 +303,7 @@ export function cloudWebsiteLayoutStyles() {
       color: var(--color-text-secondary);
       display: flex;
       align-items: center;
+      gap: var(--space-2);
       font-size: var(--text-sm);
       font-weight: 650;
       line-height: var(--lh-sm);

--- a/apps/website/src/style-sidebar.ts
+++ b/apps/website/src/style-sidebar.ts
@@ -1,0 +1,161 @@
+export function cloudWebsiteSidebarStyles() {
+  return String.raw`    body[data-sidebar-rail="collapsed"] .shell {
+      grid-template-columns: var(--cloud-shell-sidebar-rail-w) minmax(0, 1fr);
+    }
+    .sidebar-rail-toggle {
+      min-width: 0;
+      width: var(--control-h-sm);
+      height: var(--control-h-sm);
+      border-radius: var(--radius-sm);
+      padding: 0;
+    }
+    .sidebar-presence-footer {
+      display: grid;
+      grid-template-columns: var(--control-h-md) minmax(0, 1fr) var(--control-h-sm);
+      align-items: center;
+      gap: var(--space-2);
+      margin-top: auto;
+      min-width: 0;
+      border: var(--border-width-1) solid var(--color-border);
+      border-radius: var(--radius-lg);
+      background: color-mix(in srgb, var(--color-elevated) 88%, var(--color-base) 12%);
+      box-shadow: var(--surface-highlight);
+      padding: var(--row-pad);
+    }
+    .sidebar-presence-avatar,
+    .sidebar-presence-settings {
+      display: grid;
+      place-items: center;
+      border-radius: var(--radius-sm);
+    }
+    .sidebar-presence-avatar {
+      width: var(--control-h-md);
+      height: var(--control-h-md);
+      background: var(--accent-action-fill);
+      color: var(--accent-action-foreground);
+      font-family: var(--font-display);
+      font-size: var(--text-xs);
+      font-weight: 800;
+    }
+    .sidebar-presence-copy {
+      display: grid;
+      min-width: 0;
+      gap: 1px;
+    }
+    .sidebar-presence-copy strong,
+    .sidebar-presence-copy span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .sidebar-presence-settings {
+      width: var(--control-h-sm);
+      height: var(--control-h-sm);
+      color: var(--muted);
+      text-decoration: none;
+    }
+    .sidebar-presence-settings:hover {
+      background: var(--color-surface-hover);
+      color: var(--text);
+    }
+    .nav-icon {
+      width: var(--space-5);
+      height: var(--space-5);
+      border-radius: var(--radius-sm);
+      display: inline-grid;
+      flex: 0 0 auto;
+      place-items: center;
+      background: color-mix(in srgb, var(--color-surface-hover) 64%, transparent);
+      color: var(--muted);
+      font-family: var(--font-display);
+      font-size: var(--text-2xs);
+      font-weight: 800;
+      line-height: 1;
+    }
+    .nav-icon::before {
+      content: attr(data-icon);
+    }
+    .nav-links a[data-active="true"] .nav-icon {
+      background: var(--accent-action-fill);
+      color: var(--accent-action-foreground);
+    }
+    .nav-label {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .react-sidebar-thread-list,
+    .sidebar-thread-project {
+      display: grid;
+      gap: var(--space-1);
+    }
+    .sidebar-thread-project__head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-2);
+      color: var(--muted);
+      font-size: var(--text-2xs);
+      font-weight: 750;
+      letter-spacing: 0.08em;
+      line-height: var(--lh-2xs);
+      padding: var(--space-2) var(--space-2) var(--space-1);
+      text-transform: uppercase;
+    }
+    .sidebar-thread-project__head small {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    body[data-sidebar-rail="collapsed"] .nav {
+      align-items: center;
+      padding-inline: var(--space-2);
+    }
+    body[data-sidebar-rail="collapsed"] .brand {
+      grid-template-columns: var(--control-h-lg);
+      justify-items: center;
+    }
+    body[data-sidebar-rail="collapsed"] .brand-copy,
+    body[data-sidebar-rail="collapsed"] .workspace-card,
+    body[data-sidebar-rail="collapsed"] .sidebar-actions .primary,
+    body[data-sidebar-rail="collapsed"] .sidebar-search,
+    body[data-sidebar-rail="collapsed"] .sidebar-thread-pane,
+    body[data-sidebar-rail="collapsed"] .nav-heading,
+    body[data-sidebar-rail="collapsed"] .nav-label,
+    body[data-sidebar-rail="collapsed"] .nav-alert-count,
+    body[data-sidebar-rail="collapsed"] .manage-nav summary span,
+    body[data-sidebar-rail="collapsed"] .manage-nav summary small,
+    body[data-sidebar-rail="collapsed"] .admin-nav summary span,
+    body[data-sidebar-rail="collapsed"] .sidebar-presence-copy,
+    body[data-sidebar-rail="collapsed"] .sidebar-utility,
+    body[data-sidebar-rail="collapsed"] .brand-links {
+      display: none;
+    }
+    body[data-sidebar-rail="collapsed"] .sidebar-actions {
+      grid-template-columns: 1fr;
+    }
+    body[data-sidebar-rail="collapsed"] .sidebar-actions button,
+    body[data-sidebar-rail="collapsed"] .nav-links a,
+    body[data-sidebar-rail="collapsed"] .manage-nav summary,
+    body[data-sidebar-rail="collapsed"] .admin-nav summary {
+      justify-content: center;
+      width: var(--control-h-md);
+      padding-inline: 0;
+    }
+    body[data-sidebar-rail="collapsed"] .manage-nav summary::after {
+      content: 'M';
+    }
+    body[data-sidebar-rail="collapsed"] .admin-nav summary::after {
+      content: 'A';
+    }
+    body[data-sidebar-rail="collapsed"] .sidebar-presence-footer {
+      grid-template-columns: var(--control-h-md);
+      justify-content: center;
+      padding: var(--space-2) 0;
+    }
+    body[data-sidebar-rail="collapsed"] .sidebar-presence-settings {
+      display: none;
+    }`
+}

--- a/apps/website/src/styles.ts
+++ b/apps/website/src/styles.ts
@@ -9,6 +9,7 @@ import { cloudWebsiteLibraryStyles } from './style-library.ts'
 import { cloudWebsiteLayoutStyles } from './style-layout.ts'
 import { cloudWebsitePrimitiveStyles } from './style-primitives.ts'
 import { cloudWebsiteSharedUiStyles } from './style-shared-ui.ts'
+import { cloudWebsiteSidebarStyles } from './style-sidebar.ts'
 import { cloudWebsiteSettingsStyles } from './style-settings.ts'
 import { cloudWebsiteStudioUiStyles } from './style-studio-ui.ts'
 import { cloudWebsiteStudioPrimitiveStyles } from './style-studio-primitives.ts'
@@ -62,6 +63,7 @@ function cloudWebsiteBaseStyles(branding: PublicBrandingConfig) {
       color-scheme: ${cloudWebsiteColorScheme(branding)};
 ${publicBrandingCss(branding)}
       --cloud-shell-sidebar-w: 248px;
+      --cloud-shell-sidebar-rail-w: 64px;
       --shadow: var(--shadow-card);
       --surface-highlight: inset 0 1px 0 color-mix(in srgb, var(--color-text) 5%, transparent);
       --field-bg: color-mix(in srgb, var(--color-base) 72%, var(--color-elevated) 28%);
@@ -210,6 +212,7 @@ export function cloudWebsiteStyles(branding: PublicBrandingConfig) {
   return String.raw`${cloudWebsiteFontFaces()}
 ${cloudWebsiteBaseStyles(branding)}
 ${cloudWebsiteLayoutStyles()}
+${cloudWebsiteSidebarStyles()}
 ${cloudWebsiteComponentStyles()}
 ${cloudWebsitePrimitiveStyles()}
 ${cloudWebsiteAgentProfileStyles()}

--- a/apps/website/src/thread-workbench.ts
+++ b/apps/website/src/thread-workbench.ts
@@ -1,3 +1,5 @@
+import type { CloudProjectSourceSummary } from '@open-cowork/shared'
+
 export const CLOUD_WEB_THREAD_PAGE_SIZE = 200
 
 export type CloudWebThreadFilters = {
@@ -16,6 +18,7 @@ export type CloudWebThreadSession = {
   updatedAt?: string | null
   tags?: string[]
   smartFilters?: string[]
+  projectSource?: CloudProjectSourceSummary | null
 }
 
 export type CloudWebThreadProjection = {
@@ -24,7 +27,7 @@ export type CloudWebThreadProjection = {
   updatedAt?: string | null
   pendingApprovals?: unknown[]
   pendingQuestions?: unknown[]
-  projectSource?: { kind?: string, repositoryUrl?: string | null, title?: string | null } | null
+  projectSource?: CloudProjectSourceSummary | null
   tags?: string[]
   smartFilters?: string[]
 }
@@ -43,12 +46,16 @@ export function cloudWebThreadStatus(session: CloudWebThreadSession, projection:
   return projection?.status || session.status || 'idle'
 }
 
-export function cloudWebThreadProjectKind(projection: CloudWebThreadProjection | null | undefined) {
-  return projection?.projectSource?.kind || 'chat'
+export function cloudWebThreadProjectSource(session: CloudWebThreadSession | null | undefined, projection: CloudWebThreadProjection | null | undefined) {
+  return projection?.projectSource || session?.projectSource || null
 }
 
-export function cloudWebThreadProjectLabel(projection: CloudWebThreadProjection | null | undefined) {
-  const source = projection?.projectSource
+export function cloudWebThreadProjectKind(session: CloudWebThreadSession | null | undefined, projection: CloudWebThreadProjection | null | undefined) {
+  return cloudWebThreadProjectSource(session, projection)?.kind || 'chat'
+}
+
+export function cloudWebThreadProjectLabel(session: CloudWebThreadSession | null | undefined, projection: CloudWebThreadProjection | null | undefined) {
+  const source = cloudWebThreadProjectSource(session, projection)
   if (!source) return 'chat-only'
   if (source.kind === 'git') {
     const repo = source.repositoryUrl || 'git repository'
@@ -104,7 +111,7 @@ export function filterCloudWebThreads(
       const status = hasStatusFilter || hasQuery ? cloudWebThreadStatus(session, projection) : ''
       if (hasStatusFilter && status !== statusFilter && session.status !== statusFilter) return false
       if (hasProfileFilter && String(session.profileName || projection?.profileName || '').toLowerCase() !== profileFilter) return false
-      if (hasProjectFilter && cloudWebThreadProjectKind(projection) !== projectFilter) return false
+      if (hasProjectFilter && cloudWebThreadProjectKind(session, projection) !== projectFilter) return false
       const tags = hasTagFilter || hasQuery ? cloudWebThreadTags(session, projection) : []
       if (hasTagFilter && !tags.some((entry) => entry.toLowerCase().includes(tagFilter))) return false
       if (!hasQuery) return true
@@ -113,7 +120,7 @@ export function filterCloudWebThreads(
         session.title,
         session.profileName,
         status,
-        cloudWebThreadProjectLabel(projection),
+        cloudWebThreadProjectLabel(session, projection),
         ...tags,
       ].filter(Boolean).join(' ').toLowerCase()
       return queryTokens.every((token) => haystack.includes(token))

--- a/packages/cloud-client/src/contracts.ts
+++ b/packages/cloud-client/src/contracts.ts
@@ -12,6 +12,7 @@ import type {
   CloudProjectSnapshotUploadResult,
   CloudProjectSourceInput,
   CloudProjectSourcePolicyVerdict,
+  CloudProjectSourceSummary,
   CloudProjectionFenceToken,
   CloudSessionProjectionRecord,
   CloudSessionEventType,
@@ -48,6 +49,7 @@ export type {
   CloudProjectSnapshotUploadResult,
   CloudProjectSourceInput,
   CloudProjectSourcePolicyVerdict,
+  CloudProjectSourceSummary,
   CloudProjectionFenceToken,
   SessionArtifact,
   SessionArtifactAttachment,
@@ -247,6 +249,7 @@ export type SessionRecord = {
   profileName: string
   status: CloudClientSessionStatus
   title: string | null
+  projectSource?: CloudProjectSourceSummary | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/shared/src/project-source.ts
+++ b/packages/shared/src/project-source.ts
@@ -20,6 +20,15 @@ export type CloudSnapshotProjectSource = {
 export type CloudProjectSource = CloudGitProjectSource | CloudSnapshotProjectSource
 export type CloudProjectSourceInput = CloudProjectSource
 
+export type CloudProjectSourceSummary = {
+  kind: CloudProjectSourceKind
+  repositoryUrl?: string | null
+  ref?: string | null
+  subdirectory?: string | null
+  snapshotId?: string | null
+  title?: string | null
+}
+
 export type CloudProjectSourcePolicyVerdict = {
   allowed: boolean
   reason: string | null
@@ -91,6 +100,11 @@ function readNumber(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0
 }
 
+function cloudSafeGitRepositoryUrl(value: string) {
+  const stripped = value.split(/[?#]/, 1)[0]?.trim() || value.trim()
+  return stripped.replace(/^([a-z][a-z0-9+.-]*:\/\/)([^/@]+@)/i, '$1')
+}
+
 export function normalizeCloudProjectSource(value: unknown): CloudProjectSource | null {
   const record = asRecord(value)
   if (record.kind === 'git') {
@@ -118,4 +132,21 @@ export function normalizeCloudProjectSource(value: unknown): CloudProjectSource 
     }
   }
   return null
+}
+
+export function summarizeCloudProjectSource(source: CloudProjectSource | null | undefined): CloudProjectSourceSummary | null {
+  if (!source) return null
+  if (source.kind === 'git') {
+    return {
+      kind: 'git',
+      repositoryUrl: cloudSafeGitRepositoryUrl(source.repositoryUrl),
+      ref: source.ref,
+      subdirectory: source.subdirectory,
+    }
+  }
+  return {
+    kind: 'snapshot',
+    snapshotId: source.snapshotId,
+    title: source.title,
+  }
 }

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -1,4 +1,5 @@
 import type { SessionArtifact } from './artifacts.js'
+import type { CloudProjectSourceSummary } from './project-source.js'
 
 // Aggregate diff stats for a session, mirroring SDK Session.summary (additions
 // + deletions + file count across the session's snapshot diff). Distinct from
@@ -47,6 +48,9 @@ export interface SessionInfo {
   composerAgentName?: string | null
   composerModelId?: string | null
   composerReasoningVariant?: string | null
+  // Cloud-safe project source summary for remote sessions. This intentionally
+  // omits credential refs and object-store keys used by the full source.
+  projectSource?: CloudProjectSourceSummary | null
 }
 
 export interface SessionPromptOptions {

--- a/tests/cloud-config.test.ts
+++ b/tests/cloud-config.test.ts
@@ -42,6 +42,14 @@ test('cloud project source policy allows safe git sources and blocks disallowed 
   }, policy).policyCode, 'project_source.git.raw_credentials')
   assert.equal(evaluateCloudProjectSourcePolicy({
     kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git?token=secret',
+  }, policy).policyCode, 'project_source.git.url_components')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/repo.git#token-secret',
+  }, policy).policyCode, 'project_source.git.url_components')
+  assert.equal(evaluateCloudProjectSourcePolicy({
+    kind: 'git',
     repositoryUrl: 'https://github.com/acme/repo.git',
     ref: '--upload-pack=/tmp/pwned',
   }, policy).policyCode, 'project_source.git.ref')

--- a/tests/cloud-control-plane-store.test.ts
+++ b/tests/cloud-control-plane-store.test.ts
@@ -102,6 +102,41 @@ test('cloud control plane paginates and filters user session lists', () => {
   )
 })
 
+test('cloud control plane exposes safe project-source summaries on session lists', () => {
+  const store = seededStore()
+  store.writeSessionProjection({
+    tenantId: 'tenant-1',
+    sessionId: 'session-1',
+    sequence: 1,
+    view: {
+      projectSource: {
+        kind: 'git',
+        repositoryUrl: 'https://github.com/example/repo.git?token=secret#fragment',
+        ref: 'feature/sidebar',
+        subdirectory: 'apps/web',
+        credentialRef: 'secret-token-ref',
+      },
+    },
+  })
+
+  const expectedSummary = {
+    kind: 'git',
+    repositoryUrl: 'https://github.com/example/repo.git',
+    ref: 'feature/sidebar',
+    subdirectory: 'apps/web',
+  }
+  assert.deepEqual(store.listSessions('tenant-1', 'user-1')[0]?.projectSource, expectedSummary)
+  assert.deepEqual(store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1' }).items[0]?.projectSource, expectedSummary)
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(
+      store.listSessionsPage({ tenantId: 'tenant-1', userId: 'user-1' }).items[0]?.projectSource || {},
+      'credentialRef',
+    ),
+    false,
+  )
+  assert.equal(JSON.stringify(store.listSessions('tenant-1', 'user-1')[0]?.projectSource).includes('secret'), false)
+})
+
 test('cloud control plane keeps product domains isolated by tenant and org', () => {
   const store = seededStore()
   const org1 = store.ensureOrgForTenant({ tenantId: 'tenant-1', orgId: 'tenant-1', name: 'Acme' })

--- a/tests/cloud-workspace-adapter.test.ts
+++ b/tests/cloud-workspace-adapter.test.ts
@@ -127,6 +127,12 @@ function transport(): CloudTransportAdapter {
       title: 'Cloud session',
       createdAt: '2026-05-27T10:00:00.000Z',
       updatedAt: '2026-05-27T10:00:00.000Z',
+      projectSource: {
+        kind: 'git',
+        repositoryUrl: 'https://github.com/acme/project.git',
+        ref: 'main',
+        subdirectory: 'apps/web',
+      },
     }],
     createSession: async () => ({
       session: {
@@ -914,7 +920,14 @@ test('cloud workspace adapter falls back to read-only cached state when transpor
     cache,
   })
 
-  assert.equal((await offline.listSessions())[0]?.id, 'session-1')
+  const offlineSessions = await offline.listSessions()
+  assert.equal(offlineSessions[0]?.id, 'session-1')
+  assert.deepEqual(offlineSessions[0]?.projectSource, {
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/project.git',
+    ref: 'main',
+    subdirectory: 'apps/web',
+  })
   assert.equal((await offline.getSessionInfo('session-1'))?.title, 'Cloud session')
   assert.equal((await offline.getSessionView('session-1')).messages[0]?.content, 'Hello')
   assert.equal((await offline.listWorkflows()).workflows[0]?.id, 'workflow-1')

--- a/tests/cloud-workspace-cache.test.ts
+++ b/tests/cloud-workspace-cache.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { FileCloudWorkspaceCache } from '../apps/desktop/src/main/cloud-workspace-cache.ts'
-import type { SessionView } from '@open-cowork/shared'
+import type { SessionInfo, SessionView } from '@open-cowork/shared'
 
 function cachePath() {
   return join(mkdtempSync(join(tmpdir(), 'open-cowork-cloud-cache-')), 'cloud-workspace-cache.json')
@@ -98,6 +98,42 @@ test('cloud workspace metadata-only cache strips session views', () => {
   assert.equal(cache.getSessionView('cloud:test', 'session-1'), null)
   const stored = readFileSync(path, 'utf-8')
   assert.equal(stored.includes('should not persist'), false)
+})
+
+test('cloud workspace cache preserves safe project source summaries only', () => {
+  const path = cachePath()
+  const cache = new FileCloudWorkspaceCache({
+    path,
+    mode: 'metadata-only',
+    secretStorage: encryptedStorage(),
+  })
+  const session = {
+    id: 'session-1',
+    title: 'Cloud thread',
+    directory: null,
+    createdAt: '2026-05-27T10:00:00.000Z',
+    updatedAt: '2026-05-27T10:00:00.000Z',
+    projectSource: {
+      kind: 'git',
+      repositoryUrl: ' https://github.com/acme/project.git?token=query-secret#fragment-secret ',
+      ref: ' main ',
+      subdirectory: ' apps/web ',
+      credentialRef: 'credential-secret',
+    },
+  } as unknown as SessionInfo
+
+  cache.upsertSessionList('cloud:test', [session])
+
+  assert.deepEqual(cache.listSessions('cloud:test')?.[0]?.projectSource, {
+    kind: 'git',
+    repositoryUrl: 'https://github.com/acme/project.git',
+    ref: 'main',
+    subdirectory: 'apps/web',
+  })
+  const stored = readFileSync(path, 'utf-8')
+  assert.equal(stored.includes('credential-secret'), false)
+  assert.equal(stored.includes('query-secret'), false)
+  assert.equal(stored.includes('fragment-secret'), false)
 })
 
 test('cloud workspace cache persists portable product metadata without message bodies', () => {


### PR DESCRIPTION
## Summary
- Aligns desktop and Cloud Web sidebar/navigation with the Studio layout: primary nav, collapsible Manage section, grouped chats, collapsed rail behavior, and presence footer.
- Carries cloud project-source summaries through session lists, projections, adapters, and cache paths so chats can group by project without loading every full view.
- Hardens git project-source URL handling by rejecting query strings/fragments at policy entry and stripping unsafe URL components from summaries/cache serialization.

## Validation
Initial full-branch validation before the CI smoke-test correction:
- `git diff --check`
- `node scripts/run-node-tests.mjs tests/cloud-config.test.ts tests/cloud-control-plane-store.test.ts tests/cloud-workspace-cache.test.ts tests/cloud-workspace-adapter.test.ts tests/cloud-http-server.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm test:cloud-web`
- `pnpm --filter @open-cowork/desktop test -- --run src/renderer/components/layout/Sidebar.test.tsx src/renderer/components/sidebar/ThreadList.test.tsx`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode local`
- `python3 /Users/joe/.codex/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`

Post-amend CI fix validation:
- `pnpm --filter @open-cowork/desktop build`
- `node ../../scripts/run-desktop-smoke-tests.mjs --pattern "tests/navigation-wiring.smoke.test.ts" --timeout=120000 --retries=1`
- `pnpm --filter @open-cowork/desktop test -- --run src/renderer/hooks/useAppGlobalEvents.test.tsx`
- `pnpm --filter @open-cowork/desktop typecheck`
- `pnpm lint`
- `git diff --check`
- Manual closeout review of the amended delta; post-amend structured autoreview could not complete because the Codex reviewer hit its usage limit.

Closes #810