### PR TITLE
fix(config): update opencode-gateway MCP tool names to the gateway_ prefix

### DIFF
--- a/docs/oss-packaging-migration.md
+++ b/docs/oss-packaging-migration.md
@@ -61,7 +61,7 @@ Historical names may remain only as explicit compatibility aliases:
 | Historical name | Policy |
 | --- | --- |
 | `opencode-agent-gateway` repository | Historical prototype source. New users should use this `open-cowork` repo. |
-| `opencode-gateway` npm package | Legacy name. If republished, it must be a thin compatibility wrapper that points to Open Cowork Gateway or Standalone Gateway and warns clearly. |
+| `opencode-gateway` npm package | Distinct upstream tool, not a legacy alias. [`opencode-gateway`](https://github.com/joe-broadhead/opencode-gateway) is an independently maintained OpenCode durable work coordinator (Initiatives/Issues, scheduler, human gates, Mission Control) that Open Cowork integrates as an optional local MCP (`opencode-gateway mcp --tools operate`, tools exposed as `gateway_*`). It is separate from **Open Cowork Gateway** / **Standalone Gateway** (the channel adapters) despite the name overlap; do not treat the two as the same product. |
 | `ghcr.io/<owner>/opencode-gateway` image | Legacy image name. Do not publish new primary releases there unless it is an explicit alias to the matching Open Cowork image digest. |
 | `gateway.config.yaml` | Legacy standalone config name. Keep readable in migration docs, but new Open Cowork deployments should use `open-cowork.config.json` plus environment or secret-manager values. |
 | legacy unhyphenated Open Cowork spelling | Back-compat only for existing app ids, on-disk namespaces, or migration notes. New public docs should use `open-cowork`. |

--- a/open-cowork.config.json
+++ b/open-cowork.config.json
@@ -225,23 +225,23 @@
       "writeAccess": true,
       "patterns": ["mcp__opencode-gateway__*"],
       "allowPatterns": [
-        "mcp__opencode-gateway__dashboard", "mcp__opencode-gateway__briefing", "mcp__opencode-gateway__attention",
-        "mcp__opencode-gateway__alerts", "mcp__opencode-gateway__health", "mcp__opencode-gateway__readiness",
-        "mcp__opencode-gateway__governance", "mcp__opencode-gateway__observability", "mcp__opencode-gateway__work_events",
-        "mcp__opencode-gateway__task_list", "mcp__opencode-gateway__task_get", "mcp__opencode-gateway__roadmap_list",
-        "mcp__opencode-gateway__roadmap_get", "mcp__opencode-gateway__roadmap_memory", "mcp__opencode-gateway__run_list",
-        "mcp__opencode-gateway__run_get", "mcp__opencode-gateway__scheduler_status", "mcp__opencode-gateway__project_status",
-        "mcp__opencode-gateway__project_digest", "mcp__opencode-gateway__agent_catalog_list", "mcp__opencode-gateway__profile_list",
-        "mcp__opencode-gateway__permission_list", "mcp__opencode-gateway__question_list", "mcp__opencode-gateway__opencode_session_list"
+        "mcp__opencode-gateway__gateway_dashboard", "mcp__opencode-gateway__gateway_briefing", "mcp__opencode-gateway__gateway_attention",
+        "mcp__opencode-gateway__gateway_alerts", "mcp__opencode-gateway__gateway_health", "mcp__opencode-gateway__gateway_readiness",
+        "mcp__opencode-gateway__gateway_governance", "mcp__opencode-gateway__gateway_observability", "mcp__opencode-gateway__gateway_work_events",
+        "mcp__opencode-gateway__gateway_task_list", "mcp__opencode-gateway__gateway_task_get", "mcp__opencode-gateway__gateway_roadmap_list",
+        "mcp__opencode-gateway__gateway_roadmap_get", "mcp__opencode-gateway__gateway_roadmap_memory", "mcp__opencode-gateway__gateway_run_list",
+        "mcp__opencode-gateway__gateway_run_get", "mcp__opencode-gateway__gateway_scheduler_status", "mcp__opencode-gateway__gateway_project_status",
+        "mcp__opencode-gateway__gateway_project_digest", "mcp__opencode-gateway__gateway_agent_catalog_list", "mcp__opencode-gateway__gateway_profile_list",
+        "mcp__opencode-gateway__gateway_permission_list", "mcp__opencode-gateway__gateway_question_list", "mcp__opencode-gateway__gateway_opencode_session_list"
       ],
       "askPatterns": [
-        "mcp__opencode-gateway__task_create", "mcp__opencode-gateway__task_update", "mcp__opencode-gateway__task_bulk_create",
-        "mcp__opencode-gateway__task_bulk_update", "mcp__opencode-gateway__roadmap_create", "mcp__opencode-gateway__roadmap_create_with_tasks",
-        "mcp__opencode-gateway__delegation_submit", "mcp__opencode-gateway__channel_send", "mcp__opencode-gateway__channel_send_to_task",
-        "mcp__opencode-gateway__channel_send_to_roadmap", "mcp__opencode-gateway__human_gate_decide", "mcp__opencode-gateway__permission_reply",
-        "mcp__opencode-gateway__question_reply", "mcp__opencode-gateway__question_reject", "mcp__opencode-gateway__scheduler_pause",
-        "mcp__opencode-gateway__scheduler_resume", "mcp__opencode-gateway__scheduler_run_once", "mcp__opencode-gateway__active_run_control",
-        "mcp__opencode-gateway__backup_create"
+        "mcp__opencode-gateway__gateway_task_create", "mcp__opencode-gateway__gateway_task_update", "mcp__opencode-gateway__gateway_task_bulk_create",
+        "mcp__opencode-gateway__gateway_task_bulk_update", "mcp__opencode-gateway__gateway_roadmap_create", "mcp__opencode-gateway__gateway_roadmap_create_with_tasks",
+        "mcp__opencode-gateway__gateway_delegation_submit", "mcp__opencode-gateway__gateway_channel_send", "mcp__opencode-gateway__gateway_channel_send_to_task",
+        "mcp__opencode-gateway__gateway_channel_send_to_roadmap", "mcp__opencode-gateway__gateway_human_gate_decide", "mcp__opencode-gateway__gateway_permission_reply",
+        "mcp__opencode-gateway__gateway_question_reply", "mcp__opencode-gateway__gateway_question_reject", "mcp__opencode-gateway__gateway_scheduler_pause",
+        "mcp__opencode-gateway__gateway_scheduler_resume", "mcp__opencode-gateway__gateway_scheduler_run_once", "mcp__opencode-gateway__gateway_active_run_control",
+        "mcp__opencode-gateway__gateway_backup_create"
       ]
     }
   ],

