### PR TITLE
fix(audit): address deep-review follow-up nits from PR #879

### DIFF
--- a/apps/desktop/src/main/chart-spec-safety.ts
+++ b/apps/desktop/src/main/chart-spec-safety.ts
@@ -23,10 +23,20 @@ import { MAX_CHART_ARRAY_ITEMS } from '@open-cowork/shared'
 export const MAX_CHART_GENERATED_ROWS = 20_000
 
 // Maximum estimated rows any single data pipeline may reach after transforms.
-// Estimates are deliberately conservative (worst case), so this sits above the
-// per-generator cap to leave headroom for legitimate fold/flatten usage while
-// still rejecting multiplicative blow-ups long before they execute.
-export const MAX_CHART_ESTIMATED_ROWS = 50_000
+// Estimates are deliberately conservative (worst case), so this sits well above
+// the per-generator cap to leave headroom for legitimate dense charts (e.g. a
+// ~4200-row fold across a dozen series lands near 50k) while still rejecting
+// the multiplicative blow-ups (millions to billions of rows) long before they
+// execute.
+export const MAX_CHART_ESTIMATED_ROWS = 250_000
+
+// Maximum number of grid cells a compute-heavy raster transform (contour,
+// isocontour, heatmap) may declare. These transforms iterate every cell of a
+// size[0] x size[1] grid but emit only a handful of output rows (polygons or a
+// single image), so their cost is invisible to the row-count estimate above and
+// needs its own bound. ~4M cells keeps legitimate density maps working while
+// rejecting grids whose per-cell work would block the event loop.
+export const MAX_CHART_GRID_CELLS = 4_000_000
 
 function blockedRenderError(detail: string) {
   return new Error(`Chart rendering rejected an unsafe or oversized spec: ${detail}`)
@@ -64,9 +74,9 @@ function boundedSequenceRowCount(transform: Record<string, unknown>) {
 // density/kde generate `steps` samples per group; quantile generates ~1/step
 // probabilities. Cap the step-count parameters so they cannot be used as row
 // generators (their defaults are tiny, so legitimate specs are unaffected),
-// and return the implied per-group row count for the pipeline estimate.
-// Note: per-group amplification (groupby * steps) is not modeled; steps alone
-// is capped, which removes the constant-input blow-up these generators allow.
+// and return the implied PER-GROUP row count for the pipeline estimate. The
+// caller multiplies this by the (bounded) group count when the transform has a
+// `groupby`, since these generators run once per distinct group.
 function boundedGeneratorRowCount(type: string, transform: Record<string, unknown>) {
   if (type === 'density' || type === 'kde') {
     // Vega defaults: minsteps 25, maxsteps 200.
@@ -90,6 +100,51 @@ function boundedGeneratorRowCount(type: string, transform: Record<string, unknow
     return Math.ceil(1 / step)
   }
   return Array.isArray(transform.probs) ? transform.probs.length : 100
+}
+
+// True when a transform partitions its input by one or more group keys. groupby
+// may be a field name, an array of fields, or a signal; any non-empty form runs
+// the transform once per distinct group.
+function hasGroupby(transform: Record<string, unknown>) {
+  const groupby = transform.groupby
+  if (Array.isArray(groupby)) return groupby.length > 0
+  return groupby !== undefined && groupby !== null && groupby !== ''
+}
+
+// A generator/expander that runs per group emits `perGroup` rows for EVERY
+// distinct group. The group count is data-dependent and opaque here, but every
+// group requires at least one input row, so it is bounded by the stream's
+// estimated input rows. Worst-case output is therefore perGroup * inputRows,
+// which the caller caps against MAX_CHART_ESTIMATED_ROWS.
+function amplifyPerGroup(perGroup: number, transform: Record<string, unknown>, inputRows: number) {
+  if (!hasGroupby(transform)) return perGroup
+  return perGroup * Math.max(1, inputRows)
+}
+
+// contour/isocontour/heatmap iterate every cell of a declared size[0] x size[1]
+// grid. The output is a few polygons or a single image, so the row-count guard
+// never sees the cost; bound the grid area directly instead. A non-numeric
+// (e.g. signal) size cannot be bounded statically and is rejected outright, as
+// with the other generator parameters.
+function assertBoundedGridSize(type: string, transform: Record<string, unknown>) {
+  const size = transform.size
+  // Grids without a declared size derive their extent from input grid objects,
+  // which are themselves bounded by the inline array-item cap; nothing to add.
+  if (size === undefined) return
+  if (!Array.isArray(size) || size.length < 2) {
+    throw blockedRenderError(`${type} transform requires a static numeric [width, height] size`)
+  }
+  const width = toFiniteNumber(size[0])
+  const height = toFiniteNumber(size[1])
+  if (width === null || height === null || width < 0 || height < 0) {
+    throw blockedRenderError(`${type} transform size must be finite, non-negative numbers`)
+  }
+  const cells = width * height
+  if (cells > MAX_CHART_GRID_CELLS) {
+    throw blockedRenderError(
+      `${type} transform would compute a ${cells}-cell grid (max ${MAX_CHART_GRID_CELLS} cells)`,
+    )
+  }
 }
 
 function estimateDataPipeline(
@@ -125,7 +180,7 @@ function estimateDataPipeline(
 
     switch (type) {
       case 'sequence':
-        rows = Math.max(rows, boundedSequenceRowCount(transform))
+        rows = Math.max(rows, amplifyPerGroup(boundedSequenceRowCount(transform), transform, rows))
         break
       case 'cross':
         // Cartesian product: output is |left| * |right|, which cannot be
@@ -156,7 +211,22 @@ function estimateDataPipeline(
       case 'density':
       case 'kde':
       case 'quantile':
-        rows = Math.max(rows, boundedGeneratorRowCount(type, transform))
+        rows = Math.max(rows, amplifyPerGroup(boundedGeneratorRowCount(type, transform), transform, rows))
+        break
+      case 'impute': {
+        // impute materializes a full (key x groupby) grid, filling every
+        // missing combination. Output rows = distinct(key) * distinct(groupby);
+        // both distinct counts are data-dependent but bounded by the input row
+        // count. Without a groupby there is a single group and no blow-up; with
+        // one, the worst case is inputRows^2, which the cap below rejects.
+        const factor = hasGroupby(transform) ? Math.max(1, rows) : 1
+        rows = Math.max(rows, rows * factor)
+        break
+      }
+      case 'contour':
+      case 'isocontour':
+      case 'heatmap':
+        assertBoundedGridSize(type, transform)
         break
       default:
         // Remaining transforms (filter, aggregate, stack, formula, ...) do not

--- a/apps/gateway/src/delivery-dedupe.test.ts
+++ b/apps/gateway/src/delivery-dedupe.test.ts
@@ -100,6 +100,7 @@ test('gateway runtime re-acks instead of re-sending a re-served delivery that wa
     await waitFor(() => acks.length === 1)
     assert.equal(acks[0]?.input.status, 'sent')
     assert.equal(provider.sent.length, 1)
+    assert.equal(runtime.metrics.deliveryDuplicatesSuppressed, 0)
 
     // The claim lapsed before the cloud recorded the 'sent' ack, so it re-serves the same id.
     // The user must not see the message twice: no new provider send, just a fresh 'sent' ack.
@@ -108,6 +109,8 @@ test('gateway runtime re-acks instead of re-sending a re-served delivery that wa
     assert.equal(acks[1]?.deliveryId, 'delivery-1')
     assert.equal(acks[1]?.input.status, 'sent')
     assert.equal(provider.sent.length, 1)
+    // The suppressed re-serve must be visible to operators as a counter increment.
+    assert.equal(runtime.metrics.deliveryDuplicatesSuppressed, 1)
   } finally {
     await runtime.stop()
   }

--- a/apps/gateway/src/gateway-runtime.ts
+++ b/apps/gateway/src/gateway-runtime.ts
@@ -306,6 +306,9 @@ export function createGatewayRuntime(
       if (depth > metrics.deliveryQueueDepthMax) metrics.deliveryQueueDepthMax = depth
     },
     onShed: () => { metrics.deliverySheds += 1 },
+    // A re-served delivery whose id is still queued/in-flight is dropped instead of dispatched
+    // again; count it as a suppressed duplicate so a high re-serve rate is visible in metrics.
+    onDuplicate: () => { metrics.deliveryDuplicatesSuppressed += 1 },
   })
   let started = false
   // Tracks whether the cloud delivery subscription is live. The gateway's job is to relay between
@@ -350,6 +353,7 @@ export function createGatewayRuntime(
             // the user does not see the message twice; at-least-once is untouched because only
             // ids that actually reached the provider are ever recorded here.
             if (sentDeliveryIds.has(delivery.deliveryId)) {
+              metrics.deliveryDuplicatesSuppressed += 1
               void cloud.ackDelivery(delivery.deliveryId, {
                 status: 'sent',
                 claimedBy: delivery.claimedBy,

--- a/apps/gateway/src/metrics.ts
+++ b/apps/gateway/src/metrics.ts
@@ -37,6 +37,10 @@ export type GatewayMetrics = {
   // Deliveries shed (not enqueued) because the local dispatcher queue hit its cap (P1-C); they
   // stay unacked and the cloud re-serves them, so this is a sustained-overload backpressure signal.
   deliverySheds: number
+  // Duplicate delivery re-serves suppressed rather than re-sent to the channel: either the id is
+  // still queued/in-flight in the dispatcher, or it was already sent and is re-acked instead of
+  // re-dispatched. A sustained rate signals claim-TTL lapses or a cloud ack-recording problem.
+  deliveryDuplicatesSuppressed: number
   errors: number
   providerMetrics: Record<string, GatewayProviderMetrics>
 }
@@ -107,6 +111,7 @@ export function createGatewayMetrics(now = Date.now): GatewayMetrics {
     streamBackpressureDisconnects: 0,
     deliveryQueueDepthMax: 0,
     deliverySheds: 0,
+    deliveryDuplicatesSuppressed: 0,
     errors: 0,
     providerMetrics: {},
   }
@@ -221,6 +226,9 @@ export function renderPrometheusMetrics(metrics: GatewayMetrics, providerCount: 
     '# HELP open_cowork_gateway_delivery_sheds_total Deliveries shed because the local dispatcher queue hit its cap (re-served by the cloud).',
     '# TYPE open_cowork_gateway_delivery_sheds_total counter',
     `open_cowork_gateway_delivery_sheds_total ${metrics.deliverySheds}`,
+    '# HELP open_cowork_gateway_delivery_duplicates_suppressed_total Duplicate delivery re-serves suppressed (still queued/in-flight, or already sent and re-acked) rather than re-sent to the channel.',
+    '# TYPE open_cowork_gateway_delivery_duplicates_suppressed_total counter',
+    `open_cowork_gateway_delivery_duplicates_suppressed_total ${metrics.deliveryDuplicatesSuppressed}`,
     ...renderProviderMetrics(metrics),
     '',
   ].join('\n')

--- a/apps/standalone-gateway/src/runtime.test.ts
+++ b/apps/standalone-gateway/src/runtime.test.ts
@@ -82,6 +82,26 @@ test("standalone runtime replies in-channel with the assistant output", async ()
   assert.ok(provider.sent[0]?.options?.deliveryId);
 });
 
+test("standalone runtime still replies when a provider declares a sub-100 text limit", async () => {
+  const repository = new InMemoryStandaloneGatewayRepository();
+  await authorize(repository);
+  const opencode = new FakeStandaloneOpenCodeAdapter();
+  const runtime = createStandaloneGatewayRuntime({ repository, opencode });
+  // A non-conformant provider whose maxTextLength is below chunkText's minimum (100) must not
+  // make every reply throw and get silently swallowed as standalone.reply.failed.
+  const provider = new FakeChannelProvider({ id: "cli-standalone", capabilities: { maxTextLength: 20 } });
+
+  await runtime.handleMessage(provider, providerConfig, message("message-1", "hi"));
+
+  // "Standalone response: hi" (23 chars) is split into provider-sized (<=20) chunks and fully
+  // delivered — no chunkText throw, no dropped reply, all content preserved.
+  assert.ok(provider.sent.length >= 1, "reply must be delivered");
+  for (const sent of provider.sent) assert.ok((sent.text?.length ?? 0) <= 20);
+  assert.equal(provider.sent.map((s) => s.text).join(""), "Standalone response: hi");
+  const snapshot = await repository.dashboardSnapshot();
+  assert.ok(!snapshot.audits.find((a) => a.action === "standalone.reply.failed"), "reply must not fail");
+});
+
 test("standalone runtime chunks long replies to the provider text limit", async () => {
   const repository = new InMemoryStandaloneGatewayRepository();
   await authorize(repository);
@@ -208,8 +228,13 @@ for (const kind of ["workflow", "watch", "team_task"] as const) {
     const snapshot = await repository.dashboardSnapshot();
     assert.equal(snapshot.jobs[0]?.status, "failed");
     assert.match(snapshot.jobs[0]?.lastError || "", /not implemented in the standalone gateway/);
-    assert.equal(snapshot.audits[0]?.action, "standalone.job.unsupported");
-    assert.equal(snapshot.audits[0]?.metadata.kind, kind);
+    const unsupported = snapshot.audits.find((a) => a.action === "standalone.job.unsupported");
+    assert.ok(unsupported, "expected a standalone.job.unsupported audit");
+    assert.equal(unsupported.metadata.kind, kind);
+    // Every claimed job — including unsupported kinds — records a claim audit for a consistent trail.
+    const claimed = snapshot.audits.find((a) => a.action === "standalone.job.claimed");
+    assert.ok(claimed, "expected a standalone.job.claimed audit for the unsupported kind");
+    assert.equal(claimed.metadata.kind, kind);
   });
 }
 

--- a/apps/standalone-gateway/src/runtime.ts
+++ b/apps/standalone-gateway/src/runtime.ts
@@ -146,6 +146,9 @@ export function createStandaloneGatewayRuntime(input: {
         if (options.isActive && !options.isActive()) break;
         const job = await repository.claimNextJob({ claimedBy, ttlMs: 30_000, lease: options.lease });
         if (!job) break;
+        // Every claimed job gets a claim audit regardless of kind, so the audit trail is consistent
+        // between the executable "prompt" path and the unsupported kinds below.
+        await repository.recordAudit("standalone.job.claimed", claimedBy, { jobId: job.jobId, kind: job.kind });
         // Only "prompt" jobs have an execution path in the standalone appliance. Every other kind
         // must finish as failed with a descriptive reason — never as a silent "completed".
         if (job.kind !== "prompt") {
@@ -160,7 +163,6 @@ export function createStandaloneGatewayRuntime(input: {
           continue;
         }
         try {
-          await repository.recordAudit("standalone.job.claimed", claimedBy, { jobId: job.jobId, kind: job.kind });
           await runPromptJob(job);
           await repository.finishJob({ jobId: job.jobId, claimToken: job.claimToken || "", status: "completed" });
         } catch (error) {
@@ -189,7 +191,7 @@ async function sendChannelReply(input: {
   if (!replyText || !input.message.target.chatId) return;
   const deliveryBase = `standalone:${input.session.sessionId}:${input.message.providerEventId || input.message.id}:reply`;
   try {
-    const chunks = chunkText(replyText, input.provider.capabilities.maxTextLength);
+    const chunks = splitReplyToLimit(replyText, input.provider.capabilities.maxTextLength);
     for (const [index, chunk] of chunks.entries()) {
       await input.provider.sendText(input.message.target, chunk, {
         deliveryId: chunks.length === 1 ? deliveryBase : `${deliveryBase}:chunk:${index + 1}`,
@@ -203,6 +205,22 @@ async function sendChannelReply(input: {
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+// chunkText requires a limit >= 100. Real chat providers are far above that (Telegram 4096,
+// etc.), but a provider that declares a sub-100 maxTextLength would otherwise make chunkText
+// throw and silently drop every reply. For that case fall back to a plain content-preserving
+// hard split at the provider's real limit so the answer is still delivered in valid chunks.
+function splitReplyToLimit(text: string, maxTextLength: number): string[] {
+  if (Number.isInteger(maxTextLength) && maxTextLength >= 100) {
+    return chunkText(text, maxTextLength);
+  }
+  const limit = Math.max(1, Math.floor(maxTextLength));
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    chunks.push(text.slice(index, index + limit));
+  }
+  return chunks.length ? chunks : [text];
 }
 
 function coalesceAssistantText(parts: string[]): string {

--- a/mcps/semantic-ui/src/index.ts
+++ b/mcps/semantic-ui/src/index.ts
@@ -13,6 +13,9 @@ const { postToBridge } = createBridge<'/status' | '/snapshot' | '/actions/list' 
   tokenEnvVar: 'OPEN_COWORK_SEMANTIC_UI_TOKEN',
   bridgeName: 'semantic UI bridge',
   bridgeLabel: 'Semantic UI bridge',
+  // Interactive UI actions want a snappier abort than the default bridge timeout: keep the
+  // original 5s posture so an unresponsive local bridge fails fast instead of hanging 10s.
+  timeoutMs: 5_000,
 })
 
 function textResult(value: unknown) {

--- a/packages/cloud-server/src/app.ts
+++ b/packages/cloud-server/src/app.ts
@@ -1061,6 +1061,9 @@ export function createRuntimeDeltaCoalescer(options: {
     // issued synchronously in transcript order; DURABLE ordering additionally requires the
     // route itself to serialize per session (the production wiring wraps routeRuntimeEvent
     // in createSessionSerializedRuntimeEventRouter — issue #855).
+    // INVARIANT: these are fire-and-forget (`void`), so `options.route` must never reject —
+    // the production wiring pre-wraps it in `.catch(recordLoopError)`. Keep that catch if you
+    // rewire the route, or these calls will surface as unhandled promise rejections.
     if (sessionId) void flushSession(sessionId)
     void options.route(event)
   }

--- a/packages/runtime-host/src/runtime-managed-server-core.ts
+++ b/packages/runtime-host/src/runtime-managed-server-core.ts
@@ -98,9 +98,17 @@ export function buildManagedOpencodeServerEnvironment(
         // owner-only file (0600), same protection class as OpenCode's own
         // config files.
         const dir = mkdtempSync(join(tmpdir(), 'open-cowork-opencode-config-'))
-        options.onTempConfigDirCreated?.(dir)
         const file = join(dir, 'opencode-config.json')
-        writeFileSync(file, content, { mode: 0o600 })
+        try {
+          writeFileSync(file, content, { mode: 0o600 })
+        } catch (error) {
+          // If the write fails the server object (and its close() cleanup hook) is never
+          // returned, so remove the freshly created dir here rather than leaking it.
+          rmSync(dir, { recursive: true, force: true })
+          throw error
+        }
+        // Only register the dir for lifecycle cleanup once it actually holds the file.
+        options.onTempConfigDirCreated?.(dir)
         return file
       })
       next.OPENCODE_CONFIG = writeConfigFile(serialized)

--- a/tests/chart-spec-safety.test.ts
+++ b/tests/chart-spec-safety.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   MAX_CHART_ESTIMATED_ROWS,
   MAX_CHART_GENERATED_ROWS,
+  MAX_CHART_GRID_CELLS,
   assertBoundedVegaSpecCardinality,
 } from '../apps/desktop/src/main/chart-spec-safety.ts'
 import { renderChartSpecToSvg } from '../apps/desktop/src/main/chart-renderer.ts'
@@ -135,10 +136,13 @@ test('assertBoundedVegaSpecCardinality caps estimated derived rows across chaine
     new RegExp(`max ${MAX_CHART_ESTIMATED_ROWS}`),
   )
   // Fold duplication feeding a flatten in a downstream pipeline is also bounded.
+  // The flatten worst case is duplication * MAX_CHART_ARRAY_ITEMS, so the fold
+  // must duplicate enough (>~12.5x for a 20k item cap) to clear the estimate.
+  const wideFields = Array.from({ length: 14 }, (_, index) => `f${index}`)
   assert.throws(
     () => assertBoundedVegaSpecCardinality({
       data: [
-        { name: 'source_0', values: [{ a: [1, 2] }], transform: [{ type: 'fold', fields }] },
+        { name: 'source_0', values: [{ a: [1, 2] }], transform: [{ type: 'fold', fields: wideFields }] },
         { name: 'data_0', source: 'source_0', transform: [{ type: 'flatten', fields: ['a'] }] },
       ],
     }),
@@ -168,6 +172,91 @@ test('assertBoundedVegaSpecCardinality bounds density and quantile step paramete
   )
   assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
     data: [{ name: 'd', values: [{ v: 1 }, { v: 2 }], transform: [{ type: 'kde', field: 'v' }] }],
+  }))
+})
+
+test('assertBoundedVegaSpecCardinality models per-group amplification of density/kde generators', () => {
+  // ~1500 input rows x 200 steps = ~300k materialized rows once the generator
+  // runs once per group; the group count is bounded by the input row count.
+  const values = Array.from({ length: 1500 }, (_, index) => ({ v: index % 7, g: index % 1500 }))
+  assert.throws(
+    () => assertBoundedVegaSpecCardinality({
+      data: [{ name: 'd', values, transform: [{ type: 'kde', field: 'v', groupby: ['g'] }] }],
+    }),
+    new RegExp(`max ${MAX_CHART_ESTIMATED_ROWS}`),
+  )
+  // A grouped kde over a small stream stays well within the cap.
+  assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
+    data: [{
+      name: 'd',
+      values: Array.from({ length: 10 }, (_, index) => ({ v: index, g: index % 3 })),
+      transform: [{ type: 'kde', field: 'v', groupby: ['g'] }],
+    }],
+  }))
+})
+
+test('assertBoundedVegaSpecCardinality models impute grid amplification', () => {
+  // impute with a groupby fills a distinct(key) x distinct(groupby) grid; the
+  // worst case (both bounded by input rows) is inputRows^2. 600^2 = 360k > cap.
+  const values = Array.from({ length: 600 }, (_, index) => ({ x: index, series: index % 600, y: index }))
+  assert.throws(
+    () => assertBoundedVegaSpecCardinality({
+      data: [{ name: 'd', values, transform: [{ type: 'impute', key: 'x', groupby: ['series'], field: 'y' }] }],
+    }),
+    new RegExp(`max ${MAX_CHART_ESTIMATED_ROWS}`),
+  )
+  // A small impute grid, and an impute with no groupby (no blow-up), both pass.
+  assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
+    data: [{
+      name: 'd',
+      values: Array.from({ length: 100 }, (_, index) => ({ x: index, series: index % 4, y: index })),
+      transform: [{ type: 'impute', key: 'x', groupby: ['series'], field: 'y' }],
+    }],
+  }))
+  assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
+    data: [{
+      name: 'd',
+      values: Array.from({ length: 5000 }, (_, index) => ({ x: index, y: index })),
+      transform: [{ type: 'impute', key: 'x', field: 'y' }],
+    }],
+  }))
+})
+
+test('assertBoundedVegaSpecCardinality bounds compute-heavy raster grid transforms', () => {
+  // 3000 x 3000 = 9M cells of per-cell work but only a few output rows: the
+  // row-count guard cannot see it, so the grid-area bound must reject it.
+  assert.throws(
+    () => assertBoundedVegaSpecCardinality({
+      data: [{ name: 'd', values: [{ x: 1, y: 1 }], transform: [{ type: 'contour', x: 'x', y: 'y', size: [3000, 3000] }] }],
+    }),
+    new RegExp(`max ${MAX_CHART_GRID_CELLS} cells`),
+  )
+  // A non-numeric (signal) size cannot be bounded statically and is rejected.
+  assert.throws(
+    () => assertBoundedVegaSpecCardinality({
+      data: [{ name: 'd', values: [{ x: 1 }], transform: [{ type: 'heatmap', size: { signal: 'grid' } }] }],
+    }),
+    /static numeric \[width, height\] size/,
+  )
+  // A modest declared grid renders fine.
+  assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
+    data: [{ name: 'd', values: [{ x: 1, y: 1 }], transform: [{ type: 'contour', x: 'x', y: 'y', size: [400, 400] }] }],
+  }))
+})
+
+test('assertBoundedVegaSpecCardinality accepts a legitimate dense multi-series fold', () => {
+  // ~4200 rows folded across 12 series is ~50k rows: a real wide dashboard chart
+  // that the previous 50k estimate cap false-rejected. It must pass now.
+  const series = Array.from({ length: 12 }, (_, index) => `s${index}`)
+  const values = Array.from({ length: 4200 }, (_, row) =>
+    Object.fromEntries([['t', row], ...series.map((name, index) => [name, row + index])]),
+  )
+  assert.doesNotThrow(() => assertBoundedVegaSpecCardinality({
+    data: [
+      { name: 'source_0', values },
+      { name: 'data_0', source: 'source_0', transform: [{ type: 'fold', fields: series, as: ['series', 'value'] }] },
+    ],
+    marks: [{ type: 'line', from: { data: 'data_0' } }],
   }))
 })
 


### PR DESCRIPTION
## Summary

Non-blocking polish items surfaced by the production-readiness review of #879 (which merged clean). Each directly implements a reviewer recommendation; none changed the verdict on #879.

- **standalone-gateway** — deliver replies even when a provider declares a sub-100 `maxTextLength` (content-preserving split instead of the `chunkText` throw that was silently dropping the reply); record `standalone.job.claimed` for unsupported job kinds too.
- **gateway** — new `open_cowork_gateway_delivery_duplicates_suppressed_total` counter so duplicate-re-serve suppression (dispatcher drop + runtime re-ack) is observable, not silently absorbed.
- **desktop charts** — harden the main-process Vega cardinality DoS guard: model `groupby` amplification for kde/density, bound `impute` grid expansion, reject oversized `contour`/`heatmap` grids by compute cost, and raise the estimated-row cap to 250k so legitimate wide multi-series folds aren't false-rejected.
- **semantic-ui MCP** — restore the intentional 5s bridge timeout for interactive UI actions (rather than inheriting the shared 10s default).
- **runtime-host** — remove the temp OpenCode config dir if the config write fails before the cleanup hook is wired.
- **cloud-server** — document the fire-and-forget invariant on the coalescer boundary route.

## Validation
- `pnpm typecheck`, `pnpm lint` (`--max-warnings 0`), `pnpm lint:dead-code` — pass
- node (2238) + workspace (313) + MCP suites — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)