### PR TITLE
Desktop durable events, family dedupe, and allowlist status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ planned before broad distribution.
   `permission.v2.asked` request id.
 - Skill catalog boot noise when `v2.skill.list` is empty early (skills.paths
   remains authoritative).
+- Live transcript dual-family races: once `session.next.*` owns a message or
+  tool call id, classic `message.part.*` for that identity is suppressed.
 
 ### Changed
 
@@ -38,6 +40,10 @@ planned before broad distribution.
 - Wired delegated permission-inheritance checks into agent composition (log
   soft warnings instead of silent policy theater).
 - Prefer MCP clock/time-keep tools over shell CLIs in skill docs.
+- Desktop local chat attaches each prompt admission to a durable
+  `v2.session.events` tail from `admittedSeq` (global SSE stays control-plane
+  and suppresses tracked-session transcript). Classic SDK allowlist remains
+  for OpenCode 1.18.1 gaps (`session.summarize`, MCP, explorer, `tool.list`).
 
 ### Added
 

--- a/apps/desktop/src/main/desktop-pairing/local-executor.ts
+++ b/apps/desktop/src/main/desktop-pairing/local-executor.ts
@@ -2,7 +2,7 @@ import { getThreadIndexService } from '@open-cowork/runtime-host/thread-index/th
 import { toIsoTimestamp } from '@open-cowork/runtime-host/task-run-utils'
 import { getEffectiveSettings } from '@open-cowork/runtime-host/settings'
 import { getSessionRecord, listSessionRecords, toRendererSession, toSessionRecord, touchSessionRecord, updateSessionRecord, upsertSessionRecord } from '@open-cowork/runtime-host/session-registry'
