### PR TITLE
chore(deps): exclude the OpenCode engine pair from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     # Fold minor + patch dep bumps into grouped PRs so the review queue
     # stays sane; major bumps still land individually because they need
     # deliberate review.
+    # The OpenCode engine pair is exact-pinned and upgraded deliberately:
+    # bumps must re-verify the compatibility registry and the runtime
+    # contract fixture (tests/fixtures/opencode-runtime-contract.json)
+    # across every workspace that pins it, so Dependabot must not touch it.
+    ignore:
+      - dependency-name: "opencode-ai"
+      - dependency-name: "@opencode-ai/sdk"
     groups:
       vite-major:
         patterns:


### PR DESCRIPTION
## Why

Dependabot's \`minor-and-patch\` group PR (#845) bumped \`opencode-ai\` + \`@opencode-ai/sdk\` from 1.15.5 to 1.17.13 — but only in 2 of the 4 workspaces that exact-pin the pair, and without re-verifying the compatibility registry or the runtime contract fixture. The release-grade drift checks rejected it, as designed.

The engine pair is policy-managed: upgrades must sync all four pins (\`apps/desktop\`, \`apps/standalone-gateway\`, \`packages/cloud-server\`, \`packages/runtime-host\`), re-verify \`tests/fixtures/opencode-runtime-contract.json\`, and pass the compatibility registry gates. That is a deliberate upgrade task, not a routine bump.

## What

Add \`opencode-ai\` and \`@opencode-ai/sdk\` to the npm ecosystem \`ignore\` list with a comment documenting the upgrade contract.

After this merges, #845 will be recreated so the group excludes the engine pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)