### PR TITLE
chore(deps): ignore @types/node major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     ignore:
       - dependency-name: "opencode-ai"
       - dependency-name: "@opencode-ai/sdk"
+      # @types/node tracks the enforced runtime floor (.nvmrc / engines,
+      # pinned by tests/package-scripts.test.ts). Raising it is part of a
+      # deliberate Node-floor bump, not a routine types update.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       vite-major:
         patterns:


### PR DESCRIPTION
@types/node is pinned `^22.12.0` to match the enforced runtime floor (`.nvmrc` 22.12.0, `engines >=22.12`, both asserted by `tests/package-scripts.test.ts`). Dependabot's #848 bumped it to 26.1.0, which would let code type-check against Node 26 APIs the supported runtime doesn't have. Raising the floor is a deliberate multi-file change (nvmrc, engines, CONTRIBUTING, CI images), so majors for this package are ignored; minors/patches within 22.x still flow.

Supersedes #848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)