### PR TITLE
fix(runtime-host): derive sub-agent identity only from structured/labeled fields

### DIFF
--- a/packages/runtime-host/src/session-history-projector.ts
+++ b/packages/runtime-host/src/session-history-projector.ts
@@ -114,6 +114,20 @@ function taskToolDescriptor(part: NormalizedMessagePart, child?: ChildSessionRec
   const argsTitle = stringField(part.state.args, 'title')
   const inputPrompt = stringField(part.state.input, 'prompt')
   const argsPrompt = stringField(part.state.args, 'prompt')
+  // Agent IDENTITY is an execution fact OpenCode owns: derive it only from structured
+  // fields and OpenCode's own task description/title labels — never from user-supplied
+  // prompt/raw content, where a stray "@name" mention would be mis-attributed as the
+  // executing agent. Prompt/raw text remains fair game for the human-readable TITLE.
+  const agentCandidates = [
+    part.description,
+    inputDescription,
+    argsDescription,
+    part.title,
+    part.state.title,
+    inputTitle,
+    argsTitle,
+    child?.title,
+  ]
   const titleCandidates = [
     part.description,
     inputDescription,
@@ -133,7 +147,7 @@ function taskToolDescriptor(part: NormalizedMessagePart, child?: ChildSessionRec
     || normalizeAgentName(inputAgent)
     || normalizeAgentName(argsAgent)
     || normalizeAgentName(metadataAgent)
-    || extractAgentName(...titleCandidates)
+    || extractAgentName(...agentCandidates)
     || null
 
   return { agent, titleCandidates }
@@ -544,14 +558,15 @@ export async function projectSessionHistory(input: ProjectSessionHistoryInput): 
         const taskItem = addTaskRun({
           id: taskId,
           title: chooseTaskTitle(
-            normalizeAgentName(part.agent) || extractAgentName(part.description, part.title, part.prompt, part.raw, child?.title) || null,
+            normalizeAgentName(part.agent) || extractAgentName(part.description, part.title, child?.title) || null,
             part.description,
             part.title,
             part.prompt,
             part.raw,
             child?.title,
           ),
-          agent: normalizeAgentName(part.agent) || extractAgentName(part.description, part.title, part.prompt, part.raw, child?.title) || null,
+          // Agent identity from structured/labeled fields only, not user prompt/raw content.
+          agent: normalizeAgentName(part.agent) || extractAgentName(part.description, part.title, child?.title) || null,
           status: childStatus,
           sourceSessionId: child?.id || null,
           // Subtasks attached to root messages are always direct children

--- a/packages/runtime-host/src/session-history-task-binding.ts
+++ b/packages/runtime-host/src/session-history-task-binding.ts
@@ -31,8 +31,11 @@ export function timingFromChild(child: ChildSessionRecord | null, status: TaskSt
 }
 
 export function bindingHintsForSubtask(part: NormalizedMessagePart): BindingHints {
+  // Agent identity is OpenCode-owned: derive it from structured/labeled fields only,
+  // never from user prompt/raw content (which can carry a stray "@name"). Prompt/raw
+  // still feed the human-readable title below.
   const agent = normalizeAgentName(part.agent)
-    || extractAgentName(part.description, part.title, part.prompt, part.raw)
+    || extractAgentName(part.description, part.title)
     || null
   return {
     agent,

--- a/tests/session-history-projector.test.ts
+++ b/tests/session-history-projector.test.ts
@@ -1943,3 +1943,55 @@ test('history projector accepts deterministic fallback id generation', async () 
     ],
   )
 })
+
+test('history projector does not mine agent identity from user prompt/raw content', async () => {
+  const items = await projectSessionHistory({
+    sessionId: 'root-attr',
+    cachedModelId: 'databricks-claude-sonnet-4',
+    rootMessages: [
+      {
+        info: { id: 'root-attr-msg', role: 'assistant', time: { created: 1 } },
+        parts: [
+          {
+            id: 'root-attr-task',
+            type: 'tool',
+            tool: 'task',
+            callID: 'attr-call',
+            state: {
+              status: 'completed',
+              // No structured `agent`/`subagent_type`; the only "@name" token lives in the
+              // user-supplied prompt, which must NOT be attributed as the executing agent.
+              input: { description: 'Investigate the outage', prompt: 'Please ask @spurious for the runbook' },
+              output: 'started',
+              metadata: {},
+            },
+          },
+        ],
+      },
+    ],
+    rootTodos: [],
+    children: [
+      { id: 'child-attr', title: 'Investigate the outage', parentSessionId: 'root-attr', time: { created: 2, updated: 3 } },
+    ],
+    statuses: { 'root-attr': { type: 'idle' }, 'child-attr': { type: 'idle' } },
+    loadChildSnapshot: async () => ({
+      messages: [{
+        info: { id: 'child-attr-msg', role: 'assistant', time: { created: 4 } },
+        parts: [
+          { id: 'child-attr-text', type: 'text', text: 'done' },
+          { id: 'child-attr-finish', type: 'step-finish', reason: 'stop' },
+        ],
+      }],
+      todos: [],
+    }),
+  })
+
+  const taskRun = items.find((item) => item.type === 'task_run')
+  assert.ok(taskRun, 'expected a task run')
+  // Agent identity must come from structured/labeled fields only — a stray "@spurious"
+  // in the prompt is not the executing agent.
+  assert.notEqual(taskRun.taskRun?.agent, 'spurious')
+  assert.equal(taskRun.taskRun?.agent, null)
+  // The human-readable title may still draw on the description text.
+  assert.equal(taskRun.taskRun?.title, 'Investigate the outage')
+})


### PR DESCRIPTION
## Summary

Tightens the session-projection boundary flagged by the audit (deferred item #25). The history projector was mining sub-agent identity from **user-supplied prompt/raw content** via a free-text `@name` regex. That both skirts the project's "OpenCode owns execution" rule and is a real **mis-attribution bug**: a prompt like `ask @alice for the runbook` recorded the task's agent as `alice`.

Agent identity now derives only from OpenCode's structured fields (`part.agent` / `input.agent` / `subagent_type` / `metadata`) and OpenCode's own task description/title labels — never from prompt/raw user content. Those fields still feed the human-readable **title**, so titles are unchanged.

- `session-history-projector.ts` — separate agent-candidate list from title-candidate list in `taskToolDescriptor`; drop `prompt`/`raw` from the two inline `extractAgentName` calls.
- `session-history-task-binding.ts` — same narrowing in `bindingHintsForSubtask`.
- **new regression test** — a task whose only `@name` appears in the prompt now yields `agent=null` (would have been `agent=spurious` before).

## Validation
- `pnpm typecheck`, `pnpm lint` (`--max-warnings 0`), `pnpm lint:dead-code` — pass
- node + workspace suites — 0 failures, including all 35 `session-history-projector` cases (none relied on prompt/raw agent extraction, confirming the fallback was unused by legitimate data)
- coverage inventory 92.0% ≥ 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)