### PR TITLE
Ratchet cloud budgets and docs capability stats

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ hide:
 <div class="cowork-stats" markdown>
 
 <div class="stat" markdown>
-  <div class="stat-value">7 MCPs · 11 skills</div>
-  <div class="stat-label">Bundled capabilities</div>
+  <div class="stat-value">8 MCPs · 7 skills</div>
+  <div class="stat-label">Configured capabilities</div>
 </div>
 
 <div class="stat" markdown>

--- a/tests/cloud-control-plane-modularity.test.ts
+++ b/tests/cloud-control-plane-modularity.test.ts
@@ -17,8 +17,8 @@ const ignoredDirectories = new Set([
 test('cloud control-plane facade files stay within documented compatibility budgets', () => {
   const budgets = [
     { path: 'packages/cloud-server/src/http-server.ts', maxLines: 1_930 },
-    { path: 'packages/cloud-server/src/in-memory-control-plane-store.ts', maxLines: 1_750 },
-    { path: 'packages/cloud-server/src/session-service.ts', maxLines: 2_030 },
+    { path: 'packages/cloud-server/src/in-memory-control-plane-store.ts', maxLines: 1_620 },
+    { path: 'packages/cloud-server/src/session-service.ts', maxLines: 1_205 },
   ]
 
   for (const budget of budgets) {


### PR DESCRIPTION
## Summary\n- update the docs homepage capability stat to match the current configured MCP/skill surface\n- tighten the duplicate cloud control-plane modularity ratchet for the decomposed facades\n\n## Validation\n- node --no-warnings --experimental-strip-types --test tests/cloud-control-plane-modularity.test.ts tests/cloud-modularity-boundaries.test.ts\n- pnpm docs:build\n- git diff --check