### PR TITLE
chore(ci)(deps): bump github/codeql-action init+analyze to 4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Initialize CodeQL (pull request)
         if: github.event_name == 'pull_request'
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           # Faster pack + exclude products/** (see codeql-config.yml).
@@ -53,7 +53,7 @@ jobs:
 
       - name: Initialize CodeQL (master / schedule)
         if: github.event_name != 'pull_request'
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           # Deeper pack once per merge/week; full monorepo graph (no paths-ignore).
@@ -63,7 +63,7 @@ jobs:
         run: pnpm build
 
       - name: Analyze
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"
           output: codeql-results


### PR DESCRIPTION
## Summary
Combines Dependabot PRs #949 and #950. CodeQL fails when `init` and `analyze` are on different action versions (`Loaded a configuration file for version X, but running version Y`).

## Test plan
- [x] CodeQL workflow pins init and analyze to the same SHA (v4.37.1)
- [ ] CI green on this PR