-import { getClientForDirectory } from '@open-cowork/runtime-host/runtime'
+import { getClientForDirectory, getRuntimeHomeDir } from '@open-cowork/runtime-host/runtime'
 import { ensureRuntimeContextDirectory } from '@open-cowork/runtime-host/runtime-context'
 import {
   createNativeSession,
@@ -19,6 +19,7 @@ import { shortSessionId } from '@open-cowork/shared'
 import { randomUUID } from 'node:crypto'
 import type { SessionInfo } from '@open-cowork/shared'
 import { trackParentSession } from '../event-task-state.ts'
+import { markSessionPromptAdmitted } from '../durable-session-events.ts'
 import { startSessionStatusReconciliation, stopSessionStatusReconciliation } from '../session-status-reconciler.ts'
 import { log } from '@open-cowork/shared/node'
 import type { IpcHandlerContext } from '../ipc/context.ts'
@@ -191,11 +192,17 @@ export function createDesktopPairingLocalExecutor(context: IpcHandlerContext): D
       if (promptRecord) getThreadIndexService().upsertThreadFromSessionRecord(promptRecord)
       trackParentSession(input.sessionId)
       touchSessionRecord(input.sessionId)
-      await promptNativeSession(client, {
+      const admitted = await promptNativeSession(client, {
         sessionID: input.sessionId,
         parts: promptParts(text, attachments),
         model: model ? { ...model, variant: options.variant || undefined } : null,
         agent,
+      })
+      markSessionPromptAdmitted({
+        directory: record?.opencodeDirectory || getRuntimeHomeDir(),
+        sessionId: input.sessionId,
+        admittedSeq: admitted.admittedSeq,
+        admissionId: admitted.id,
       })
       startSessionStatusReconciliation(input.sessionId, {
         getMainWindow: context.getMainWindow,

--- a/apps/desktop/src/main/durable-session-events.ts
+++ b/apps/desktop/src/main/durable-session-events.ts
@@ -1,0 +1,280 @@
+/**
+ * Desktop local durable session event tails.
+ *
+ * After a V2 prompt admission, track the session on `v2.session.events` from
+ * `admittedSeq` so transcript survives the HTTP→SSE gap and reconnects with an
+ * `after` cursor. The global `v2.event.subscribe` stream remains the control
+ * plane (permissions, questions, untracked sessions) and suppresses transcript
+ * for sessions owned by a durable tail.
+ */
+
+import type { OpencodeClient } from '@opencode-ai/sdk/v2'
+import {
+  advanceDurableCursor,
+  durableAfterCursor,
+  type DurableSequenceCursor,
+  readDurableSequenceFromEvent,
+  readSessionStatusType,
+  shouldSuppressGlobalEventForTrackedSession,
+} from '@open-cowork/runtime-host'
+import { log } from '@open-cowork/shared/node'
+
+const RECONNECT_INITIAL_MS = 250
+const RECONNECT_MAX_MS = 8_000
+
+export type DurableRawEventHandler = (raw: unknown) => void | Promise<void>
+
+type DurableSessionState = {
+  sessionId: string
+  cursor: DurableSequenceCursor
+  admittedSeq: number | null
+  streamTask: Promise<void> | null
+  stopped: boolean
+}
+
+type DirectoryDurableHub = {
+  client: OpencodeClient
+  directory: string | null
+  signal: AbortSignal
+  onEvent: DurableRawEventHandler
+  sessions: Map<string, DurableSessionState>
+  stop: () => void
+}
+
+const hubsByDirectory = new Map<string, DirectoryDurableHub>()
+
+function directoryKey(directory: string | null | undefined) {
+  return directory || '__runtime_home__'
+}
+
+function waitForReconnect(signal: AbortSignal, delayMs: number) {
+  if (signal.aborted) return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    const finish = () => {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', finish)
+      resolve()
+    }
+    const timer = setTimeout(finish, delayMs)
+    timer.unref?.()
+    signal.addEventListener('abort', finish, { once: true })
+  })
+}
+
+function ensureSessionState(hub: DirectoryDurableHub, sessionId: string): DurableSessionState {
+  const existing = hub.sessions.get(sessionId)
+  if (existing) return existing
+  const created: DurableSessionState = {
+    sessionId,
+    cursor: { lastSequence: -1 },
+    admittedSeq: null,
+    streamTask: null,
+    stopped: false,
+  }
+  hub.sessions.set(sessionId, created)
+  return created
+}
+
+async function durableStreamLoop(hub: DirectoryDurableHub, state: DurableSessionState) {
+  let consecutiveFailures = 0
+  while (!hub.signal.aborted && !state.stopped) {
+    let receivedEvent = false
+    let streamError: unknown = null
+    let lastSseEventId: string | undefined
+    try {
+      const sessionEvents = hub.client.v2.session.events
+      if (typeof sessionEvents !== 'function') {
+        throw new Error('OpenCode SDK v2 client is missing durable session events.')
+      }
+      const after = durableAfterCursor({
+        lastSequence: state.cursor.lastSequence >= 0 ? state.cursor.lastSequence : null,
+        admittedSeq: state.admittedSeq,
+      })
+      const result = await sessionEvents.call(hub.client.v2.session, {
+        sessionID: state.sessionId,
+        ...(after ? { after } : {}),
+      }, {
+        signal: hub.signal,
+        // Own reconnects so every retry carries the last durable sequence.
+        sseMaxRetryAttempts: 1,
+        onSseError(error: unknown) {
+          streamError = error
+        },
+        onSseEvent(event: { id?: string }) {
+          if (event.id) lastSseEventId = event.id
+        },
+      })
+      for await (const raw of result.stream as AsyncIterable<unknown>) {
+        if (hub.signal.aborted || state.stopped) break
+        const sequence = readDurableSequenceFromEvent(raw)
+        if (sequence !== null && sequence <= state.cursor.lastSequence) continue
+        state.cursor = advanceDurableCursor(state.cursor, raw, lastSseEventId)
+        receivedEvent = true
+        await hub.onEvent(raw)
+      }
+      if (hub.signal.aborted || state.stopped) break
+      throw streamError || new Error(`OpenCode durable event stream ended for session ${state.sessionId}.`)
+    } catch (error) {
+      if (hub.signal.aborted || state.stopped) break
+      const message = error instanceof Error ? error.message : String(error)
+      log('events', `Durable session stream error [${state.sessionId}]: ${message}`)
+      consecutiveFailures = receivedEvent ? 1 : Math.min(consecutiveFailures + 1, 16)
+      const retryDelayMs = Math.min(
+        RECONNECT_MAX_MS,
+        RECONNECT_INITIAL_MS * (2 ** Math.min(consecutiveFailures - 1, 8)),
+      )
+      await waitForReconnect(hub.signal, retryDelayMs)
+    }
+  }
+}
+
+function startDurableStream(hub: DirectoryDurableHub, state: DurableSessionState) {
+  if (state.streamTask || state.stopped) return
+  state.streamTask = durableStreamLoop(hub, state).finally(() => {
+    if (hub.sessions.get(state.sessionId) === state) {
+      state.streamTask = null
+    }
+  })
+}
+
+/**
+ * Register the durable hub for one directory-scoped global event subscription.
+ * Call once per `subscribeToEvents` invocation; `signal` abort tears it down.
+ */
+export function attachDirectoryDurableHub(options: {
+  client: OpencodeClient
+  directory: string | null
+  signal: AbortSignal
+  onEvent: DurableRawEventHandler
+}) {
+  const key = directoryKey(options.directory)
+  const previous = hubsByDirectory.get(key)
+  previous?.stop()
+
+  const hub: DirectoryDurableHub = {
+    client: options.client,
+    directory: options.directory,
+    signal: options.signal,
+    onEvent: options.onEvent,
+    sessions: new Map(),
+    stop() {
+      for (const state of hub.sessions.values()) {
+        state.stopped = true
+      }
+      hub.sessions.clear()
+      if (hubsByDirectory.get(key) === hub) hubsByDirectory.delete(key)
+    },
+  }
+  hubsByDirectory.set(key, hub)
+  options.signal.addEventListener('abort', () => hub.stop(), { once: true })
+  return hub
+}
+
+export function markSessionPromptAdmitted(options: {
+  directory: string | null | undefined
+  sessionId: string
+  admittedSeq?: number | null
+  admissionId?: string | null
+}) {
+  const sessionId = options.sessionId.trim()
+  if (!sessionId) return false
+  const hub = hubsByDirectory.get(directoryKey(options.directory))
+  if (!hub) {
+    log('events', `Durable admit skipped (no hub) session=${sessionId}`)
+    return false
+  }
+  const state = ensureSessionState(hub, sessionId)
+  if (typeof options.admittedSeq === 'number' && Number.isSafeInteger(options.admittedSeq)) {
+    state.admittedSeq = options.admittedSeq
+  }
+  // First admission with no observed cursor: seed after from admittedSeq.
+  if (state.cursor.lastSequence < 0 && state.admittedSeq !== null) {
+    const after = durableAfterCursor({ admittedSeq: state.admittedSeq })
+    if (after) state.cursor = { ...state.cursor, after }
+  }
+  startDurableStream(hub, state)
+  log(
+    'events',
+    `Durable session tracked session=${sessionId} admittedSeq=${state.admittedSeq ?? 'none'} after=${state.cursor.after || 'start'}`,
+  )
+  return true
+}
+
+export function isSessionDurablyTracked(
+  directory: string | null | undefined,
+  sessionId: string | null | undefined,
+) {
+  if (!sessionId) return false
+  const hub = hubsByDirectory.get(directoryKey(directory))
+  return Boolean(hub?.sessions.has(sessionId))
+}
+
+export function shouldSuppressGlobalRuntimeEvent(
+  directory: string | null | undefined,
+  type: string | null | undefined,
+  properties: Record<string, unknown> | null | undefined,
+) {
+  const sessionId = readSessionIdFromProperties(properties)
+  if (!sessionId) return false
+  if (!isSessionDurablyTracked(directory, sessionId)) return false
+  const statusType = type === 'session.status' ? readSessionStatusType(properties) : null
+  return shouldSuppressGlobalEventForTrackedSession(true, type, statusType)
+}
+
+function readSessionIdFromProperties(properties: Record<string, unknown> | null | undefined) {
+  if (!properties) return null
+  const direct = properties.sessionID ?? properties.sessionId
+  if (typeof direct === 'string' && direct.trim()) return direct.trim()
+  const info = properties.info
+  if (info && typeof info === 'object' && !Array.isArray(info)) {
+    const sessionID = (info as { sessionID?: unknown }).sessionID
+    if (typeof sessionID === 'string' && sessionID.trim()) return sessionID.trim()
+  }
+  const part = properties.part
+  if (part && typeof part === 'object' && !Array.isArray(part)) {
+    const sessionID = (part as { sessionID?: unknown }).sessionID
+      ?? (part as { sessionId?: unknown }).sessionId
+    if (typeof sessionID === 'string' && sessionID.trim()) return sessionID.trim()
+  }
+  return null
+}
+
+/** Test helper: clear all hubs between unit tests. */
+export function resetDurableSessionHubsForTests() {
+  for (const hub of hubsByDirectory.values()) hub.stop()
+  hubsByDirectory.clear()
+}
+
+/** Test helper: mark a session tracked without starting a live stream. */
+export function __testTrackSession(directory: string | null, sessionId: string, admittedSeq = 1) {
+  const key = directoryKey(directory)
+  let hub = hubsByDirectory.get(key)
+  if (!hub) {
+    hub = {
+      client: {} as OpencodeClient,
+      directory,
+      signal: new AbortController().signal,
+      onEvent: () => undefined,
+      sessions: new Map(),
+      stop() {
+        for (const state of hub!.sessions.values()) state.stopped = true
+        hub!.sessions.clear()
+        hubsByDirectory.delete(key)
+      },
+    }
+    hubsByDirectory.set(key, hub)
+  }
+  const state = ensureSessionState(hub, sessionId)
+  state.admittedSeq = admittedSeq
+  state.streamTask = Promise.resolve()
+}
+
+export function __testShouldSuppress(
+  directory: string | null,
+  sessionId: string,
+  type: string,
+  statusType?: string | null,
+) {
+  if (!isSessionDurablyTracked(directory, sessionId)) return false
+  return shouldSuppressGlobalEventForTrackedSession(true, type, statusType)
+}

--- a/apps/desktop/src/main/event-message-handlers.ts
+++ b/apps/desktop/src/main/event-message-handlers.ts
@@ -49,6 +49,19 @@ export type SessionScopedMessageState = {
   messageRolesBySession: Map<string, Map<string, 'user' | 'assistant'>>
   pendingTextEventsBySession: Map<string, Map<string, PendingTextEvent[]>>
   nativeToolPartsByKey: Map<string, Record<string, unknown>>
+  /**
+   * Messages that have received at least one `session.next.*` transcript event.
+   * Once native owns a message, classic `message.part.*` for the same message
+   * is suppressed so dual-family emission cannot double-project text/tools.
+   * Keyed as `sessionScope\0messageId`.
+   */
+  nativeOwnedMessages: Set<string>
+  /**
+   * Tool call ids observed on the native family. Classic tool parts that share
+   * the same callID are suppressed after native ownership.
+   * Keyed as `sessionId\0callId`.
+   */
+  nativeOwnedToolCalls: Set<string>
   totalPendingTextEvents: number
   totalMessageRoles: number
 }
@@ -58,9 +71,49 @@ export function createSessionScopedMessageState(): SessionScopedMessageState {
     messageRolesBySession: new Map(),
     pendingTextEventsBySession: new Map(),
     nativeToolPartsByKey: new Map(),
+    nativeOwnedMessages: new Set(),
+    nativeOwnedToolCalls: new Set(),
     totalPendingTextEvents: 0,
     totalMessageRoles: 0,
   }
+}
+
+function nativeMessageOwnershipKey(sessionId: string | null | undefined, messageId: string) {
+  return `${messageSessionScope(sessionId, messageId)}\0${messageId}`
+}
+
+function markNativeMessageOwned(
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
+  messageId: string,
+) {
+  state.nativeOwnedMessages.add(nativeMessageOwnershipKey(sessionId, messageId))
+}
+
+function isNativeMessageOwned(
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
+  messageId: string | null | undefined,
+) {
+  if (!messageId) return false
+  return state.nativeOwnedMessages.has(nativeMessageOwnershipKey(sessionId, messageId))
+}
+
+function markNativeToolOwned(
+  state: SessionScopedMessageState,
+  sessionId: string,
+  callId: string,
+) {
+  state.nativeOwnedToolCalls.add(nativeToolKey(sessionId, callId))
+}
+
+function isNativeToolOwned(
+  state: SessionScopedMessageState,
+  sessionId: string | null | undefined,
+  callId: string | null | undefined,
+) {
+  if (!sessionId || !callId) return false
+  return state.nativeOwnedToolCalls.has(nativeToolKey(sessionId, callId))
 }
 
 function messageSessionScope(sessionId: string | null | undefined, messageId: string) {
@@ -351,6 +404,7 @@ export function handleMessagePartDeltaEvent(
   dispatchRuntimeEvent: DispatchRuntimeEvent,
   properties: Record<string, unknown> | null | undefined,
   messageState: SessionScopedMessageState,
+  options?: { fromNativeFamily?: boolean },
 ) {
   const rawPart = asRecord(readRecordValue(properties, 'part'))
   const messageId = readString(readRecordValue(properties, 'messageID'))
@@ -375,6 +429,12 @@ export function handleMessagePartDeltaEvent(
     ? consumePendingPromptEcho(sessionId, rawDelta)
     : rawDelta
   if (!delta || !sessionId) return
+
+  // Cross-family contract: once session.next owns a message, classic
+  // message.part.delta is secondary and must not double-append.
+  if (!options?.fromNativeFamily && messageId && isNativeMessageOwned(messageState, actualSessionId, messageId)) {
+    return
+  }
 
   const taskRunId = actualSessionId && actualSessionId !== sessionId
     ? (getTaskRunIdForChild(actualSessionId)
@@ -887,9 +947,25 @@ export function handleMessagePartUpdatedEvent(
   properties: Record<string, unknown> | null | undefined,
   messageState: SessionScopedMessageState,
   cachedModelId: string,
+  options?: { fromNativeFamily?: boolean },
 ) {
   const ctx = resolveUpdatedPartContext(win, dispatchRuntimeEvent, properties, messageState, cachedModelId)
   if (!ctx || ignoreUpdatedPart(ctx.part)) return
+
+  // Prefer session.next for live transcript when present. Classic parts for a
+  // native-owned message (or tool call id) are dropped to avoid dual projection.
+  if (!options?.fromNativeFamily) {
+    if (ctx.messageId && isNativeMessageOwned(messageState, ctx.actualSessionId, ctx.messageId)) {
+      return
+    }
+    const callId = readString(readRecordValue(ctx.part, 'callID'))
+      || readString(readRecordValue(ctx.part, 'callId'))
+      || (ctx.part.type === 'tool' ? ctx.partId : null)
+    if (callId && isNativeToolOwned(messageState, ctx.actualSessionId, callId)) {
+      return
+    }
+  }
+
   handleUpdatedTextPart(ctx)
     || handleUpdatedReasoningPart(ctx)
     || handleUpdatedStepFinishPart(ctx)
@@ -918,13 +994,14 @@ export function handleNativeTextDeltaEvent(
   const delta = readString(readRecordValue(properties, 'delta'))
   if (!sessionID || !messageID || !delta) return
   setMessageRole(messageState, sessionID, messageID, 'assistant')
+  markNativeMessageOwned(messageState, sessionID, messageID)
   handleMessagePartDeltaEvent(win, dispatchRuntimeEvent, {
     sessionID,
     messageID,
     partID,
     type: kind,
     delta,
-  }, messageState)
+  }, messageState, { fromNativeFamily: true })
 }
 
 export function handleNativeTextEndedEvent(
@@ -940,6 +1017,7 @@ export function handleNativeTextEndedEvent(
   const content = readString(readRecordValue(properties, 'text'))
   if (!sessionID || !messageID || !content) return
   setMessageRole(messageState, sessionID, messageID, 'assistant')
+  markNativeMessageOwned(messageState, sessionID, messageID)
   handleMessagePartUpdatedEvent(win, dispatchRuntimeEvent, {
     sessionID,
     messageID,
@@ -950,7 +1028,7 @@ export function handleNativeTextEndedEvent(
       messageID,
       text: content,
     },
-  }, messageState, cachedModelId)
+  }, messageState, cachedModelId, { fromNativeFamily: true })
 }
 
 function nativeToolKey(sessionID: string, callID: string) {
@@ -968,6 +1046,8 @@ export function handleNativeToolEvent(
   const { sessionID, messageID } = nativeMessageEventFields(properties)
   const callID = readString(readRecordValue(properties, 'callID'))
   if (!sessionID || !messageID || !callID) return
+  markNativeMessageOwned(messageState, sessionID, messageID)
+  markNativeToolOwned(messageState, sessionID, callID)
   const key = nativeToolKey(sessionID, callID)
   const previous = messageState.nativeToolPartsByKey.get(key) || {}
   const previousState = asRecord(readRecordValue(previous, 'state'))
@@ -1032,7 +1112,7 @@ export function handleNativeToolEvent(
     sessionID,
     messageID,
     part: next,
-  }, messageState, cachedModelId)
+  }, messageState, cachedModelId, { fromNativeFamily: true })
 }
 
 export function handleNativeStepEndedEvent(
@@ -1045,6 +1125,7 @@ export function handleNativeStepEndedEvent(
   const { sessionID, messageID } = nativeMessageEventFields(properties)
   if (!sessionID || !messageID) return
   setMessageRole(messageState, sessionID, messageID, 'assistant')
+  markNativeMessageOwned(messageState, sessionID, messageID)
   handleMessagePartUpdatedEvent(win, dispatchRuntimeEvent, {
     sessionID,
     messageID,
@@ -1057,5 +1138,5 @@ export function handleNativeStepEndedEvent(
       tokens: readRecordValue(properties, 'tokens'),
       reason: readRecordValue(properties, 'finish'),
     },
-  }, messageState, cachedModelId)
+  }, messageState, cachedModelId, { fromNativeFamily: true })
 }

--- a/apps/desktop/src/main/events.ts
+++ b/apps/desktop/src/main/events.ts
@@ -20,9 +20,15 @@ import {
   handleNativeTextEndedEvent,
   handleNativeToolEvent,
   sweepSessionScopedMessageState,
+  type SessionScopedMessageState,
 } from './event-message-handlers.ts'
 import { handleRuntimeSideEffectEvent } from './event-runtime-handlers.ts'
+import {
+  attachDirectoryDurableHub,
+  shouldSuppressGlobalRuntimeEvent,
+} from './durable-session-events.ts'
 export { removeParentSession } from './event-runtime-handlers.ts'
+export { markSessionPromptAdmitted } from './durable-session-events.ts'
 
 const UNKNOWN_EVENT_LOG_INTERVAL_MS = 60_000
 const unknownEventLastLoggedAt = new Map<string, number>()
@@ -59,6 +65,125 @@ function logUnknownRuntimeEvent(type: string, scopeLabel: string) {
   log('events', `Unknown OpenCode event type${scopeLabel}: ${type}`)
 }
 
+function processOpenCodeRuntimeEvent(options: {
+  win: BrowserWindow
+  raw: unknown
+  messageState: SessionScopedMessageState
+  cachedModelId: string
+  getMainWindow: () => BrowserWindow | null
+  scopeLabel: string
+  directory: string | null | undefined
+  /** When true, skip durable-ownership suppress (event already on durable tail). */
+  fromDurableStream?: boolean
+}) {
+  const data = normalizeRuntimeEventEnvelope(options.raw)
+  if (!data) return
+
+  if (
+    !options.fromDurableStream
+    && shouldSuppressGlobalRuntimeEvent(options.directory, data.type, data.properties)
+  ) {
+    return
+  }
+
+  try {
+    switch (data.type) {
+      case 'message.updated': {
+        handleMessageUpdatedEvent(options.win, dispatchRuntimeEvent, data.properties, options.messageState)
+        break
+      }
+
+      case 'message.part.delta': {
+        handleMessagePartDeltaEvent(options.win, dispatchRuntimeEvent, data.properties, options.messageState)
+        break
+      }
+
+      case 'message.part.updated': {
+        handleMessagePartUpdatedEvent(
+          options.win,
+          dispatchRuntimeEvent,
+          data.properties,
+          options.messageState,
+          options.cachedModelId,
+        )
+        break
+      }
+
+      case 'session.next.text.delta':
+      case 'session.next.reasoning.delta': {
+        handleNativeTextDeltaEvent(
+          options.win,
+          dispatchRuntimeEvent,
+          data.properties,
+          options.messageState,
+          data.type === 'session.next.text.delta' ? 'text' : 'reasoning',
+        )
+        break
+      }
+
+      case 'session.next.text.ended':
+      case 'session.next.reasoning.ended': {
+        handleNativeTextEndedEvent(
+          options.win,
+          dispatchRuntimeEvent,
+          data.properties,
+          options.messageState,
+          options.cachedModelId,
+          data.type === 'session.next.text.ended' ? 'text' : 'reasoning',
+        )
+        break
+      }
+
+      case 'session.next.tool.called':
+      case 'session.next.tool.progress':
+      case 'session.next.tool.success':
+      case 'session.next.tool.failed': {
+        handleNativeToolEvent(
+          options.win,
+          dispatchRuntimeEvent,
+          data.type,
+          data.properties,
+          options.messageState,
+          options.cachedModelId,
+        )
+        break
+      }
+
+      case 'session.next.step.ended': {
+        handleNativeStepEndedEvent(
+          options.win,
+          dispatchRuntimeEvent,
+          data.properties,
+          options.messageState,
+          options.cachedModelId,
+        )
+        handleRuntimeSideEffectEvent({
+          win: options.win,
+          type: data.type,
+          properties: data.properties,
+          dispatchRuntimeEvent,
+          getMainWindow: options.getMainWindow,
+        })
+        break
+      }
+
+      default:
+        if (!handleRuntimeSideEffectEvent({
+          win: options.win,
+          type: data.type,
+          properties: data.properties,
+          dispatchRuntimeEvent,
+          getMainWindow: options.getMainWindow,
+        })) {
+          logUnknownRuntimeEvent(data.type, options.scopeLabel)
+        }
+        break
+    }
+  } catch (err) {
+    log('error', `Failed to process SSE event ${data.type}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
 export async function subscribeToEvents(
   client: OpencodeClient,
   getMainWindow: () => BrowserWindow | null,
@@ -67,6 +192,11 @@ export async function subscribeToEvents(
 ) {
   const scopeLabel = directory ? ` [${directory}]` : ''
   log('events', `Subscribing to SSE event stream${scopeLabel}`)
+  // Durable hub needs an abort signal to tear down per-session tails when the
+  // directory subscription ends. Prefer the caller signal; otherwise create a
+  // local controller aborted only in finally after the global stream exits.
+  const localController = signal ? null : new AbortController()
+  const durableSignal = signal || localController!.signal
   const result = await client.v2.event.subscribe(signal ? { signal } : undefined)
   const stream = result.stream
   log('events', `SSE stream connected${scopeLabel}`)
@@ -77,6 +207,28 @@ export async function subscribeToEvents(
     sweepStaleTaskState()
     sweepSessionScopedMessageState(messageState)
   }, 5 * 60 * 1000)
+
+  // Durable per-session tails share this message-state + handler pipeline so
+  // classic/native projection and task binding stay consistent across streams.
+  attachDirectoryDurableHub({
+    client,
+    directory: directory ?? null,
+    signal: durableSignal,
+    onEvent: async (raw) => {
+      const win = getMainWindow()
+      if (!win) return
+      processOpenCodeRuntimeEvent({
+        win,
+        raw,
+        messageState,
+        cachedModelId,
+        getMainWindow,
+        scopeLabel,
+        directory,
+        fromDurableStream: true,
+      })
+    },
+  })
 
   // One-shot trace: log the first event per subscription so a silent stream
   // is obvious in the log (as opposed to a stream that just isn't being
@@ -96,108 +248,19 @@ export async function subscribeToEvents(
       const win = getMainWindow()
       if (!win) continue
 
-      const data = normalizeRuntimeEventEnvelope(event)
-      if (!data) continue
-
-      try {
-        switch (data.type) {
-          case 'message.updated': {
-            handleMessageUpdatedEvent(win, dispatchRuntimeEvent, data.properties, messageState)
-            break
-          }
-
-          case 'message.part.delta': {
-            handleMessagePartDeltaEvent(win, dispatchRuntimeEvent, data.properties, messageState)
-            break
-          }
-
-          case 'message.part.updated': {
-            handleMessagePartUpdatedEvent(
-              win,
-              dispatchRuntimeEvent,
-              data.properties,
-              messageState,
-              cachedModelId,
-            )
-            break
-          }
-
-          case 'session.next.text.delta':
-          case 'session.next.reasoning.delta': {
-            handleNativeTextDeltaEvent(
-              win,
-              dispatchRuntimeEvent,
-              data.properties,
-              messageState,
-              data.type === 'session.next.text.delta' ? 'text' : 'reasoning',
-            )
-            break
-          }
-
-          case 'session.next.text.ended':
-          case 'session.next.reasoning.ended': {
-            handleNativeTextEndedEvent(
-              win,
-              dispatchRuntimeEvent,
-              data.properties,
-              messageState,
-              cachedModelId,
-              data.type === 'session.next.text.ended' ? 'text' : 'reasoning',
-            )
-            break
-          }
-
-          case 'session.next.tool.called':
-          case 'session.next.tool.progress':
-          case 'session.next.tool.success':
-          case 'session.next.tool.failed': {
-            handleNativeToolEvent(
-              win,
-              dispatchRuntimeEvent,
-              data.type,
-              data.properties,
-              messageState,
-              cachedModelId,
-            )
-            break
-          }
-
-          case 'session.next.step.ended': {
-            handleNativeStepEndedEvent(
-              win,
-              dispatchRuntimeEvent,
-              data.properties,
-              messageState,
-              cachedModelId,
-            )
-            handleRuntimeSideEffectEvent({
-              win,
-              type: data.type,
-              properties: data.properties,
-              dispatchRuntimeEvent,
-              getMainWindow,
-            })
-            break
-          }
-
-          default:
-            if (!handleRuntimeSideEffectEvent({
-              win,
-              type: data.type,
-              properties: data.properties,
-              dispatchRuntimeEvent,
-              getMainWindow,
-            })) {
-              logUnknownRuntimeEvent(data.type, scopeLabel)
-            }
-            break
-        }
-      } catch (err) {
-        log('error', `Failed to process SSE event ${data.type}: ${err instanceof Error ? err.message : String(err)}`)
-      }
+      processOpenCodeRuntimeEvent({
+        win,
+        raw: event,
+        messageState,
+        cachedModelId,
+        getMainWindow,
+        scopeLabel,
+        directory,
+      })
     }
   } finally {
     clearInterval(sweepInterval)
+    localController?.abort()
   }
 
   if (signal?.aborted) {

--- a/apps/desktop/src/main/ipc/session-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-handlers.ts
@@ -18,6 +18,7 @@ import { randomUUID } from 'node:crypto'
 import { closeSync, constants as fsConstants, fstatSync, openSync, readFileSync } from 'node:fs'
 import { getProviderDescriptor } from '@open-cowork/runtime-host/config'
 import { forgetSubmittedPrompt, rememberSubmittedPrompt, trackParentSession } from '../event-task-state.ts'
+import { markSessionPromptAdmitted } from '../durable-session-events.ts'
 import { startSessionStatusReconciliation, stopSessionStatusReconciliation } from '../session-status-reconciler.ts'
 import { log } from '@open-cowork/shared/node'
 import {
@@ -561,13 +562,23 @@ export function registerSessionHandlers(context: IpcHandlerContext) {
       })
       if (promptRecord) getThreadIndexService().upsertThreadFromSessionRecord(promptRecord)
 
-      await promptNativeSession(client, {
+      const admitted = await promptNativeSession(client, {
         sessionID: sessionId,
         parts,
         model: promptModel
           ? { ...promptModel, variant: promptVariant || undefined }
           : null,
         agent: requestedAgent,
+      })
+      // V2 prompt is admission-only. Attach the session to the durable
+      // v2.session.events tail from admittedSeq so transcript is not lost
+      // between the HTTP response and the global SSE stream.
+      markSessionPromptAdmitted({
+        // Match event-subscription keys (runtime home path, not null).
+        directory: record?.opencodeDirectory || getRuntimeHomeDir(),
+        sessionId,
+        admittedSeq: admitted.admittedSeq,
+        admissionId: admitted.id,
       })
 
       startSessionStatusReconciliation(sessionId, {

--- a/apps/desktop/src/main/workflow/workflow-service.ts
+++ b/apps/desktop/src/main/workflow/workflow-service.ts
@@ -27,6 +27,7 @@ import type {
 } from '@open-cowork/shared'
 import { getConfiguredAgentsFromConfig } from '@open-cowork/runtime-host/config'
 import { trackParentSession } from '../event-task-state.ts'
+import { markSessionPromptAdmitted } from '../durable-session-events.ts'
 import { log } from '@open-cowork/shared/node'
 import { createKeyedPromiseChain } from '../promise-chain.ts'
 import { startSessionStatusReconciliation } from '../session-status-reconciler.ts'
@@ -201,10 +202,16 @@ async function createWorkflowThread(input: {
   trackParentSession(session.id)
   input.onSessionCreated?.(session.id)
   const prompt = typeof input.prompt === 'function' ? input.prompt(session.id) : input.prompt
-  await promptNativeSession(client, {
+  const admitted = await promptNativeSession(client, {
     sessionID: session.id,
     parts: [{ type: 'text', text: prompt }],
     agent: input.agent,
+  })
+  markSessionPromptAdmitted({
+    directory: opencodeDirectory,
+    sessionId: session.id,
+    admittedSeq: admitted.admittedSeq,
+    admissionId: admitted.id,
   })
   if (input.kind === 'workflow_run') {
     startSessionStatusReconciliation(session.id, {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -312,14 +312,19 @@ This layer is responsible for:
 - notifications
 
 Code:
-- `apps/desktop/src/main/events.ts` — SSE subscription to the OpenCode
-  runtime.
+- `apps/desktop/src/main/events.ts` — control-plane SSE (`v2.event.subscribe`)
+  plus shared projection into the SessionEngine pipeline.
+- `apps/desktop/src/main/durable-session-events.ts` — per-session durable tails
+  (`v2.session.events`) started from prompt `admittedSeq`, with global-stream
+  transcript suppress for tracked sessions.
+- `packages/runtime-host/src/opencode-durable-session-events.ts` — shared cursor
+  and suppress helpers used by Desktop (and aligned with cloud/standalone).
 - `apps/desktop/src/main/event-subscriptions.ts` — subscription manager with
   retry and directory-scoped clients.
 - `apps/desktop/src/main/event-runtime-handlers.ts`,
   `apps/desktop/src/main/event-message-handlers.ts`,
   `apps/desktop/src/main/event-task-state.ts` — normalizers for each event
-  class.
+  class (including classic vs `session.next` family ownership).
 - `packages/runtime-host/src/session-engine.ts` — the state machine that applies
   normalized events and derives the view model.
 - `packages/runtime-host/src/session-history-loader.ts`,

--- a/docs/opencode-sdk-v2-boundary.md
+++ b/docs/opencode-sdk-v2-boundary.md
@@ -111,6 +111,21 @@ remaining call by file, method, and count so this list cannot expand silently:
 Remove an allowlist entry as soon as the pinned SDK exposes a working native V2
 equivalent. Do not emulate these OpenCode-owned behaviors in Open Cowork.
 
+**Status on OpenCode 1.18.1 (verified):** no allowlist row is burnable yet.
+
+| Gap | Why it stays classic |
+|-----|----------------------|
+| `session.summarize` | Generated `v2.session.compact` exists but server returns `OperationUnavailable`. |
+| `session.command` / `delete` / `diff` / `fork` / `share` / `todo` / `unshare` / `update` | No working native V2 routes on the pin. |
+| MCP `auth.*` / `connect` / `disconnect` / `status` | No V2 MCP group. |
+| `file.read` | Generated `v2.fs.read` does not expose the wildcard path for `/api/fs/read/*`. |
+| `file.status`, `find.symbols`, `find.text` | No working V2 equivalents (`v2.fs.list` / `v2.fs.find` already cover list/find-files). |
+| `tool.list` | V2 catalogs agents/commands/skills/providers/models, not the effective tool set. |
+
+Burn-down is gated on an OpenCode SDK/runtime bump that proves each method,
+then removes the exact allowlist entry in `tests/opencode-sdk-boundary.test.ts`
+and switches the call site to `client.v2.*`.
+
 ## Shared Event Contract
 
 The OpenCode SDK event stream is normalized once at the runtime boundary:
@@ -149,6 +164,36 @@ adapter consumes `v2.session.events` from the returned `admittedSeq` rather
 than relying on the lossy global event tail. This preserves fast completions
 and crash retries without re-executing tool side effects. A bounded execution
 deadline interrupts the native session if no terminal event arrives.
+
+Desktop local runtime uses the same durable admission contract:
+
+- `v2.event.subscribe` remains the process-level control plane (permissions,
+  questions, untracked sessions, heartbeats).
+- After each local `v2.session.prompt` admission, Desktop tracks that session
+  on `v2.session.events` from `admittedSeq` and advances an `after` cursor from
+  observed `durable.seq` values.
+- While a session is durable-tracked, global-stream transcript
+  (`session.next.*`, classic `message.*`) and idle terminals for that session
+  are suppressed so two SSE tails cannot double-project.
+- Shared helpers live in
+  `packages/runtime-host/src/opencode-durable-session-events.ts`; the Desktop
+  hub is `apps/desktop/src/main/durable-session-events.ts`.
+
+### Classic vs `session.next` family ownership
+
+OpenCode may emit both classic `message.part.*` and native `session.next.*` for
+the same turn. Open Cowork receive-side ownership is:
+
+1. Prefer `session.next.*` for live transcript once a message (or tool
+   `callID`) has been observed on the native family.
+2. Classic `message.part.delta` / `message.part.updated` for that message or
+   call id is suppressed thereafter.
+3. Classic handlers remain for history-shaped events and turns that never emit
+   native events.
+
+Idle multi-signal dedupe (`session.status` idle, `session.idle`, non-tool
+`session.next.step.ended`) is unchanged and lives in
+`event-runtime-handlers.ts`.
 
 ## SDK v2 Upgrade Checklist
 

--- a/docs/opencode-sdk-v2-boundary.md
+++ b/docs/opencode-sdk-v2-boundary.md
@@ -62,6 +62,7 @@ still touch SDK event/types at the desktop edge.
 - `packages/cloud-server/src/opencode-runtime-adapter.ts`
 - `packages/cloud-server/src/runtime-adapter.ts`
 - `packages/cloud-server/src/worker-scoped-runtime-adapter.ts`
+- `apps/desktop/src/main/durable-session-events.ts`
 - `apps/desktop/src/main/event-subscriptions.ts`
 - `apps/desktop/src/main/events.ts`
 - `apps/desktop/src/main/ipc/context.ts`

--- a/packages/runtime-host/src/index.ts
+++ b/packages/runtime-host/src/index.ts
@@ -5,6 +5,7 @@
 // (tests/opencode-sdk-boundary.test.ts) and ships in the cloud Docker image.
 export * from './opencode-adapter.js'
 export * from './opencode-v2.js'
+export * from './opencode-durable-session-events.js'
 export * from './runtime-managed-server-protocol.js'
 export * from './runtime-managed-server-output.js'
 export * from './runtime-managed-server-core.js'

--- a/packages/runtime-host/src/opencode-durable-session-events.ts
+++ b/packages/runtime-host/src/opencode-durable-session-events.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared helpers for OpenCode V2 durable per-session event streams
+ * (`v2.session.events` + `admittedSeq` / `after` cursors).
+ *
+ * Cloud workers and standalone gateway already consume the durable aggregate
+ * for transcript truth. Desktop local runtime uses the same predicates so the
+ * global control-plane stream and per-session durable tails do not double-project.
+ */
+
+import { readString } from '@open-cowork/shared'
+
+export type DurableSequenceCursor = {
+  /** Last observed durable.seq for this session, or -1 if none. */
+  lastSequence: number
+  /** Optional last SSE event id used when durable.seq is absent. */
+  after?: string
+}
+
+/**
+ * Initial `after` cursor for a durable subscription.
+ *
+ * - After live events: resume from the last observed sequence (exclusive upper
+ *   bound is encoded by OpenCode as `after: lastSequence`).
+ * - On first admission: start just before the admitted input sequence so the
+ *   admitted prompt and its outputs are replayable (standalone/cloud contract).
+ */
+export function durableAfterCursor(options: {
+  lastSequence?: number | null
+  admittedSeq?: number | null
+}): string | undefined {
+  const last = options.lastSequence
+  if (typeof last === 'number' && Number.isSafeInteger(last) && last >= 0) {
+    return String(last)
+  }
+  const admitted = options.admittedSeq
+  if (typeof admitted === 'number' && Number.isSafeInteger(admitted) && admitted > 0) {
+    return String(admitted - 1)
+  }
+  return undefined
+}
+
+export function isTrackedTranscriptEventType(type: string | null | undefined): boolean {
+  if (!type) return false
+  return type.startsWith('session.next.')
+    || type === 'message.updated'
+    || type === 'message.part.updated'
+    || type === 'message.part.delta'
+}
+
+export function isTrackedTerminalEventType(
+  type: string | null | undefined,
+  statusType?: string | null,
+): boolean {
+  if (type === 'session.idle') return true
+  if (type === 'session.status' && statusType === 'idle') return true
+  return false
+}
+
+/**
+ * When a session is owned by a durable `v2.session.events` subscription, the
+ * global `v2.event.subscribe` tail must not project the same transcript or
+ * idle terminal — two independent SSE connections cannot guarantee order.
+ */
+export function shouldSuppressGlobalEventForTrackedSession(
+  tracked: boolean,
+  type: string | null | undefined,
+  statusType?: string | null,
+): boolean {
+  if (!tracked) return false
+  return isTrackedTranscriptEventType(type)
+    || isTrackedTerminalEventType(type, statusType)
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+export function readDurableSequenceFromEvent(raw: unknown): number | null {
+  const envelope = objectRecord(raw)
+  if (!envelope) return null
+  // Prefer nested payload (cloud envelopes) then the event root.
+  const payload = objectRecord(envelope.payload) || envelope
+  const durable = objectRecord(payload.durable) || objectRecord(envelope.durable)
+  if (!durable) return null
+  const seq = durable.seq
+  if (typeof seq === 'number' && Number.isSafeInteger(seq) && seq >= 0) return seq
+  return null
+}
+
+export function readSessionStatusType(properties: Record<string, unknown> | null | undefined): string | null {
+  if (!properties) return null
+  const status = objectRecord(properties.status)
+  return readString(status?.type)
+    || readString(properties.statusType)
+    || null
+}
+
+export function advanceDurableCursor(
+  cursor: DurableSequenceCursor,
+  raw: unknown,
+  fallbackAfter?: string,
+): DurableSequenceCursor {
+  const sequence = readDurableSequenceFromEvent(raw)
+  if (sequence !== null) {
+    if (sequence <= cursor.lastSequence) return cursor
+    return {
+      lastSequence: sequence,
+      after: String(sequence),
+    }
+  }
+  if (fallbackAfter && fallbackAfter !== cursor.after) {
+    return { ...cursor, after: fallbackAfter }
+  }
+  return cursor
+}

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -38,6 +38,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'destructive-actions.ts',
   'diagnostics-export.ts',
   'directory-grants.ts',
+  'durable-session-events.ts',
   'event-message-handlers.ts',
   'event-runtime-handlers.ts',
   'event-subscriptions.ts',

--- a/tests/event-message-handlers.test.ts
+++ b/tests/event-message-handlers.test.ts
@@ -4,6 +4,7 @@ import type { BrowserWindow } from 'electron'
 import {
   createSessionScopedMessageState,
   handleMessagePartDeltaEvent,
+  handleMessagePartUpdatedEvent,
   handleMessageUpdatedEvent,
   handleNativeStepEndedEvent,
   handleNativeTextDeltaEvent,
@@ -439,4 +440,65 @@ test('native v2 tool terminal events retain called metadata and step events proj
   assert.equal(cost?.data?.cost, 0.125)
   assert.deepEqual(cost?.data?.tokens, { input: 5, output: 7, reasoning: 1, cache: { read: 2, write: 3 } })
   assert.equal(messageState.nativeToolPartsByKey.size, 0)
+})
+
+test('classic message.part events are suppressed once session.next owns the message', () => {
+  const win = {} as BrowserWindow
+  const messageState = createSessionScopedMessageState()
+  const collector = createDispatchCollector()
+  trackParentSession('dual-family-session')
+
+  handleNativeTextDeltaEvent(win, collector.dispatch, {
+    sessionID: 'dual-family-session',
+    assistantMessageID: 'assistant-dual',
+    textID: 'text-1',
+    delta: 'Native ',
+  }, messageState, 'text')
+
+  // Classic family for the same message must not double-append after native owns it.
+  handleMessagePartDeltaEvent(win, collector.dispatch, {
+    sessionID: 'dual-family-session',
+    messageID: 'assistant-dual',
+    partID: 'text-1',
+    type: 'text',
+    delta: 'Classic-dup',
+  }, messageState)
+
+  handleNativeToolEvent(win, collector.dispatch, 'session.next.tool.called', {
+    sessionID: 'dual-family-session',
+    assistantMessageID: 'assistant-dual',
+    callID: 'call-dual',
+    tool: 'bash',
+    input: { command: 'echo hi' },
+  }, messageState, 'openai/gpt-5')
+
+  // Classic tool part with the same call id must not re-project.
+  handleMessagePartUpdatedEvent(win, collector.dispatch, {
+    sessionID: 'dual-family-session',
+    messageID: 'assistant-dual',
+    part: {
+      type: 'tool',
+      id: 'call-dual',
+      callID: 'call-dual',
+      sessionID: 'dual-family-session',
+      messageID: 'assistant-dual',
+      tool: 'bash',
+      state: {
+        status: 'completed',
+        input: { command: 'echo hi' },
+        output: 'should-not-appear',
+      },
+    },
+  }, messageState, 'openai/gpt-5')
+
+  const textEvents = collector.events.filter((event) => {
+    const data = (event as { data?: { type?: string; content?: string } }).data
+    return data?.type === 'text'
+  }) as Array<{ data: { content?: string } }>
+  assert.equal(textEvents.length, 1)
+  assert.equal(textEvents[0]?.data.content, 'Native ')
+
+  const toolEvents = collector.events.filter((event) => (event as { type?: string }).type === 'tool_call')
+  // Only the native tool.called projection — not a second classic completion.
+  assert.equal(toolEvents.length, 1)
 })

--- a/tests/opencode-durable-session-events.test.ts
+++ b/tests/opencode-durable-session-events.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  advanceDurableCursor,
+  durableAfterCursor,
+  isTrackedTerminalEventType,
+  isTrackedTranscriptEventType,
+  readDurableSequenceFromEvent,
+  shouldSuppressGlobalEventForTrackedSession,
+} from '../packages/runtime-host/src/opencode-durable-session-events.ts'
+import {
+  __testShouldSuppress,
+  __testTrackSession,
+  resetDurableSessionHubsForTests,
+} from '../apps/desktop/src/main/durable-session-events.ts'
+
+test('durableAfterCursor prefers last observed sequence over admission', () => {
+  assert.equal(durableAfterCursor({ lastSequence: 12, admittedSeq: 7 }), '12')
+  assert.equal(durableAfterCursor({ lastSequence: -1, admittedSeq: 7 }), '6')
+  assert.equal(durableAfterCursor({ lastSequence: null, admittedSeq: 1 }), '0')
+  assert.equal(durableAfterCursor({ lastSequence: null, admittedSeq: 0 }), undefined)
+  assert.equal(durableAfterCursor({}), undefined)
+})
+
+test('readDurableSequenceFromEvent reads nested durable.seq', () => {
+  assert.equal(readDurableSequenceFromEvent({
+    type: 'session.next.text.delta',
+    durable: { seq: 4, aggregateID: 'agg' },
+  }), 4)
+  assert.equal(readDurableSequenceFromEvent({
+    payload: {
+      type: 'message.part.delta',
+      durable: { seq: 9 },
+    },
+  }), 9)
+  assert.equal(readDurableSequenceFromEvent({ type: 'session.idle' }), null)
+})
+
+test('advanceDurableCursor ignores stale sequences', () => {
+  const cursor = { lastSequence: 5, after: '5' }
+  assert.deepEqual(
+    advanceDurableCursor(cursor, { durable: { seq: 3 } }),
+    cursor,
+  )
+  assert.deepEqual(
+    advanceDurableCursor(cursor, { durable: { seq: 8 } }),
+    { lastSequence: 8, after: '8' },
+  )
+})
+
+test('tracked transcript and terminal predicates cover classic and native families', () => {
+  assert.equal(isTrackedTranscriptEventType('session.next.text.delta'), true)
+  assert.equal(isTrackedTranscriptEventType('message.part.updated'), true)
+  assert.equal(isTrackedTranscriptEventType('permission.v2.asked'), false)
+  assert.equal(isTrackedTerminalEventType('session.idle'), true)
+  assert.equal(isTrackedTerminalEventType('session.status', 'idle'), true)
+  assert.equal(isTrackedTerminalEventType('session.status', 'busy'), false)
+})
+
+test('global suppress only applies to tracked sessions for transcript and idle', () => {
+  assert.equal(
+    shouldSuppressGlobalEventForTrackedSession(true, 'session.next.tool.called'),
+    true,
+  )
+  assert.equal(
+    shouldSuppressGlobalEventForTrackedSession(true, 'message.part.delta'),
+    true,
+  )
+  assert.equal(
+    shouldSuppressGlobalEventForTrackedSession(true, 'session.status', 'idle'),
+    true,
+  )
+  assert.equal(
+    shouldSuppressGlobalEventForTrackedSession(true, 'permission.v2.asked'),
+    false,
+  )
+  assert.equal(
+    shouldSuppressGlobalEventForTrackedSession(false, 'session.next.text.delta'),
+    false,
+  )
+})
+
+test('desktop durable hub suppresses global transcript once a session is admitted', () => {
+  resetDurableSessionHubsForTests()
+  try {
+    __testTrackSession(null, 'ses_1', 7)
+    assert.equal(__testShouldSuppress(null, 'ses_1', 'session.next.text.delta'), true)
+    assert.equal(__testShouldSuppress(null, 'ses_1', 'message.part.updated'), true)
+    assert.equal(__testShouldSuppress(null, 'ses_1', 'permission.v2.asked'), false)
+    assert.equal(__testShouldSuppress(null, 'ses_other', 'session.next.text.delta'), false)
+  } finally {
+    resetDurableSessionHubsForTests()
+  }
+})

--- a/tests/opencode-sdk-boundary.test.ts
+++ b/tests/opencode-sdk-boundary.test.ts
@@ -41,6 +41,7 @@ const allowedSdkImportPaths = new Set([
   'packages/cloud-server/src/opencode-runtime-adapter.ts',
   'packages/cloud-server/src/runtime-adapter.ts',
   'packages/cloud-server/src/worker-scoped-runtime-adapter.ts',
+  'apps/desktop/src/main/durable-session-events.ts',
   'apps/desktop/src/main/event-subscriptions.ts',
   'apps/desktop/src/main/events.ts',
   'apps/desktop/src/main/ipc/context.ts',


### PR DESCRIPTION
## Summary

Follow-up to the merged V2 audit cleanup (#943). Completes the three deferred items end-to-end where product code can:

1. **Desktop durable event parity** — after each local `v2.session.prompt` admission, track the session on `v2.session.events` from `admittedSeq`, advance an `after` cursor from `durable.seq`, and suppress tracked-session transcript/idle on the global `v2.event.subscribe` control plane (same contract as cloud/standalone).
2. **Cross-family classic vs `session.next` ownership** — once native owns a message or tool `callID`, classic `message.part.*` for that identity is suppressed.
3. **Classic SDK allowlist burn-down** — re-verified on OpenCode **1.18.1**; no row is burnable yet (summarize/MCP/explorer/`tool.list` still lack working native V2). Documented the status table so the next SDK bump can burn entries method-by-method.

## Test plan

- [x] `node scripts/run-node-tests.mjs tests/opencode-durable-session-events.test.ts tests/event-message-handlers.test.ts tests/events.test.ts` (23 pass)
- [x] `pnpm --filter @open-cowork/runtime-host build`
- [ ] CI green
- [ ] Manual: prompt a local Desktop session and confirm assistant stream still works; kill/reconnect should not require full reboot for mid-turn durable tails when the server is up