--- a/skills/opencode-gateway/SKILL.md
+++ b/skills/opencode-gateway/SKILL.md
@@ -11,18 +11,18 @@ should be able to inspect later in Mission Control.
 
 ## Core loop
 
-1. Orient first: `mcp__opencode-gateway__briefing` and
-   `mcp__opencode-gateway__attention` show changed work, active runs,
+1. Orient first: `mcp__opencode-gateway__gateway_briefing` and
+   `mcp__opencode-gateway__gateway_attention` show changed work, active runs,
    blockers, and pending gates before you act.
 2. Structure work as Issues under Initiatives:
-   `mcp__opencode-gateway__roadmap_list` to find the right Initiative, then
-   `mcp__opencode-gateway__task_create` (asks for approval by design) with
+   `mcp__opencode-gateway__gateway_roadmap_list` to find the right Initiative, then
+   `mcp__opencode-gateway__gateway_task_create` (asks for approval by design) with
    a clear title, priority, and pipeline.
-3. Watch execution with `mcp__opencode-gateway__run_list` /
-   `mcp__opencode-gateway__run_get`; explain run outcomes from their
+3. Watch execution with `mcp__opencode-gateway__gateway_run_list` /
+   `mcp__opencode-gateway__gateway_run_get`; explain run outcomes from their
    receipts rather than guessing.
-4. Route human decisions honestly: `mcp__opencode-gateway__permission_list`
-   and `mcp__opencode-gateway__question_list` show pending OpenCode
+4. Route human decisions honestly: `mcp__opencode-gateway__gateway_permission_list`
+   and `mcp__opencode-gateway__gateway_question_list` show pending OpenCode
    requests — surface them to the user; replies require approval.
 
 ## Boundaries

--- a/tests/config-elements.test.ts
+++ b/tests/config-elements.test.ts
@@ -43,8 +43,9 @@ test('open core ships with built-in tools, skills, mcps, and agents configured b
   assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'time-keep')!).includes('mcp__time-keep__timer_set'), true)
   assert.equal(tools.find((tool) => tool.id === 'time-keep')?.allowPatterns?.includes('mcp__time-keep__business_days'), true)
   // opencode-gateway: inspection tools auto-allowed; durable-work mutations ask.
-  assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'opencode-gateway')!).includes('mcp__opencode-gateway__task_create'), true)
-  assert.equal(tools.find((tool) => tool.id === 'opencode-gateway')?.allowPatterns?.includes('mcp__opencode-gateway__briefing'), true)
+  // Tools are exposed to OpenCode with the `gateway_` prefix (opencode-gateway >= 1.x).
+  assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'opencode-gateway')!).includes('mcp__opencode-gateway__gateway_task_create'), true)
+  assert.equal(tools.find((tool) => tool.id === 'opencode-gateway')?.allowPatterns?.includes('mcp__opencode-gateway__gateway_briefing'), true)
   assert.equal(getConfiguredToolAskPatterns(tools.find((tool) => tool.id === 'clock')!).length, 0)
   assert.equal(tools.find((tool) => tool.id === 'clock')?.defaultAccess, true)
   const providers = getProviderDescriptors()


### PR DESCRIPTION
## Summary

Re-read the two integrated upstream tools (**open-wiki** and **opencode-gateway**) against their current default branches. OpenWiki is in sync, but **opencode-gateway** (now v1.3.0) changed its MCP surface: it exposes tools to OpenCode with a `gateway_` prefix (`opencode-gateway mcp` serves `gateway_*` tools; `--tools read|operate|admin` tiers). Open Cowork's integration still listed the **old un-prefixed names**, so none of the 43 curated allow/ask entries matched the tools OpenCode actually sees — the operate-tier integration was effectively broken.

### Changes
- **`open-cowork.config.json`** — prefixed all 43 `opencode-gateway` allow/askPatterns with `gateway_`. Each was verified to map to a current operate-tier tool (computed from opencode-gateway's own tiering: operate = all tools except the 25 admin-tier). The `mcp__opencode-gateway__*` namespace wildcard is untouched.
- **`skills/opencode-gateway/SKILL.md`** — prefixed the 8 tool names the skill instructs the agent to call.
- **`tests/config-elements.test.ts`** — updated the two assertions that pinned the old names.
- **`docs/oss-packaging-migration.md`** — corrected the row that framed `opencode-gateway` as a legacy alias for Open Cowork Gateway; it is now a distinct, independently maintained upstream tool integrated as an optional MCP.

### OpenWiki — verified in sync
Its `wiki.*` tool names and the `--tools proposal` allow(23)/ask(4) sets already match OpenWiki's canonical `integrations/open-cowork/mcp/openwiki.local.json`; the 8 destructive tools it recommends denying are handled by omission + the proposal tier (Open Cowork's tool schema has no deny bucket). No change needed.

## Validation
- node suite (2242) + config-schema/effective-skills/permission/builtin-skills tests — 0 failures
- `mkdocs --strict`, `pnpm lint` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)