### PR TITLE
fix(post-961): hardening PR for P0–P3 residuals

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Typecheck Gateway
         run: pnpm --filter cowork-gateway typecheck
 
+      - name: Dead code (knip)
+        run: pnpm --filter cowork-gateway knip
+
       - name: Test Gateway
         run: pnpm --filter cowork-gateway test
 

--- a/.github/workflows/ci-wiki.yml
+++ b/.github/workflows/ci-wiki.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Typecheck Wiki workspace
         run: pnpm --filter cowork-wiki-workspace typecheck
 
+      - name: Dead code (knip)
+        run: pnpm --filter cowork-wiki-workspace check:dead-code
+
       # Unit suite includes hosted-readiness-evidence dry-run contract (JOE-975).
       # Full dual-replica --enforce is release/operator-gated, not PR CI.
       - name: Test Wiki (unit)

--- a/apps/desktop/src/main/README.md
+++ b/apps/desktop/src/main/README.md
@@ -27,8 +27,9 @@ new behavior has more than one file or clear lifecycle ownership.
 - `runtime-*` — OpenCode SDK/server composition and runtime-home isolation.
 - `session-*` — session registry, replay, view projection, and reconciliation.
 - `event-*` — runtime event handlers and task-run lineage projection.
-- `cloud-workspace-*` / `gateway-workspace-*` / `workspace-gateway*` —
-  local/cloud/gateway workspace control-plane adapters.
+- `cloud-workspace-*` / `gateway-workspace-*` / `workspace-gateway*` /
+  `local-workspace-session` / `workspace-session-port` — local/cloud/gateway
+  workspace control-plane adapters and progressive local session port wiring.
 - `chart-*` / `artifact-*` — chart rendering and private artifact handling.
 - `main-window-*` / `window-*` — BrowserWindow lifecycle, state, zoom, and
   security policy.

--- a/apps/desktop/src/main/ipc/artifact-handlers.ts
+++ b/apps/desktop/src/main/ipc/artifact-handlers.ts
@@ -1,4 +1,3 @@
-import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
 import { listLocalArtifactIndex, listLocalSessionArtifacts, updateLocalArtifactStatus } from '@open-cowork/runtime-host/artifact-index'
 import electron from 'electron'
 import { resolve } from 'path'
@@ -30,6 +29,7 @@ import { buildArtifactAttachmentPayload, inferArtifactMime } from '../artifact-a
 import { getChartArtifactsRoot } from '../chart-artifacts.ts'
 import { cleanupSandboxStorage, getSandboxStorageStats } from '../sandbox-storage.ts'
 import { log } from '@open-cowork/shared/node'
+import { getLocalSessionPort } from '../local-workspace-session.ts'
 import { isReadableSessionArtifact } from '../session-artifact-access.ts'
 import { readWorkspaceIdOption } from '../workspace-gateway.ts'
 
@@ -146,10 +146,11 @@ function electronTempPath(app: typeof electron.app | null | undefined) {
   }
 }
 
-function isAuthorizedLocalArtifact(root: string, source: string, sessionId: string) {
+async function isAuthorizedLocalArtifact(root: string, source: string, sessionId: string) {
   const chartRoot = resolve(getChartArtifactsRoot(sessionId))
   if (root === safeRealPath(chartRoot)) return true
-  return isReadableSessionArtifact(sessionEngine.getSessionView(sessionId), source)
+  const view = await getLocalSessionPort().getSessionView(sessionId)
+  return isReadableSessionArtifact(view, source)
 }
 
 export function registerArtifactHandlers(context: IpcHandlerContext) {
@@ -211,7 +212,7 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
 
     const { root, source } = context.resolvePrivateArtifactPath(request)
     safeArtifactOpenFilename(basename(source), inferArtifactMime(source), basename(source))
-    if (!isAuthorizedLocalArtifact(root, source, request.sessionId)) {
+    if (!(await isAuthorizedLocalArtifact(root, source, request.sessionId))) {
       throw new Error('Only surfaced session artifacts can be opened directly.')
     }
     log('artifact', `Opened artifact ${basename(source)} from ${shortSessionId(request.sessionId)}`)
@@ -235,7 +236,7 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
     }
 
     const { root, source } = context.resolvePrivateArtifactPath(request)
-    if (!isAuthorizedLocalArtifact(root, source, request.sessionId)) {
+    if (!(await isAuthorizedLocalArtifact(root, source, request.sessionId))) {
       throw new Error('Only surfaced session artifacts can be exported.')
     }
 
@@ -256,7 +257,7 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
       throw new Error('Cloud artifacts cannot be revealed in the local filesystem. Export the artifact instead.')
     }
     const { root, source } = context.resolvePrivateArtifactPath(request)
-    if (!isAuthorizedLocalArtifact(root, source, request.sessionId)) {
+    if (!(await isAuthorizedLocalArtifact(root, source, request.sessionId))) {
       throw new Error('Only surfaced session artifacts can be revealed.')
     }
     shell.showItemInFolder(source)
@@ -270,7 +271,7 @@ export function registerArtifactHandlers(context: IpcHandlerContext) {
       return context.workspaceGateway.readCloudArtifactAttachment(event, request.sessionId, request.filePath, workspaceId)
     }
     const { root, source } = context.resolvePrivateArtifactPath(request)
-    if (!isAuthorizedLocalArtifact(root, source, request.sessionId)) {
+    if (!(await isAuthorizedLocalArtifact(root, source, request.sessionId))) {
       throw new Error('Only surfaced session artifacts can be attached to the thread.')
     }
     return buildArtifactAttachmentPayload(source)

--- a/apps/desktop/src/main/local-workspace-session.ts
+++ b/apps/desktop/src/main/local-workspace-session.ts
@@ -4,6 +4,13 @@
  * Adapts the process-local sessionEngine singleton behind the shared port so
  * high-traffic IPC can migrate off direct engine imports without inventing a
  * second session implementation.
+ *
+ * Scope today: only `getSessionView` is wired — that is what artifact-handlers
+ * need. Other core port methods (`createSession`, `listSessions`, `promptSession`,
+ * etc.) are intentionally unmapped: sessionEngine does not expose matching
+ * shapes, and inventing stubs would fake a full IPC cutover. Callers that need
+ * those operations still use sessionEngine (or cloud adapter) directly until a
+ * later progressive PR maps them.
  */
 import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
 import {
@@ -14,9 +21,9 @@ import {
 let localPort: WorkspaceSessionPort | null = null
 
 /**
- * Module-level local session port wrapping methods that exist on sessionEngine.
- * Full IPC cutover remains progressive; callers should prefer this over raw
- * sessionEngine for port-shaped surfaces (getSessionView first).
+ * Module-level local session port for progressive port-shaped surfaces.
+ * Currently: getSessionView only. Other core methods throw
+ * `Local WorkspaceSessionPort method not available` by design.
  */
 export function getLocalSessionPort(): WorkspaceSessionPort {
   if (!localPort) {

--- a/apps/desktop/src/main/local-workspace-session.ts
+++ b/apps/desktop/src/main/local-workspace-session.ts
@@ -1,0 +1,28 @@
+/**
+ * Progressive local WorkspaceSessionPort wiring (post-#961 hardening).
+ *
+ * Adapts the process-local sessionEngine singleton behind the shared port so
+ * high-traffic IPC can migrate off direct engine imports without inventing a
+ * second session implementation.
+ */
+import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
+import {
+  createLocalWorkspaceSessionPort,
+  type WorkspaceSessionPort,
+} from './workspace-session-port.ts'
+
+let localPort: WorkspaceSessionPort | null = null
+
+/**
+ * Module-level local session port wrapping methods that exist on sessionEngine.
+ * Full IPC cutover remains progressive; callers should prefer this over raw
+ * sessionEngine for port-shaped surfaces (getSessionView first).
+ */
+export function getLocalSessionPort(): WorkspaceSessionPort {
+  if (!localPort) {
+    localPort = createLocalWorkspaceSessionPort({
+      getSessionView: (sessionId) => sessionEngine.getSessionView(sessionId),
+    })
+  }
+  return localPort
+}

--- a/docs/evidence/gateway-multi-writer-hazards-2026-07-21.md
+++ b/docs/evidence/gateway-multi-writer-hazards-2026-07-21.md
@@ -1,8 +1,21 @@
 # Process-local multi-writer hazards inventory (JOE-948)
 
-**Date:** 2026-07-21
+**Date:** 2026-07-21 (reaffirmed 2026-07-23 post-#961 hardening)
 **Scope:** Durable Gateway (`products/gateway`) + Channel Gateway process-local maps
 **Related:** JOE-931, JOE-954, `products/gateway/docs/concepts/multi-daemon-scaling.md`
+**Proving registry:** `docs/development/distributed-ownership-proving-registry.json`
+
+## Current claim posture (fail-closed)
+
+| Claim | Status |
+| --- | --- |
+| Single daemon per state directory | **Supported** production shape |
+| Experimental multi-replica (`experimentalDistributedOwnership=true`) | **Lab-only** — Helm can set `replicaCount > 1`, but migrate hazards remain open |
+| Multi-AZ / production multi-replica HA | **Forbidden** until registry `status=ready` **and** `openMigrateHazards` is empty |
+
+**As of 2026-07-23:** registry `status=partial`, `openMigrateHazards: ["H1","H3","H4","H8","H13"]`.
+Experimental multi-replica **still fails** these open migrate hazards — do not market as HA.
+Doctor / readiness surface a non-blocking `multi_writer_ownership` check that reports this posture.
 
 ## Disposition legend
 

--- a/docs/evidence/post-961-master-full-audit-2026-07-23.md
+++ b/docs/evidence/post-961-master-full-audit-2026-07-23.md
@@ -131,10 +131,10 @@ Desktop sandbox + IPC sender checks; cloud CSRF + OIDC path-only returnTo; webho
 1. **#961 structural win:** `config.ts` and `daemon-routes/work.ts` under soft 1500 with real headroom (hard maxes now loose — should ratchet).  
 2. **Still soft-fail:** work-store, scheduler, cloud HTTP/app, desktop workspace-gateway.  
 3. **Unbudgeted gods:** `mcp.ts`, `channel-commands.ts`, `channel-sync.ts`.  
-4. **Import cycles:** monorepo SCAN_ROOTS = app + ui + shared only; runtime-host / cloud / desktop main unscanned.  
-5. **`createLocalWorkspaceSessionPort` exists** but **no production IPC wiring** (sessionEngine still direct).  
+4. **Import cycles:** monorepo SCAN_ROOTS = app + ui + shared only; runtime-host skipped on known cycle (see Hardening PR); cloud / desktop main still unscanned.  
+5. **`createLocalWorkspaceSessionPort`:** progressive IPC wiring started (`local-workspace-session` + artifact handlers); full IPC cutover still open.  
 6. **Dual-stack freeze honest**; protocol body still dual.  
-7. **Root knip ignores products/***; product-local knip not root-linted.
+7. **Root knip ignores products/***; product-local knip now CI-gated on gateway/wiki workflows (Hardening PR).
 
 ---
 
@@ -227,6 +227,25 @@ Private evidence campaign (load/soak/restore/failover/BYOK/support/cost/rollback
 - Ops explore (claims, CI, HA, private-beta, evals)  
 
 **Related evidence:** `post-959-master-full-audit-2026-07-22.md`, multi-writer hazards, channel security matrix, private-beta ops package, wiki surface audit.
+
+---
+
+## Hardening PR (progressive structural — branch `fix/post-961-hardening-p0-p3`)
+
+Follow-on hardening against this audit's P2 progressive + P3 pin/process items.
+Does **not** invent private-beta go or multi-AZ HA claims.
+
+| Close | Item | Notes |
+| --- | --- | --- |
+| P2-1 | Wire `createLocalWorkspaceSessionPort` | `apps/desktop/src/main/local-workspace-session.ts` + `artifact-handlers.ts` uses `getLocalSessionPort().getSessionView` (progressive; not full IPC rewrite) |
+| P2-4 (attempted) | Widen import-cycle `SCAN_ROOTS` | **Skipped** `packages/runtime-host/src` — known cycle `runtime → runtime-config-builder → custom-agents-utils → runtime-tools → runtime`; documented in `scripts/check-import-cycles.mjs` |
+| P2-5 | Wiki `tool-router` peel | Helpers → `tool-router-helpers.ts`; router ~643 LOC (under 650/800) |
+| P2-6 (docs + flag) | HA migrate hazards honesty | Hazards inventory + multi-daemon doc reaffirm experimental multi-replica still fails `openMigrateHazards`; readiness `multi_writer_ownership` + doctor line |
+| P3-6 | Product knip in CI | `ci-gateway.yml` runs `knip`; `ci-wiki.yml` runs `check:dead-code` |
+| P0 package | Private-beta validate | Still green; public decision remains **`no-go`** (no invented go) |
+| P3-1/2/4 | Docs reaffirm | Classic Won't Do, chart CSP, HTTPS MCP in `security-model.md`; Dependabot #960 superseded by monorepo override |
+
+**Still open (not this PR):** MCP `state_export` dual-intent (P1), route export integration tests, hard budget ratchets, full HA migrate code, full IPC port cutover, classic burn-down wait on pin >1.18.1.
 
 ---
 

--- a/docs/evidence/post-961-master-full-audit-2026-07-23.md
+++ b/docs/evidence/post-961-master-full-audit-2026-07-23.md
@@ -1,8 +1,8 @@
 # Full deep & wide codebase audit — post-#961 `master`
 
-**Date:** 2026-07-23  
-**HEAD:** `12320da7` (`fix(post-959): close P0–P3 audit residuals (#961)`)  
-**Prior audit:** `docs/evidence/post-959-master-full-audit-2026-07-22.md` (as-of #959 / `12e48c9c`)  
+**Date:** 2026-07-23
+**HEAD:** `12320da7` (`fix(post-959): close P0–P3 audit residuals (#961)`)
+**Prior audit:** `docs/evidence/post-959-master-full-audit-2026-07-22.md` (as-of #959 / `12e48c9c`)
 **Method:** Local quantitative gates + three parallel read-only deep audits (security, architecture, ops/claims). Skeptical re-check of #961 “closed” items against source.
 
 ---
@@ -128,12 +128,12 @@ Desktop sandbox + IPC sender checks; cloud CSRF + OIDC path-only returnTo; webho
 
 ## Architecture findings
 
-1. **#961 structural win:** `config.ts` and `daemon-routes/work.ts` under soft 1500 with real headroom (hard maxes now loose — should ratchet).  
-2. **Still soft-fail:** work-store, scheduler, cloud HTTP/app, desktop workspace-gateway.  
-3. **Unbudgeted gods:** `mcp.ts`, `channel-commands.ts`, `channel-sync.ts`.  
-4. **Import cycles:** monorepo SCAN_ROOTS = app + ui + shared only; runtime-host skipped on known cycle (see Hardening PR); cloud / desktop main still unscanned.  
-5. **`createLocalWorkspaceSessionPort`:** progressive IPC wiring started (`local-workspace-session` + artifact handlers); full IPC cutover still open.  
-6. **Dual-stack freeze honest**; protocol body still dual.  
+1. **#961 structural win:** `config.ts` and `daemon-routes/work.ts` under soft 1500 with real headroom (hard maxes now loose — should ratchet).
+2. **Still soft-fail:** work-store, scheduler, cloud HTTP/app, desktop workspace-gateway.
+3. **Unbudgeted gods:** `mcp.ts`, `channel-commands.ts`, `channel-sync.ts`.
+4. **Import cycles:** monorepo SCAN_ROOTS = app + ui + shared only; runtime-host skipped on known cycle (see Hardening PR); cloud / desktop main still unscanned.
+5. **`createLocalWorkspaceSessionPort`:** progressive IPC wiring started (`local-workspace-session` + artifact handlers); full IPC cutover still open.
+6. **Dual-stack freeze honest**; protocol body still dual.
 7. **Root knip ignores products/***; product-local knip now CI-gated on gateway/wiki workflows (Hardening PR).
 
 ---
@@ -196,11 +196,11 @@ Private evidence campaign (load/soak/restore/failover/BYOK/support/cost/rollback
 
 ## Non-claims (re-affirmed at HEAD)
 
-1. Multi-AZ HA / production multi-replica Durable Gateway  
-2. Hosted private-beta **go**  
-3. Full dual-stack **protocol** delete  
-4. Full Desktop classic SDK burn-down on pin 1.18.1  
-5. Public multi-tenant Wiki product readiness  
+1. Multi-AZ HA / production multi-replica Durable Gateway
+2. Hosted private-beta **go**
+3. Full dual-stack **protocol** delete
+4. Full Desktop classic SDK burn-down on pin 1.18.1
+5. Public multi-tenant Wiki product readiness
 
 **Do claim (accurate):** local/self-host beta; Durable V2 construction + session façade; pin lockstep 1.18.1; JOE-952 dual-intent on sensitive HTTP dumps; trusted-proxy webhook rate keys; soft-budget façades for config + work routes; empty advisory graph at this audit; public private-beta package COMPLETE with decision **no-go**.
 
@@ -221,10 +221,10 @@ Private evidence campaign (load/soak/restore/failover/BYOK/support/cost/rollback
 
 ## Method appendix
 
-- Local: `pnpm audit:*`, LOC inventories, all check scripts, residual greps  
-- Security explore (post-#961 remediations + residual hunt)  
-- Architecture explore (budgets, cycles, ports, dual-stack)  
-- Ops explore (claims, CI, HA, private-beta, evals)  
+- Local: `pnpm audit:*`, LOC inventories, all check scripts, residual greps
+- Security explore (post-#961 remediations + residual hunt)
+- Architecture explore (budgets, cycles, ports, dual-stack)
+- Ops explore (claims, CI, HA, private-beta, evals)
 
 **Related evidence:** `post-959-master-full-audit-2026-07-22.md`, multi-writer hazards, channel security matrix, private-beta ops package, wiki surface audit.
 

--- a/docs/evidence/post-961-master-full-audit-2026-07-23.md
+++ b/docs/evidence/post-961-master-full-audit-2026-07-23.md
@@ -237,15 +237,18 @@ Does **not** invent private-beta go or multi-AZ HA claims.
 
 | Close | Item | Notes |
 | --- | --- | --- |
+| P1 | MCP `state_export` dual-intent | Tool always hits `/storage/export?localAdmin=true` (tool invoke = operator intent) |
+| P1 | Route export dual-intent tests | `daemon-routes.test.ts` asserts 403 without intent / 200 with shape for storage export; session messages raw dual-intent |
+| P1 | Hard budget ratchets | `module-boundary-budget.json` fileLocBudgets ratcheted for work-store / config / scheduler / work routes after façade peels |
 | P2-1 | Wire `createLocalWorkspaceSessionPort` | `apps/desktop/src/main/local-workspace-session.ts` + `artifact-handlers.ts` uses `getLocalSessionPort().getSessionView` (progressive; not full IPC rewrite) |
 | P2-4 (attempted) | Widen import-cycle `SCAN_ROOTS` | **Skipped** `packages/runtime-host/src` — known cycle `runtime → runtime-config-builder → custom-agents-utils → runtime-tools → runtime`; documented in `scripts/check-import-cycles.mjs` |
 | P2-5 | Wiki `tool-router` peel | Helpers → `tool-router-helpers.ts`; router ~643 LOC (under 650/800) |
-| P2-6 (docs + flag) | HA migrate hazards honesty | Hazards inventory + multi-daemon doc reaffirm experimental multi-replica still fails `openMigrateHazards`; readiness `multi_writer_ownership` + doctor line |
+| P2-6 (docs + flag) | HA migrate hazards honesty | Hazards inventory + multi-daemon doc reaffirm experimental multi-replica still fails `openMigrateHazards`; readiness `multi_writer_ownership` + doctor line (shared registry loader) |
 | P3-6 | Product knip in CI | `ci-gateway.yml` runs `knip`; `ci-wiki.yml` runs `check:dead-code` |
 | P0 package | Private-beta validate | Still green; public decision remains **`no-go`** (no invented go) |
 | P3-1/2/4 | Docs reaffirm | Classic Won't Do, chart CSP, HTTPS MCP in `security-model.md`; Dependabot #960 superseded by monorepo override |
 
-**Still open (not this PR):** MCP `state_export` dual-intent (P1), route export integration tests, hard budget ratchets, full HA migrate code, full IPC port cutover, classic burn-down wait on pin >1.18.1.
+**Still open (not this PR):** full HA migrate code (open migrate hazards remain lab-only), full IPC port cutover beyond `getSessionView`, classic burn-down wait on pin >1.18.1, hosted private-beta **go**, dual-stack protocol delete.
 
 ---
 

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -43,9 +43,14 @@ belongs to the caller — pass it in as an argument rather than reaching upward.
 Circular import chains are the most common cause of fragile initialization
 order (`Cannot access 'X' before initialization`), un-tree-shakeable bundles,
 and confusing refactors. `scripts/check-import-cycles.mjs` statically scans the
-first-party **relative** imports inside `packages/app/src` and `packages/ui/src`
-and fails if any circular chain exists. The current cycle count is **zero** and
-the gate keeps it there.
+first-party **relative** imports inside the configured `SCAN_ROOTS` (`packages/app/src`,
+`packages/ui/src`, `packages/shared/src`) and fails if any circular chain exists.
+The current cycle count is **zero** and the gate keeps it there.
+
+**Widen note (post-#961 hardening):** `packages/runtime-host/src` was evaluated
+for inclusion but **skipped** because it still has a value-import cycle
+(`runtime` → `runtime-config-builder` → `custom-agents-utils` → `runtime-tools`
+→ `runtime`). Break that cycle before ratcheting `SCAN_ROOTS`.
 
 - Only value imports are considered — `import type` / `export type` are erased
   by the compiler and cannot form a runtime cycle.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -181,7 +181,7 @@ policy-validated resolved address while preserving the original `Host` header
 (`pinHttpMcpRemoteEntry` in `packages/runtime-host/src/runtime-mcp.ts`). That
 closes the DNS-rebinding window for HTTP.
 
-**HTTPS residual (accepted — still accepted post-#959):** OpenCode owns the TLS
+**HTTPS residual (accepted — reaffirmed post-#961 hardening):** OpenCode owns the TLS
 transport; IP-pinning would break SNI and certificate hostname checks, so
 `https:` MCPs stay hostname-based after the pre-connect DNS policy check
 (`evaluateHttpMcpUrlResolved` still rejects private/link-local/metadata
@@ -332,7 +332,7 @@ lifecycle, lease/fencing contract, recovery behavior, and threat model live in
 desktop main-window CSP keep `script-src 'self'` with **no** `'unsafe-eval'`.
 Interactive Vega must not execute in the parent document.
 
-**Chart iframe residual (accepted — still accepted post-#959):** Chart rendering
+**Chart iframe residual (accepted — reaffirmed post-#961 hardening):** Chart rendering
 uses Vega, which compiles its specs with `new Function()` (the reactive
 dataflow interpreter evaluates expressions at runtime). That means the **chart
 iframe** must allow `unsafe-eval` — there is no AOT path without reimplementing
@@ -490,6 +490,14 @@ URL credentials, or local home-directory paths.
   - Several CVE forces raise transitive dependencies past their patched
     versions (for example `dompurify`, `form-data`, `hono`, `js-yaml`, `qs`,
     `tar`, `tmp`, `undici`, and `vite`).
+  - **Dependabot PR #960** (dompurify 3.4.12 alone) was **superseded by the
+    monorepo `dompurify` override landed in #961**; close #960 if it is still
+    open rather than double-applying the bump.
+- **Classic OpenCode SDK full burn-down (Won't Do on pin 1.18.1):** Desktop
+  keeps an intentional classic allowlist residual while pinned to OpenCode
+  `1.18.1`. Full burn-down is **Won't Do** until a later pin grows native V2
+  routes for those residual methods — see `docs/opencode-classic-sdk-burndown.md`
+  and `docs/opencode-sdk-v2-boundary.md`.
 - Audit-gate exceptions: when an advisory that trips the CI audit gate has no
   fixed release yet, add only its `CVE-*` or `GHSA-*` identifier to
   `pnpm.auditConfig.ignoreCves` or `pnpm.auditConfig.ignoreGhsas` in the root

--- a/products/gateway/docs/api/http-api.md
+++ b/products/gateway/docs/api/http-api.md
@@ -71,7 +71,7 @@ Routes are currently served unprefixed and are treated as **v1**. A future `/v1`
 | `POST` | `/storage/backups` | Create a timestamped backup. Refuses while runs or starting dispatches are active unless `allowActiveRuns=true`; requires `admin` for non-local requests. |
 | `POST` | `/storage/backups/verify` | Verify backup metadata, checksums, and SQLite integrity. Requires `admin` for non-local requests. |
 | `POST` | `/storage/recovery-drills` | Restore a backup into isolated state and write scheduler/storage/channel recovery evidence. Requires `admin` for non-local requests. |
-| `GET` | `/storage/export` | Export durable Gateway state as JSON. Requires `admin` for non-local requests. |
+| `GET` | `/storage/export?localAdmin=true` | Export durable Gateway state as JSON. Requires `admin` for non-local requests **and** explicit `localAdmin=true` dual-intent (JOE-952; always treated as unredacted; rate-limited). |
 | `POST` | `/storage/restore` | Restore a verified backup; requires stopped daemon or `maintenanceMode=true`. Requires `admin` for non-local requests and a destructive human gate when approval gating is enabled; retry with `approvedGateId` after approval. |
 | `POST` | `/restart` | Request restart. Requires `admin` for non-local requests; the action is audited and no human approval gate applies. A service manager must be installed for the daemon to come back automatically. |
 | `POST` | `/shutdown` | Request shutdown. Requires `admin` for non-local requests; the action is audited and no human approval gate applies. |

--- a/products/gateway/docs/api/openapi.json
+++ b/products/gateway/docs/api/openapi.json
@@ -1457,7 +1457,7 @@
     },
     "/storage/export": {
       "get": {
-        "summary": "Export durable Gateway state as JSON. Requires admin for non-local requests.",
+        "summary": "Export durable Gateway state as JSON. Requires admin for non-local requests and localAdmin=true dual-intent (JOE-952; always unredacted; rate-limited).",
         "tags": [
           "Service"
         ],

--- a/products/gateway/docs/api/openapi.json
+++ b/products/gateway/docs/api/openapi.json
@@ -1467,12 +1467,27 @@
           }
         ],
         "x-required-capability": "admin",
+        "parameters": [
+          {
+            "name": "localAdmin",
+            "in": "query",
+            "required": true,
+            "description": "JOE-952 dual-intent. Must be true to export unredacted durable state. MCP state_export supplies this automatically because tool invocation is the operator intent.",
+            "schema": {
+              "type": "boolean",
+              "enum": [true]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful response"
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Forbidden — missing admin capability or localAdmin dual-intent"
+          },
+          "429": {
+            "description": "Rate limited (unredacted storage export budget)"
           }
         }
       }

--- a/products/gateway/docs/concepts/multi-daemon-scaling.md
+++ b/products/gateway/docs/concepts/multi-daemon-scaling.md
@@ -4,7 +4,9 @@ Status: accepted design record; implementation is future work. (This record date
 
 Gateway is currently a local, single-operator control plane. It can run unattended and recover work after restarts, but it is not yet a multi-host or hosted/team scheduler. This record defines what is true today, what architecture Gateway should grow toward next, and which state must become durable before more than one daemon can safely participate.
 
-**Operator runbook (audit 2026-07-21 / JOE-931):** Never run two full daemons against one state directory. The open-cowork Helm chart fails closed when `replicaCount > 1` unless experimental distributed ownership is explicitly enabled. Chart fail-closed must not be bypassed for production.
+**Operator runbook (audit 2026-07-21 / JOE-931; reaffirmed 2026-07-23):** Never run two full daemons against one state directory. The open-cowork Helm chart fails closed when `replicaCount > 1` unless experimental distributed ownership is explicitly enabled. Chart fail-closed must not be bypassed for production.
+
+**Experimental multi-replica still fails open migrate hazards.** Enabling `gateway.experimentalDistributedOwnership=true` is **lab-only**. While the proving registry reports `status=partial` and non-empty `openMigrateHazards` (`H1`, `H3`, `H4`, `H8`, `H13` as of 2026-07-23), multi-replica is **not** multi-AZ HA and must not be marketed as production-ready. See the [hazard inventory](../../../../docs/evidence/gateway-multi-writer-hazards-2026-07-21.md). Gateway doctor and `/readiness` include a non-blocking `multi_writer_ownership` check that reports open migrate hazards.
 
 **Follow-on design:** [Distributed ownership + fencing](distributed-ownership-design.md) (JOE-954).
 **Hazard inventory:** [gateway-multi-writer-hazards-2026-07-21](../../../../docs/evidence/gateway-multi-writer-hazards-2026-07-21.md) (JOE-948).

--- a/products/gateway/docs/development/module-boundary-budget.json
+++ b/products/gateway/docs/development/module-boundary-budget.json
@@ -815,9 +815,9 @@
  "fileLocBudgets": [
   {
    "path": "src/work-store.ts",
-   "maxLines": 1500,
+   "maxLines": 1550,
    "owner": "work_store",
-   "note": "Hard LOC budget (JOE-919/JOE-942); post-#961 project-orchestration extract; hard max ratcheted to soft \u22641500 (~1497)"
+   "note": "Hard LOC budget (JOE-919/JOE-942); post-#961 project-orchestration extract; hard max 1550 (soft \u22641500); current ~1497 — leave drive-by headroom like work routes"
   },
   {
    "path": "src/environments.ts",

--- a/products/gateway/docs/development/module-boundary-budget.json
+++ b/products/gateway/docs/development/module-boundary-budget.json
@@ -6,8 +6,8 @@
  "sourceRoot": "src",
  "dependencyBudget": {
   "includeTests": false,
-  "maxModuleCount": 243,
-  "maxEdgeCount": 1080,
+  "maxModuleCount": 247,
+  "maxEdgeCount": 1120,
   "maxCycleComponents": 0,
   "maxCycleComponentSize": 4,
   "knownCycles": []
@@ -19,6 +19,7 @@
    "changeRule": "Change orchestration calculations in the kernel before adapting scheduler or route execution code.",
    "ownerModules": [
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/orchestration-kernel.ts",
     "src/capacity.ts"
    ],
@@ -47,7 +48,8 @@
     "src/work-store/validators.ts",
     "src/work-store/queries.ts",
     "src/work-store/db.ts",
-    "src/work-store/row-mappers.ts"
+    "src/work-store/row-mappers.ts",
+    "src/work-store/project-orchestration.ts"
    ],
    "edgeAdapters": [
     "src/storage.ts",
@@ -59,7 +61,9 @@
     "src/storage/integrity.ts",
     "src/storage/drills.ts",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts",
     "src/agent-presence.ts",
     "src/persona.ts"
    ],
@@ -80,6 +84,7 @@
    "ownerModules": [
     "src/channel-actions.ts",
     "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts",
     "src/channels/capabilities.ts",
     "src/channels/renderer.ts",
     "src/channels/provider.ts"
@@ -186,6 +191,7 @@
    "edgeAdapters": [
     "src/dashboard.ts",
     "src/mcp.ts",
+    "src/mcp-tools-ops.ts",
     "src/daemon-routes/system.ts"
    ],
    "primaryTests": [
@@ -294,6 +300,7 @@
    "from": [
     "src/channel-actions.ts",
     "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts",
     "src/channels/capabilities.ts",
     "src/channels/renderer.ts",
     "src/channels/provider.ts"
@@ -317,11 +324,13 @@
    ],
    "blocked": [
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/daemon.ts",
     "src/daemon-router.ts",
     "src/daemon-routes/**",
     "src/dashboard.ts",
     "src/mcp.ts",
+    "src/mcp-tools-ops.ts",
     "src/mission-data.ts"
    ],
    "exceptions": []
@@ -337,6 +346,7 @@
    ],
    "blocked": [
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/cli.ts",
     "src/daemon.ts",
     "src/daemon-router.ts",
@@ -344,7 +354,8 @@
     "src/channels/**",
     "src/channel-sync.ts",
     "src/dashboard.ts",
-    "src/mcp.ts"
+    "src/mcp.ts",
+    "src/mcp-tools-ops.ts"
    ],
    "exceptions": []
   },
@@ -360,6 +371,7 @@
     "src/work-store.ts",
     "src/work-store/**",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/storage.ts",
     "src/wakeup.ts",
     "src/workers.ts",
@@ -383,6 +395,7 @@
     "src/work-store.ts",
     "src/work-store/**",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/storage.ts",
     "src/channel-sync.ts",
     "src/channels/telegram.ts",
@@ -390,6 +403,7 @@
     "src/channels/discord.ts",
     "src/dashboard.ts",
     "src/mcp.ts",
+    "src/mcp-tools-ops.ts",
     "src/daemon.ts",
     "src/daemon-router.ts",
     "src/daemon-routes/**"
@@ -406,6 +420,7 @@
    ],
    "blocked": [
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/capacity.ts",
     "src/workers.ts",
     "src/daemon.ts",
@@ -415,7 +430,8 @@
     "src/channels/whatsapp.ts",
     "src/channels/discord.ts",
     "src/dashboard.ts",
-    "src/mcp.ts"
+    "src/mcp.ts",
+    "src/mcp-tools-ops.ts"
    ],
    "exceptions": []
   },
@@ -433,9 +449,11 @@
     "src/work-store/**",
     "src/storage.ts",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/capacity.ts",
     "src/workers.ts",
     "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts",
     "src/channel-sync.ts",
     "src/channels/telegram.ts",
     "src/channels/whatsapp.ts",
@@ -443,7 +461,8 @@
     "src/daemon.ts",
     "src/daemon-router.ts",
     "src/daemon-routes/**",
-    "src/mcp.ts"
+    "src/mcp.ts",
+    "src/mcp-tools-ops.ts"
    ],
    "exceptions": []
   },
@@ -453,16 +472,19 @@
    "reason": "MCP tools are local edge surfaces; they must authorize, call daemon endpoints, and format typed view-model data rather than importing mutable storage, scheduler, dashboard, or provider-adapter owners.",
    "reviewCondition": "Expose behavior through a daemon route, security policy, or Mission Control view model before wiring a new MCP tool.",
    "from": [
-    "src/mcp.ts"
+    "src/mcp.ts",
+    "src/mcp-tools-ops.ts"
    ],
    "blocked": [
     "src/work-store.ts",
     "src/work-store/**",
     "src/storage.ts",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/capacity.ts",
     "src/workers.ts",
     "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts",
     "src/channel-sync.ts",
     "src/channels/telegram.ts",
     "src/channels/whatsapp.ts",
@@ -489,6 +511,7 @@
     "src/channels/whatsapp.ts",
     "src/channels/discord.ts",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/daemon-routes/**"
    ],
    "exceptions": []
@@ -507,6 +530,7 @@
     "src/work-store/**",
     "src/storage.ts",
     "src/scheduler.ts",
+    "src/scheduler-helpers.ts",
     "src/capacity.ts",
     "src/workers.ts",
     "src/daemon.ts",
@@ -515,6 +539,7 @@
     "src/dashboard/**",
     "src/dashboard.ts",
     "src/mcp.ts",
+    "src/mcp-tools-ops.ts",
     "src/channels/telegram.ts",
     "src/channels/whatsapp.ts",
     "src/channels/discord.ts",
@@ -536,7 +561,8 @@
     "src/channels/telegram.ts",
     "src/channels/whatsapp.ts",
     "src/channels/discord.ts",
-    "src/channel-commands.ts"
+    "src/channel-commands.ts",
+    "src/channel-commands-helpers.ts"
    ],
    "exceptions": []
   }
@@ -730,7 +756,7 @@
     "ownerCategory": "daemon_cli_edge",
     "growthKind": "runtime",
     "rationale": "Extract work-presentation helpers and config schema/normalize leaves so work.ts and config.ts stay under soft LOC target 1500 without expanding release claims.",
-    "consolidationPath": "Keep leaves pure; consumers continue to import façades (workRoutes/config) unless a second extraction needs direct leaf imports."
+    "consolidationPath": "Keep leaves pure; consumers continue to import fa\u00e7ades (workRoutes/config) unless a second extraction needs direct leaf imports."
    },
    {
     "id": "post_959_facade_loc_remediation_edges",
@@ -741,8 +767,32 @@
     "delta": 30,
     "ownerCategory": "daemon_cli_edge",
     "growthKind": "runtime",
-    "rationale": "work.ts→work-presentation and config.ts→config-schema/config-normalize plus presentation helper imports increase graph edges during LOC façade split.",
-    "consolidationPath": "Prefer keeping presentation helpers behind workRoutes; collapse duplicate façade re-export edges if leaves stabilize."
+    "rationale": "work.ts\u2192work-presentation and config.ts\u2192config-schema/config-normalize plus presentation helper imports increase graph edges during LOC fa\u00e7ade split.",
+    "consolidationPath": "Prefer keeping presentation helpers behind workRoutes; collapse duplicate fa\u00e7ade re-export edges if leaves stabilize."
+   },
+   {
+    "id": "post_961_facade_loc_hardening_modules",
+    "issue": "POST-961-P0-P3",
+    "metric": "module_count",
+    "previous": 243,
+    "current": 247,
+    "delta": 4,
+    "ownerCategory": "runtime_scheduler",
+    "growthKind": "runtime",
+    "rationale": "Extract scheduler-helpers, work-store/project-orchestration, mcp-tools-ops, and channel-commands-helpers so god fa\u00e7ades approach soft LOC 1500 without expanding release claims.",
+    "consolidationPath": "Keep leaves pure/orchestration-only; consumers continue to import fa\u00e7ades (scheduler/work-store/mcp/channel-commands) unless a second extraction needs direct leaf imports."
+   },
+   {
+    "id": "post_961_facade_loc_hardening_edges",
+    "issue": "POST-961-P0-P3",
+    "metric": "edge_count",
+    "previous": 1080,
+    "current": 1120,
+    "delta": 40,
+    "ownerCategory": "runtime_scheduler",
+    "growthKind": "runtime",
+    "rationale": "Fa\u00e7ade\u2192leaf imports for scheduler, work-store orchestration, MCP ops tools, and channel-command helpers increase graph edges during LOC split.",
+    "consolidationPath": "Prefer fa\u00e7ade re-exports; collapse duplicate re-export edges if leaves stabilize."
    }
   ],
   "directionalImportPilots": [
@@ -765,33 +815,51 @@
  "fileLocBudgets": [
   {
    "path": "src/work-store.ts",
-   "maxLines": 2000,
+   "maxLines": 1500,
    "owner": "work_store",
-   "note": "Hard LOC budget (JOE-919/JOE-942); current ~1956 after state-io + event-queries + final helper moves; at ≤2000 target"
+   "note": "Hard LOC budget (JOE-919/JOE-942); post-#961 project-orchestration extract; hard max ratcheted to soft \u22641500 (~1497)"
   },
   {
    "path": "src/environments.ts",
    "maxLines": 1300,
    "owner": "environments",
-   "note": "Hard LOC budget (JOE-919/JOE-936); current ~1262 after util/lifecycle/local-container/remote-crabbox extract; ≤2000"
+   "note": "Hard LOC budget (JOE-919/JOE-936); current ~1262 after util/lifecycle/local-container/remote-crabbox extract; \u22642000"
   },
   {
    "path": "src/config.ts",
-   "maxLines": 1800,
+   "maxLines": 1500,
    "owner": "config",
-   "note": "Hard LOC budget (JOE-919); current ~1408 after config-schema + config-normalize extract; soft target ≤1500"
+   "note": "Hard LOC budget (JOE-919); post-#961 extract ratcheted hard max to soft target \u22641500; current ~1407"
   },
   {
    "path": "src/scheduler.ts",
-   "maxLines": 1820,
+   "maxLines": 1500,
    "owner": "scheduler_replay",
-   "note": "Hard LOC budget (JOE-919); current 1800 lines; under 2000"
+   "note": "Hard LOC budget (JOE-919); post-#961 scheduler-helpers extract; hard max ratcheted to soft \u22641500 (~1461)"
   },
   {
    "path": "src/daemon-routes/work.ts",
-   "maxLines": 1960,
+   "maxLines": 1550,
    "owner": "scheduler_replay",
-   "note": "Hard LOC budget (JOE-919); current ~1495 after work-presentation extract; soft target ≤1500"
+   "note": "Hard LOC budget (JOE-919); post-#961 work-presentation extract; hard max ratcheted to 1550 (soft \u22641500); current ~1495"
+  },
+  {
+   "path": "src/mcp.ts",
+   "maxLines": 1650,
+   "owner": "daemon_cli_edge",
+   "note": "Hard LOC budget (post-#961); mcp-tools-ops extract for backup/storage tools; current ~1614 under 1650 hard max"
+  },
+  {
+   "path": "src/channel-commands.ts",
+   "maxLines": 1450,
+   "owner": "channels",
+   "note": "Hard LOC budget (post-#961); channel-commands-helpers extract; current ~1300 under soft 1400 / hard 1450"
+  },
+  {
+   "path": "src/channel-sync.ts",
+   "maxLines": 1100,
+   "owner": "channels",
+   "note": "Hard LOC budget (post-#961); current ~1004; HA migrate residual H1 surface"
   }
  ]
 }

--- a/products/gateway/src/__tests__/daemon-routes.test.ts
+++ b/products/gateway/src/__tests__/daemon-routes.test.ts
@@ -1122,7 +1122,14 @@ describe.sequential('daemon JSON routes', () => {
 
     const allowed = await dispatchRoute(routes, context('GET', '/storage/export?localAdmin=true'))
     expect(allowed?.status).toBe(200)
-    expect(allowed?.body).toBeTruthy()
+    const body = allowed?.body as Record<string, unknown>
+    expect(body).toEqual(expect.objectContaining({
+      exportedAt: expect.any(String),
+      state: expect.anything(),
+      channelBindings: expect.any(Array),
+      recentEvents: expect.any(Array),
+    }))
+    expect(Number.isFinite(Date.parse(String(body['exportedAt'])))).toBe(true)
   })
 
   it('defaults session messages to redacted and requires dual-intent for raw messages', async () => {

--- a/products/gateway/src/__tests__/daemon-routes.test.ts
+++ b/products/gateway/src/__tests__/daemon-routes.test.ts
@@ -1115,6 +1115,48 @@ describe.sequential('daemon JSON routes', () => {
     expect((deniedEvidence?.body as any).error).toBe('localAdmin intent required')
   })
 
+  it('requires localAdmin dual-intent for storage export and allows with intent', async () => {
+    const denied = await dispatchRoute(routes, context('GET', '/storage/export'))
+    expect(denied?.status).toBe(403)
+    expect((denied?.body as any).error).toBe('localAdmin intent required')
+
+    const allowed = await dispatchRoute(routes, context('GET', '/storage/export?localAdmin=true'))
+    expect(allowed?.status).toBe(200)
+    expect(allowed?.body).toBeTruthy()
+  })
+
+  it('defaults session messages to redacted and requires dual-intent for raw messages', async () => {
+    const client = {
+      session: {
+        messages: async () => ({
+          data: [
+            { id: 'm1', role: 'user', content: 'token=secret-transcript-value' },
+          ],
+        }),
+      },
+    }
+    const redacted = await dispatchRoute(routes, {
+      ...context('GET', '/opencode/sessions/ses_msg/messages'),
+      client,
+    })
+    expect(redacted?.status).toBe(200)
+    expect(JSON.stringify(redacted?.body)).not.toContain('secret-transcript-value')
+
+    const denied = await dispatchRoute(routes, {
+      ...context('GET', '/opencode/sessions/ses_msg/messages?raw=true'),
+      client,
+    })
+    expect(denied?.status).toBe(403)
+    expect((denied?.body as any).error).toBe('localAdmin intent required')
+
+    const raw = await dispatchRoute(routes, {
+      ...context('GET', '/opencode/sessions/ses_msg/messages?raw=true&localAdmin=true'),
+      client,
+    })
+    expect(raw?.status).toBe(200)
+    expect(JSON.stringify(raw?.body)).toContain('secret-transcript-value')
+  })
+
   it('exposes roadmap supervisor CRUD routes', async () => {
     const roadmap = createRoadmap({ title: 'HTTP supervised project' })
 

--- a/products/gateway/src/__tests__/gateway-catalog-inventory.test.ts
+++ b/products/gateway/src/__tests__/gateway-catalog-inventory.test.ts
@@ -6,25 +6,30 @@ import { GATEWAY_TOOL_CATALOG, GATEWAY_TOOL_GROUPS, buildGatewayToolCatalog, for
 import { classifyGatewayTool } from '../mcp-tool-tiers.js'
 
 /**
- * Every tool registered in src/mcp.ts, including the task_/project_ lifecycle
- * families registered via loops. The literal `server.tool('name'` matches plus
- * the two documented loop families give the full runtime surface.
+ * Every tool registered in src/mcp.ts + src/mcp-tools-ops.ts, including the
+ * task_/project_ lifecycle families registered via loops. The literal
+ * `server.tool('name'` matches plus the two documented loop families give the
+ * full runtime surface.
  */
 function registeredToolNames(): string[] {
   const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
-  const source = fs.readFileSync(path.join(repoRoot, 'src', 'mcp.ts'), 'utf-8')
+  const sources = ['mcp.ts', 'mcp-tools-ops.ts'].map((file) =>
+    fs.readFileSync(path.join(repoRoot, 'src', file), 'utf-8'),
+  )
   const names = new Set<string>()
-  for (const match of source.matchAll(/server\.tool\(\s*'([a-z0-9_]+)'/g)) names.add(match[1]!)
-  // Loop-registered families use template literals, not string literals.
-  for (const match of source.matchAll(/for \(const action of \[([^\]]+)\] as const\) \{\s*server\.tool\(`([a-z]+)_\$\{action\}`/g)) {
-    const actions = [...match[1]!.matchAll(/'([a-z]+)'/g)].map(m => m[1]!)
-    for (const action of actions) names.add(`${match[2]}_${action}`)
+  for (const source of sources) {
+    for (const match of source.matchAll(/server\.tool\(\s*'([a-z0-9_]+)'/g)) names.add(match[1]!)
+    // Loop-registered families use template literals, not string literals.
+    for (const match of source.matchAll(/for \(const action of \[([^\]]+)\] as const\) \{\s*server\.tool\(`([a-z]+)_\$\{action\}`/g)) {
+      const actions = [...match[1]!.matchAll(/'([a-z]+)'/g)].map(m => m[1]!)
+      for (const action of actions) names.add(`${match[2]}_${action}`)
+    }
   }
   return [...names].sort()
 }
 
 describe('Gateway MCP tool catalog', () => {
-  it('covers exactly the tools registered in src/mcp.ts', () => {
+  it('covers exactly the tools registered in src/mcp.ts + mcp-tools-ops.ts', () => {
     const catalogNames = GATEWAY_TOOL_CATALOG.map(entry => entry.name).sort()
     expect(catalogNames).toEqual(registeredToolNames())
   })

--- a/products/gateway/src/__tests__/gateway-tools.test.ts
+++ b/products/gateway/src/__tests__/gateway-tools.test.ts
@@ -7,8 +7,12 @@ import { GATEWAY_MCP_TOOL_NAMES } from '../gateway-tools.js'
 describe('Gateway MCP tool inventory', () => {
   it('matches registered MCP tool names used for access inspection', () => {
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
-    const mcpSource = fs.readFileSync(path.join(repoRoot, 'src', 'mcp.ts'), 'utf-8')
-    const registered = [...mcpSource.matchAll(new RegExp("server\\.tool\\('([^']+)'", 'g'))].map(match => `gateway_${match[1]}`).sort()
+    const sources = ['mcp.ts', 'mcp-tools-ops.ts'].map((file) =>
+      fs.readFileSync(path.join(repoRoot, 'src', file), 'utf-8'),
+    )
+    const registered = sources
+      .flatMap((source) => [...source.matchAll(new RegExp("server\\.tool\\('([^']+)'", 'g'))].map((match) => `gateway_${match[1]}`))
+      .sort()
 
     expect([...GATEWAY_MCP_TOOL_NAMES].sort()).toEqual(registered)
   })

--- a/products/gateway/src/__tests__/module-boundaries.test.ts
+++ b/products/gateway/src/__tests__/module-boundaries.test.ts
@@ -49,9 +49,9 @@ describe('module boundary budget', () => {
           edgeDelta: 12,
         },
         runtimeRisk: {
-          // Types extraction (audit 2026-07-21) + work/config façade LOC split (post-959).
-          moduleDelta: 15,
-          edgeDelta: 110,
+          // Types extraction (audit 2026-07-21) + work/config façade LOC split (post-959) + post-961 façade extracts.
+          moduleDelta: 19,
+          edgeDelta: 150,
         },
       },
     })

--- a/products/gateway/src/channel-commands-helpers.ts
+++ b/products/gateway/src/channel-commands-helpers.ts
@@ -1,0 +1,166 @@
+/**
+ * Pure channel-command helpers (LOC façade split).
+ * Leaf relative to channel-commands.ts — parse, format, and pure classification live here.
+ */
+import type { ChannelMessage } from './channels/provider.js'
+import type { ChannelSessionLink } from './channel-sessions.js'
+import type { OperatorDecisionSummary } from './operator-decisions.js'
+import type { WorkTaskView } from './work-store.js'
+
+export interface ParsedChannelCommand {
+  name: string
+  args: string[]
+  rest: string
+}
+
+export interface ChannelCommandAction {
+  label: string
+  command: string
+  description: string
+}
+
+export function parseChannelCommand(text: string): ParsedChannelCommand | null {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('/')) return null
+  const [raw = '', ...args] = trimmed.split(/\s+/)
+  const name = raw.slice(1).split('@')[0]!.toLowerCase().replace(/_/g, '-')
+  return { name, args, rest: trimmed.slice(raw.length).trim() }
+}
+
+export function isChannelCommandMenuRequest(commandName: string): boolean {
+  return ['help', 'start', 'commands'].includes(commandName)
+}
+
+export function isPreTrustChannelCommandText(text: string): boolean {
+  const command = parseChannelCommand(text)
+  if (!command) return false
+  return command.name === 'whereami' || isChannelCommandMenuRequest(command.name)
+}
+
+export function channelBindingSystemContext(binding?: ChannelSessionLink): string {
+  if (!binding) return ''
+  if (binding.mode === 'task' && binding.taskId) return `This channel is bound to Gateway Issue ${binding.taskId}. Keep replies focused on that Issue unless the user asks otherwise.`
+  if (binding.mode === 'roadmap' && binding.roadmapId) return `This channel is bound to Gateway Project ${binding.roadmapId}. Keep replies focused on that Project unless the user asks otherwise.`
+  return ''
+}
+
+export function formatCompletionProposal(proposal: { id: string; roadmapId: string; recommendation: string; unresolvedRisks: string[]; evidence: string[] }): string {
+  return `Project completion proposal ${proposal.id}: ${proposal.roadmapId}\nRecommendation: ${proposal.recommendation}\nProof: ${proposal.evidence.length}; risks: ${proposal.unresolvedRisks.length}\nAction: /completion approve ${proposal.id} OR /completion reject ${proposal.id} [note]`
+}
+
+export function formatProjectBinding(binding: { alias: string; roadmapId: string; scope: string; provider?: string; chatId?: string; threadId?: string }): string {
+  const channel = binding.provider && binding.chatId ? ` ${binding.provider}:${binding.chatId}${binding.threadId ? `:${binding.threadId}` : ''}` : ''
+  return `- ${binding.alias} -> ${binding.roadmapId} (${binding.scope}${channel})`
+}
+
+export function bindingMatches(binding: ChannelSessionLink, kind: string, id: string): boolean {
+  if (kind === 'task') return binding.mode === 'task' && binding.taskId === id
+  if (kind === 'roadmap') return binding.mode === 'roadmap' && binding.roadmapId === id
+  return false
+}
+
+export function describeChannelBinding(binding: ChannelSessionLink): string {
+  if (binding.mode === 'task' && binding.taskId) return `Issue ${binding.taskId} (Session ${binding.sessionId})`
+  if (binding.mode === 'roadmap' && binding.roadmapId) return `Project ${binding.roadmapId} (Session ${binding.sessionId})`
+  return `Session ${binding.sessionId}`
+}
+
+export function displayBindingMode(mode?: string): string {
+  if (mode === 'task') return 'issue'
+  if (mode === 'roadmap') return 'project'
+  return mode || 'session'
+}
+
+export function formatTaskSummary(task: WorkTaskView): string[] {
+  return [
+    `Issue: ${task.title}`,
+    `ID: ${task.id}`,
+    `Status: ${task.status}`,
+    `Priority: ${task.priority}`,
+    `Stage: ${task.currentStage || 'complete'}`,
+    task.lastRun ? `Latest run: ${task.lastRun.status} ${task.lastRun.stage} (${task.lastRun.id})` : 'Latest run: none',
+  ]
+}
+
+export const READ_ONLY_CHANNEL_COMMANDS = new Set([
+  'help', 'start', 'commands', 'whereami',
+  'status', 'current', 'open', 'latest',
+  'tasks', 'issues', 'roadmaps', 'initiatives',
+  'governance', 'budget', 'attention', 'needs-attention',
+  'gates', 'alerts', 'incident', 'questions', 'permissions', 'digest',
+])
+
+export const READ_ONLY_PROJECT_ACTIONS = new Set(['status', 'digest', 'decisions', 'open'])
+
+export function isPrivilegedChannelAction(command: ParsedChannelCommand): boolean {
+  if (READ_ONLY_CHANNEL_COMMANDS.has(command.name)) return false
+  if (command.name === 'session' || command.name === 'sessions') {
+    const action = command.args[0] || 'list'
+    // Listing is read-only; select/switch rebinds this chat and stays privileged.
+    return action !== 'list' && action !== 'recent'
+  }
+  if (command.name === 'scheduler') return (command.args[0] || 'status') !== 'status'
+  if (command.name === 'completion' || command.name === 'complete') {
+    const action = command.args[0] || 'list'
+    return action !== 'list' && action !== 'status'
+  }
+  if (command.name === 'project' || command.name === 'p') {
+    return !READ_ONLY_PROJECT_ACTIONS.has(command.args[0] || 'status')
+  }
+  // Everything else — including unknown/new commands — is privileged by default.
+  return true
+}
+
+export function commandOperation(command: ParsedChannelCommand): string {
+  if (command.name === 'approve' || command.name === 'deny') return 'opencode_permission.reply'
+  if (command.name === 'answer' || command.name === 'reject-question') return 'opencode_question.reply'
+  return `${command.name}${command.args[0] ? `.${command.args[0]}` : ''}`.substring(0, 120)
+}
+
+export function isExpired(iso: string | undefined, nowMs = Date.now()): boolean {
+  const expires = Date.parse(iso || '')
+  return Number.isFinite(expires) && expires <= nowMs
+}
+
+export function isClockTime(value: string | undefined): value is string {
+  return typeof value === 'string' && /^([01]?\d|2[0-3]):[0-5]\d$/.test(value)
+}
+
+export function formatChannelDecisionHint(decision: OperatorDecisionSummary): string {
+  return [
+    `Decision owner: ${formatDecisionOwner(decision)}; State: ${decision.state}.`,
+    `Authority: ${decision.authority}`,
+    `Next action: ${decision.safeNextAction}`,
+    `Evidence: ${decision.evidenceRef}`,
+  ].join('\n')
+}
+
+export function formatDecisionOwner(decision: OperatorDecisionSummary): string {
+  if (decision.owner === 'opencode') return 'OpenCode'
+  if (decision.owner === 'gateway') return 'Gateway'
+  return 'Gateway channel security'
+}
+
+export function isActionDenial(reply: string): boolean {
+  return reply.startsWith('Action denied:')
+}
+
+export function gatewaySessionTitle(msg: Pick<ChannelMessage, 'provider' | 'chatId' | 'threadId'>, title: string): string {
+  const thread = msg.threadId ? `:${msg.threadId}` : ''
+  return `GW:${msg.provider}:${msg.chatId}${thread}: ${title}`.substring(0, 200)
+}
+
+export function cleanTitle(title: string | undefined): string | undefined {
+  return title?.replace(/^GW:/, '').trim()
+}
+
+export function channelPreTrustHelpText(): string {
+  return [
+    'Gateway setup',
+    '',
+    'This channel is not trusted yet, so only setup-safe commands are available.',
+    'Ask the local operator to create a Gateway channel claim for this provider, then send the displayed claim code here before it expires.',
+    '',
+    'Safe before trust: /start, /help, /commands, /whereami.',
+  ].join('\n')
+}

--- a/products/gateway/src/channel-commands.ts
+++ b/products/gateway/src/channel-commands.ts
@@ -16,18 +16,36 @@ import { channelTargetFingerprint, isTrustedChannelActor, isTrustedChannelTarget
 import { decideChannelCommandSecurityPolicy, summarizeSecurityPolicyDecision } from './security-policy.js'
 import { channelActionMenuItems, formatChannelUxTruthForHelp } from './channel-actions.js'
 import { channelActionDeniedDecision, type OperatorDecisionSummary } from './operator-decisions.js'
+import {
+  bindingMatches,
+  channelPreTrustHelpText,
+  cleanTitle,
+  commandOperation,
+  describeChannelBinding,
+  displayBindingMode,
+  formatChannelDecisionHint,
+  formatCompletionProposal,
+  formatProjectBinding,
+  formatTaskSummary,
+  gatewaySessionTitle,
+  isActionDenial,
+  isChannelCommandMenuRequest,
+  isClockTime,
+  isExpired,
+  isPrivilegedChannelAction,
+  parseChannelCommand,
+  type ChannelCommandAction,
+  type ParsedChannelCommand,
+} from './channel-commands-helpers.js'
 
-export interface ParsedChannelCommand {
-  name: string
-  args: string[]
-  rest: string
-}
-
-export interface ChannelCommandAction {
-  label: string
-  command: string
-  description: string
-}
+export type { ParsedChannelCommand, ChannelCommandAction } from './channel-commands-helpers.js'
+export {
+  parseChannelCommand,
+  isChannelCommandMenuRequest,
+  isPreTrustChannelCommandText,
+  channelPreTrustHelpText,
+  channelBindingSystemContext,
+} from './channel-commands-helpers.js'
 
 export interface ChannelCommandClient {
   session: {
@@ -42,13 +60,6 @@ const ACTION_RECEIPT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
 const CHANNEL_ACTION_RECEIPT_EVENT = 'channel.action.accepted'
 const projectBindings = createSqliteWorkStoreBindingsPort()
 
-export function parseChannelCommand(text: string): ParsedChannelCommand | null {
-  const trimmed = text.trim()
-  if (!trimmed.startsWith('/')) return null
-  const [raw = '', ...args] = trimmed.split(/\s+/)
-  const name = raw.slice(1).split('@')[0]!.toLowerCase().replace(/_/g, '-')
-  return { name, args, rest: trimmed.slice(raw.length).trim() }
-}
 
 export async function handleChannelCommand(client: ChannelCommandClient, msg: ChannelMessage): Promise<string | null> {
   const command = parseChannelCommand(msg.text)
@@ -227,34 +238,6 @@ export function channelCommandHelpText(): string {
 
 export function channelCommandMenuActions(): ChannelCommandAction[] {
   return channelActionMenuItems()
-}
-
-export function isChannelCommandMenuRequest(commandName: string): boolean {
-  return ['help', 'start', 'commands'].includes(commandName)
-}
-
-export function isPreTrustChannelCommandText(text: string): boolean {
-  const command = parseChannelCommand(text)
-  if (!command) return false
-  return command.name === 'whereami' || isChannelCommandMenuRequest(command.name)
-}
-
-export function channelPreTrustHelpText(): string {
-  return [
-    'Gateway setup',
-    '',
-    'This channel is not trusted yet, so only setup-safe commands are available.',
-    'Ask the local operator to create a Gateway channel claim for this provider, then send the displayed claim code here before it expires.',
-    '',
-    'Safe before trust: /start, /help, /commands, /whereami.',
-  ].join('\n')
-}
-
-export function channelBindingSystemContext(binding?: ChannelSessionLink): string {
-  if (!binding) return ''
-  if (binding.mode === 'task' && binding.taskId) return `This channel is bound to Gateway Issue ${binding.taskId}. Keep replies focused on that Issue unless the user asks otherwise.`
-  if (binding.mode === 'roadmap' && binding.roadmapId) return `This channel is bound to Gateway Project ${binding.roadmapId}. Keep replies focused on that Project unless the user asks otherwise.`
-  return ''
 }
 
 async function newSession(client: ChannelCommandClient, msg: ChannelMessage, title: string): Promise<string> {
@@ -550,10 +533,6 @@ function completionCommand(args: string[], msg: ChannelMessage): string {
   return [`Completion ${action}: ${result.proposal.id}`, `Status: ${result.proposal.status}`, result.roadmap ? `Project: ${result.roadmap.title} (${result.roadmap.status})` : ''].filter(Boolean).join('\n')
 }
 
-function formatCompletionProposal(proposal: { id: string; roadmapId: string; recommendation: string; unresolvedRisks: string[]; evidence: string[] }): string {
-  return `Project completion proposal ${proposal.id}: ${proposal.roadmapId}\nRecommendation: ${proposal.recommendation}\nProof: ${proposal.evidence.length}; risks: ${proposal.unresolvedRisks.length}\nAction: /completion approve ${proposal.id} OR /completion reject ${proposal.id} [note]`
-}
-
 async function projectCommand(client: ChannelCommandClient, msg: ChannelMessage, args: string[]): Promise<string> {
   const action = args[0] || 'status'
   if (action === 'create') return createProject(client, msg, args.slice(1))
@@ -713,10 +692,6 @@ function updateCurrentProjectBinding(msg: ChannelMessage, alias?: string) {
   return binding
 }
 
-function isClockTime(value: string | undefined): value is string {
-  return typeof value === 'string' && /^([01]?\d|2[0-3]):[0-5]\d$/.test(value)
-}
-
 function projectDecisions(msg: ChannelMessage, alias?: string): string {
   const resolution = projectBindings.resolveProjectContext(projectContextInput(msg, alias))
   if (resolution.status === 'ambiguous') return `${resolution.reason}\nCandidates:\n${(resolution.candidates || []).slice(0, 6).map(formatProjectBinding).join('\n')}`
@@ -785,11 +760,6 @@ function unbindProject(msg: ChannelMessage, alias?: string): string {
   return projectBindings.deleteProjectBinding(binding.id) ? `Project unbound: ${binding.alias}` : `Project binding not found: ${binding.id}`
 }
 
-function formatProjectBinding(binding: { alias: string; roadmapId: string; scope: string; provider?: string; chatId?: string; threadId?: string }): string {
-  const channel = binding.provider && binding.chatId ? ` ${binding.provider}:${binding.chatId}${binding.threadId ? `:${binding.threadId}` : ''}` : ''
-  return `- ${binding.alias} -> ${binding.roadmapId} (${binding.scope}${channel})`
-}
-
 function projectContextInput(msg: ChannelMessage, value?: string): { alias?: string; roadmapId?: string; provider: string; chatId: string; threadId?: string } {
   const state = value ? loadWorkState() : undefined
   const roadmapId = value && (state?.roadmaps.some(roadmap => roadmap.id === value) || value.startsWith('roadmap_')) ? value : undefined
@@ -808,24 +778,6 @@ function currentBinding(msg: ChannelMessage): ChannelSessionLink | undefined {
 
 function isTrustedCommandTarget(msg: ChannelMessage): boolean {
   return isTrustedChannelTarget(msg.provider, msg.chatId, msg.threadId, getConfig())
-}
-
-function bindingMatches(binding: ChannelSessionLink, kind: string, id: string): boolean {
-  if (kind === 'task') return binding.mode === 'task' && binding.taskId === id
-  if (kind === 'roadmap') return binding.mode === 'roadmap' && binding.roadmapId === id
-  return false
-}
-
-function describeChannelBinding(binding: ChannelSessionLink): string {
-  if (binding.mode === 'task' && binding.taskId) return `Issue ${binding.taskId} (Session ${binding.sessionId})`
-  if (binding.mode === 'roadmap' && binding.roadmapId) return `Project ${binding.roadmapId} (Session ${binding.sessionId})`
-  return `Session ${binding.sessionId}`
-}
-
-function displayBindingMode(mode?: string): string {
-  if (mode === 'task') return 'issue'
-  if (mode === 'roadmap') return 'project'
-  return mode || 'session'
 }
 
 interface RelevantSessionRow {
@@ -907,17 +859,6 @@ function resolveOpenTarget(_msg: ChannelMessage, requested: string): OpenTargetR
 function boundTask(msg: ChannelMessage): WorkTaskView | undefined {
   const binding = currentBinding(msg)
   return binding?.taskId ? getWorkTask(binding.taskId) : undefined
-}
-
-function formatTaskSummary(task: WorkTaskView): string[] {
-  return [
-    `Issue: ${task.title}`,
-    `ID: ${task.id}`,
-    `Status: ${task.status}`,
-    `Priority: ${task.priority}`,
-    `Stage: ${task.currentStage || 'complete'}`,
-    task.lastRun ? `Latest run: ${task.lastRun.status} ${task.lastRun.stage} (${task.lastRun.id})` : 'Latest run: none',
-  ]
 }
 
 async function sessionLinksText(client: ChannelCommandClient, sessionId: string): Promise<string> {
@@ -1097,34 +1038,6 @@ async function denyPermission(requestId: string | undefined, message: string | u
 // unless it is on this explicit allowlist of known-safe read-only surfaces. A
 // new mutating command is therefore actor-gated by default instead of silently
 // skipping the preflight in a trusted group chat.
-const READ_ONLY_CHANNEL_COMMANDS = new Set([
-  'help', 'start', 'commands', 'whereami',
-  'status', 'current', 'open', 'latest',
-  'tasks', 'issues', 'roadmaps', 'initiatives',
-  'governance', 'budget', 'attention', 'needs-attention',
-  'gates', 'alerts', 'incident', 'questions', 'permissions', 'digest',
-])
-const READ_ONLY_PROJECT_ACTIONS = new Set(['status', 'digest', 'decisions', 'open'])
-
-function isPrivilegedChannelAction(command: ParsedChannelCommand): boolean {
-  if (READ_ONLY_CHANNEL_COMMANDS.has(command.name)) return false
-  if (command.name === 'session' || command.name === 'sessions') {
-    const action = command.args[0] || 'list'
-    // Listing is read-only; select/switch rebinds this chat and stays privileged.
-    return action !== 'list' && action !== 'recent'
-  }
-  if (command.name === 'scheduler') return (command.args[0] || 'status') !== 'status'
-  if (command.name === 'completion' || command.name === 'complete') {
-    const action = command.args[0] || 'list'
-    return action !== 'list' && action !== 'status'
-  }
-  if (command.name === 'project' || command.name === 'p') {
-    return !READ_ONLY_PROJECT_ACTIONS.has(command.args[0] || 'status')
-  }
-  // Everything else — including unknown/new commands — is privileged by default.
-  return true
-}
-
 function preflightPrivilegedChannelAction(msg: ChannelMessage, command: ParsedChannelCommand): string | null {
   if (isStaleChannelAction(msg)) return denyChannelAction(msg, commandOperation(command), 'this channel action is too old to process', actionReceiptKey(msg) || command.name, 'stale')
   if (hasAcceptedActionReceipt(msg)) return denyChannelAction(msg, commandOperation(command), 'this channel action was already processed', actionReceiptKey(msg), 'replayed')
@@ -1214,12 +1127,6 @@ function actionReceiptKey(msg: ChannelMessage): string | undefined {
     : `fallback:${msg.userId || msg.provider}:${msg.timestamp || ''}:${String(msg.text || '').trim()}`
   if (!msg.messageId && (!msg.timestamp || !String(msg.text || '').trim())) return undefined
   return `${redactedChannelTargetLabel(msg.provider, msg.chatId, msg.threadId)}:${msg.messageId ? 'message' : 'fallback'}:${channelTargetFingerprint(msg.provider, source, msg.threadId)}`.substring(0, 500)
-}
-
-function commandOperation(command: ParsedChannelCommand): string {
-  if (command.name === 'approve' || command.name === 'deny') return 'opencode_permission.reply'
-  if (command.name === 'answer' || command.name === 'reject-question') return 'opencode_question.reply'
-  return `${command.name}${command.args[0] ? `.${command.args[0]}` : ''}`.substring(0, 120)
 }
 
 function authorizeHumanGateAction(msg: ChannelMessage, gateId: string): string | null {
@@ -1320,11 +1227,6 @@ function configuredGatewayBaseUrl(): string {
   return gatewayLocalBaseUrl(config.httpPort, config.security.httpHost)
 }
 
-function isExpired(iso: string | undefined): boolean {
-  const expires = Date.parse(iso || '')
-  return Number.isFinite(expires) && expires <= Date.now()
-}
-
 function denyChannelAction(msg: ChannelMessage, operation: string, reason: string, target: string | undefined, detail: string): string {
   const decision = channelActionDeniedDecision({ operation, targetId: target, reason, reasonCode: detail })
   appendSecurityAudit(msg, operation, target, detail, decision)
@@ -1342,27 +1244,8 @@ function appendSecurityAudit(msg: ChannelMessage, operation: string, target: str
   })
 }
 
-function formatChannelDecisionHint(decision: OperatorDecisionSummary): string {
-  return [
-    `Decision owner: ${formatDecisionOwner(decision)}; State: ${decision.state}.`,
-    `Authority: ${decision.authority}`,
-    `Next action: ${decision.safeNextAction}`,
-    `Evidence: ${decision.evidenceRef}`,
-  ].join('\n')
-}
-
-function formatDecisionOwner(decision: OperatorDecisionSummary): string {
-  if (decision.owner === 'opencode') return 'OpenCode'
-  if (decision.owner === 'gateway') return 'Gateway'
-  return 'Gateway channel security'
-}
-
 function channelSource(msg: ChannelMessage): string {
   return redactedChannelTargetLabel(msg.provider, msg.chatId, msg.threadId)
-}
-
-function isActionDenial(reply: string): boolean {
-  return reply.startsWith('Action denied:')
 }
 
 async function currentOrNewSession(client: ChannelCommandClient, msg: ChannelMessage, title: string): Promise<string> {
@@ -1416,11 +1299,3 @@ async function createFreshSession(client: ChannelCommandClient, msg: ChannelMess
   return created.id
 }
 
-function gatewaySessionTitle(msg: ChannelMessage, title: string): string {
-  const thread = msg.threadId ? `:${msg.threadId}` : ''
-  return `GW:${msg.provider}:${msg.chatId}${thread}: ${title}`.substring(0, 200)
-}
-
-function cleanTitle(title: string | undefined): string | undefined {
-  return title?.replace(/^GW:/, '').trim()
-}

--- a/products/gateway/src/cli/commands/health.ts
+++ b/products/gateway/src/cli/commands/health.ts
@@ -1,7 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
-import { fileURLToPath } from 'node:url'
 import { z } from 'zod'
 import { getConfig } from '../../config.js'
 import { redactSecret } from '../../security.js'
@@ -145,22 +144,21 @@ export async function doctor() {
     console.log(`- ${entry.id}: ${entry.statusCode} — ${entry.remediation || entry.summary}`)
   }
   // Multi-writer ownership posture (non-blocking): experimental multi-replica still fails open migrate hazards.
-  try {
-    const registryPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../docs/development/distributed-ownership-proving-registry.json')
-    if (fs.existsSync(registryPath)) {
-      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')) as { status?: string; openMigrateHazards?: string[] }
-      const open = Array.isArray(registry.openMigrateHazards) ? registry.openMigrateHazards : []
-      const registryStatus = typeof registry.status === 'string' ? registry.status : 'unknown'
+  // Shared loader with readiness so path resolution cannot drift.
+  {
+    const { loadDistributedOwnershipProvingRegistry } = await import('../../distributed-ownership-registry.js')
+    const loaded = loadDistributedOwnershipProvingRegistry()
+    if (!loaded.ok) {
+      console.log(`Multi-writer ownership: proving registry unavailable (assume single-daemon production only; ${loaded.reason})`)
+    } else {
+      const open = Array.isArray(loaded.registry.openMigrateHazards) ? loaded.registry.openMigrateHazards : []
+      const registryStatus = typeof loaded.registry.status === 'string' ? loaded.registry.status : 'unknown'
       if (open.length === 0 && registryStatus === 'ready') {
         console.log(`Multi-writer ownership: ready (registry status=${registryStatus})`)
       } else {
         console.log(`Multi-writer ownership: single-daemon production only; experimental multi-replica still fails open migrate hazards (${open.join(', ') || 'none'}; registry status=${registryStatus})`)
       }
-    } else {
-      console.log('Multi-writer ownership: proving registry not found (assume single-daemon production only)')
     }
-  } catch {
-    console.log('Multi-writer ownership: could not load proving registry (assume single-daemon production only)')
   }
   console.log()
 

--- a/products/gateway/src/cli/commands/health.ts
+++ b/products/gateway/src/cli/commands/health.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { fileURLToPath } from 'node:url'
 import { z } from 'zod'
 import { getConfig } from '../../config.js'
 import { redactSecret } from '../../security.js'
@@ -142,6 +143,24 @@ export async function doctor() {
   console.log(`Local readiness catalog: ${blockedReadiness.length ? 'blocked' : attentionReadiness.length ? 'attention' : 'ready'} (${Object.entries(localReadiness.totals).map(([status, count]) => `${status}:${count}`).join(', ')})`)
   for (const entry of [...blockedReadiness, ...attentionReadiness].slice(0, 5)) {
     console.log(`- ${entry.id}: ${entry.statusCode} — ${entry.remediation || entry.summary}`)
+  }
+  // Multi-writer ownership posture (non-blocking): experimental multi-replica still fails open migrate hazards.
+  try {
+    const registryPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../docs/development/distributed-ownership-proving-registry.json')
+    if (fs.existsSync(registryPath)) {
+      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')) as { status?: string; openMigrateHazards?: string[] }
+      const open = Array.isArray(registry.openMigrateHazards) ? registry.openMigrateHazards : []
+      const registryStatus = typeof registry.status === 'string' ? registry.status : 'unknown'
+      if (open.length === 0 && registryStatus === 'ready') {
+        console.log(`Multi-writer ownership: ready (registry status=${registryStatus})`)
+      } else {
+        console.log(`Multi-writer ownership: single-daemon production only; experimental multi-replica still fails open migrate hazards (${open.join(', ') || 'none'}; registry status=${registryStatus})`)
+      }
+    } else {
+      console.log('Multi-writer ownership: proving registry not found (assume single-daemon production only)')
+    }
+  } catch {
+    console.log('Multi-writer ownership: could not load proving registry (assume single-daemon production only)')
   }
   console.log()
 

--- a/products/gateway/src/daemon.ts
+++ b/products/gateway/src/daemon.ts
@@ -460,6 +460,32 @@ export interface DaemonHttpServerInput {
  * can boot the actual server on an ephemeral port; the returned server is not
  * yet listening.
  */
+/**
+ * Defense-in-depth headers for Durable Mission Control HTML surfaces.
+ * Script is restricted to 'self' (dashboard) or inline only on the tiny live page.
+ * Frame ancestors none; no object plugins.
+ */
+function applyDurableHtmlSecurityHeaders(res: http.ServerResponse, options: { allowInlineScript?: boolean } = {}): void {
+  const scriptSrc = options.allowInlineScript ? "'self' 'unsafe-inline'" : "'self'"
+  res.setHeader(
+    'Content-Security-Policy',
+    [
+      "default-src 'none'",
+      `script-src ${scriptSrc}`,
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data:",
+      "connect-src 'self'",
+      "base-uri 'none'",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "object-src 'none'",
+    ].join('; '),
+  )
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  res.setHeader('X-Frame-Options', 'DENY')
+}
+
 export function createDaemonHttpServer(input: DaemonHttpServerInput): http.Server {
   return http.createServer(async (req, res) => {
     const port = input.resolvePort()
@@ -524,7 +550,9 @@ export function createDaemonHttpServer(input: DaemonHttpServerInput): http.Serve
       // Web dashboard
       if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/dashboard')) {
         const html = await renderDashboard(url.searchParams)
-        res.setHeader('Content-Type', 'text/html')
+        // Mission Control HTML embeds inline script/style (self-contained page).
+        applyDurableHtmlSecurityHeaders(res, { allowInlineScript: true })
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
         res.writeHead(200)
         return res.end(html)
       }
@@ -539,7 +567,9 @@ export function createDaemonHttpServer(input: DaemonHttpServerInput): http.Serve
 
       // Live dashboard HTML
       if (req.method === 'GET' && url.pathname === '/live') {
-        res.setHeader('Content-Type', 'text/html')
+        // Live page embeds a small inline EventSource script (no external assets).
+        applyDurableHtmlSecurityHeaders(res, { allowInlineScript: true })
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
         res.writeHead(200)
         return res.end(`<!DOCTYPE html>
 <html><head>

--- a/products/gateway/src/daemon.ts
+++ b/products/gateway/src/daemon.ts
@@ -454,13 +454,6 @@ export interface DaemonHttpServerInput {
 }
 
 /**
- * The real daemon HTTP surface: security check before any dispatch, the 403
- * denial body, CORS origin reflection, OPTIONS handling, webhooks, SSE, and
- * JSON route dispatch. Extracted from serve() unchanged so integration tests
- * can boot the actual server on an ephemeral port; the returned server is not
- * yet listening.
- */
-/**
  * Defense-in-depth headers for Durable Mission Control HTML surfaces.
  * Script is restricted to 'self' (dashboard) or inline only on the tiny live page.
  * Frame ancestors none; no object plugins.
@@ -486,6 +479,13 @@ function applyDurableHtmlSecurityHeaders(res: http.ServerResponse, options: { al
   res.setHeader('X-Frame-Options', 'DENY')
 }
 
+/**
+ * The real daemon HTTP surface: security check before any dispatch, the 403
+ * denial body, CORS origin reflection, OPTIONS handling, webhooks, SSE, and
+ * JSON route dispatch. Extracted from serve() unchanged so integration tests
+ * can boot the actual server on an ephemeral port; the returned server is not
+ * yet listening.
+ */
 export function createDaemonHttpServer(input: DaemonHttpServerInput): http.Server {
   return http.createServer(async (req, res) => {
     const port = input.resolvePort()

--- a/products/gateway/src/distributed-ownership-registry.ts
+++ b/products/gateway/src/distributed-ownership-registry.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared loader for the monorepo distributed-ownership proving registry.
+ * Used by readiness + doctor so path resolution does not drift.
+ *
+ * Override with GATEWAY_PROVING_REGISTRY_PATH when the monorepo docs tree
+ * is not co-located with the package (packaged installs soft-fail cleanly).
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export interface DistributedOwnershipProvingRegistry {
+  status?: string
+  openMigrateHazards?: string[]
+}
+
+export type ProvingRegistryLoadResult =
+  | { ok: true; registry: DistributedOwnershipProvingRegistry; registryPath: string }
+  | { ok: false; reason: string; registryPath?: string }
+
+/**
+ * Resolve and load the proving registry JSON.
+ * Walks up from this package (`src/`) toward repo root looking for
+ * `docs/development/distributed-ownership-proving-registry.json`.
+ */
+export function loadDistributedOwnershipProvingRegistry(): ProvingRegistryLoadResult {
+  const envPath = process.env['GATEWAY_PROVING_REGISTRY_PATH']?.trim()
+  if (envPath) {
+    return readRegistryFile(path.resolve(envPath))
+  }
+
+  const startDir = path.dirname(fileURLToPath(import.meta.url))
+  let dir = startDir
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, 'docs', 'development', 'distributed-ownership-proving-registry.json')
+    if (fs.existsSync(candidate)) return readRegistryFile(candidate)
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  return {
+    ok: false,
+    reason: 'proving registry not found near package (assume single-daemon production only)',
+  }
+}
+
+function readRegistryFile(registryPath: string): ProvingRegistryLoadResult {
+  try {
+    const raw = fs.readFileSync(registryPath, 'utf8')
+    const registry = JSON.parse(raw) as DistributedOwnershipProvingRegistry
+    return { ok: true, registry, registryPath }
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: err?.message || String(err),
+      registryPath,
+    }
+  }
+}

--- a/products/gateway/src/mcp-tools-ops.ts
+++ b/products/gateway/src/mcp-tools-ops.ts
@@ -21,7 +21,10 @@ export function registerMcpOpsTools(server: McpServer, runTool: RunTool, fetchJS
   server.tool('recovery_drill', 'Restore a backup into an isolated state directory and prove scheduler, storage, and channel recovery behavior. Writes evidence under recovery-drills/.', { path: z.string().optional(), label: z.string().optional(), outputDir: z.string().optional(), retryLimit: z.number().optional() },
     async (args: { path?: string; label?: string; outputDir?: string; retryLimit?: number }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/recovery-drills', args), null, 2)))
 
-  server.tool('state_export', 'Export Gateway durable state as JSON for audit or machine transfer. Requires JOE-952 dual-intent (localAdmin) on the daemon admin surface.', {},
+  // Always append localAdmin=true: MCP tool invocation is the operator intent for
+  // JOE-952 dual-intent. Without this query the HTTP surface permanently 403s
+  // state_export after dual-intent landed (tool has no separate query surface).
+  server.tool('state_export', 'Export Gateway durable state as JSON for audit or machine transfer. Requires JOE-952 dual-intent (localAdmin) on the daemon admin surface; this tool supplies localAdmin=true because invoking the tool is the operator intent.', {},
     async () => runTool(async () => JSON.stringify(await fetchJSON('GET', '/storage/export?localAdmin=true'), null, 2)))
 
   server.tool('restore', 'Restore Gateway state from a verified backup. Requires maintenanceMode=true while daemon is active and destructive-action approval by default. Pass dryRun=true to preview the backup verification and current state that would be replaced without restoring.', { path: z.string(), maintenanceMode: z.boolean().optional(), skipSafetyBackup: z.boolean().optional(), approvedGateId: z.string().optional(), dryRun: z.boolean().optional() },

--- a/products/gateway/src/mcp-tools-ops.ts
+++ b/products/gateway/src/mcp-tools-ops.ts
@@ -1,0 +1,29 @@
+/**
+ * Backup / storage / recovery MCP tool registrations (LOC façade split).
+ * Leaf relative to mcp.ts — receives (server, runTool, fetchJSON) and registers tools.
+ */
+import { z } from 'zod'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+type RunTool = (fn: () => Promise<string>) => Promise<any>
+type FetchJSON = (method: string, path: string, body?: any) => Promise<any>
+
+export function registerMcpOpsTools(server: McpServer, runTool: RunTool, fetchJSON: FetchJSON): void {
+  server.tool('backup_create', 'Create a timestamped Gateway state backup. Refuses active runs and starting dispatches unless allowActiveRuns=true is supplied during an operator-controlled maintenance window.', { label: z.string().optional(), retention: z.number().optional(), allowActiveRuns: z.boolean().optional() },
+    async (args: { label?: string; retention?: number; allowActiveRuns?: boolean }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/backups', args), null, 2)))
+
+  server.tool('backup_list', 'List Gateway state backups and verification status.', {},
+    async () => runTool(async () => JSON.stringify(await fetchJSON('GET', '/storage/backups'), null, 2)))
+
+  server.tool('backup_verify', 'Verify a Gateway state backup checksum, metadata, and SQLite integrity.', { path: z.string() },
+    async (args: { path: string }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/backups/verify', args), null, 2)))
+
+  server.tool('recovery_drill', 'Restore a backup into an isolated state directory and prove scheduler, storage, and channel recovery behavior. Writes evidence under recovery-drills/.', { path: z.string().optional(), label: z.string().optional(), outputDir: z.string().optional(), retryLimit: z.number().optional() },
+    async (args: { path?: string; label?: string; outputDir?: string; retryLimit?: number }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/recovery-drills', args), null, 2)))
+
+  server.tool('state_export', 'Export Gateway durable state as JSON for audit or machine transfer. Requires JOE-952 dual-intent (localAdmin) on the daemon admin surface.', {},
+    async () => runTool(async () => JSON.stringify(await fetchJSON('GET', '/storage/export?localAdmin=true'), null, 2)))
+
+  server.tool('restore', 'Restore Gateway state from a verified backup. Requires maintenanceMode=true while daemon is active and destructive-action approval by default. Pass dryRun=true to preview the backup verification and current state that would be replaced without restoring.', { path: z.string(), maintenanceMode: z.boolean().optional(), skipSafetyBackup: z.boolean().optional(), approvedGateId: z.string().optional(), dryRun: z.boolean().optional() },
+    async (args: { path: string; maintenanceMode?: boolean; skipSafetyBackup?: boolean; approvedGateId?: string; dryRun?: boolean }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/restore', args), null, 2)))
+}

--- a/products/gateway/src/mcp.ts
+++ b/products/gateway/src/mcp.ts
@@ -12,6 +12,7 @@ import { buildGatewayToolCatalog } from './gateway-tools.js'
 import { formatTaskCounts } from './task-summary.js'
 import { httpCapabilityForRequest, type HttpCapability } from './security.js'
 import { readScopedHttpTokenFile } from './secrets-lifecycle.js'
+import { registerMcpOpsTools } from './mcp-tools-ops.js'
 
 const DAEMON_URL = process.env['GATEWAY_DAEMON_URL'] || 'http://127.0.0.1:4097'
 const REQUEST_TIMEOUT_MS = 15000
@@ -777,23 +778,7 @@ server.tool('config_get', 'Read Gateway configuration with secrets redacted.', {
 server.tool('config_update', 'Update Gateway configuration deterministically. Destructive-action approval is required by default: first call returns a gate, then retry with approvedGateId after approval. Pass dryRun=true to preview the affected config sections (redacted) without writing.', { config: zStringRecord(z.any()), approvedGateId: z.string().optional(), dryRun: z.boolean().optional() },
   async (args: { config: Record<string, unknown>; approvedGateId?: string; dryRun?: boolean }) => runTool(async () => JSON.stringify(await fetchJSON('PATCH', '/config', { ...args.config, approvedGateId: args.approvedGateId, dryRun: args.dryRun }), null, 2)))
 
-server.tool('backup_create', 'Create a timestamped Gateway state backup. Refuses active runs and starting dispatches unless allowActiveRuns=true is supplied during an operator-controlled maintenance window.', { label: z.string().optional(), retention: z.number().optional(), allowActiveRuns: z.boolean().optional() },
-  async (args: { label?: string; retention?: number; allowActiveRuns?: boolean }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/backups', args), null, 2)))
-
-server.tool('backup_list', 'List Gateway state backups and verification status.', {},
-  async () => runTool(async () => JSON.stringify(await fetchJSON('GET', '/storage/backups'), null, 2)))
-
-server.tool('backup_verify', 'Verify a Gateway state backup checksum, metadata, and SQLite integrity.', { path: z.string() },
-  async (args: { path: string }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/backups/verify', args), null, 2)))
-
-server.tool('recovery_drill', 'Restore a backup into an isolated state directory and prove scheduler, storage, and channel recovery behavior. Writes evidence under recovery-drills/.', { path: z.string().optional(), label: z.string().optional(), outputDir: z.string().optional(), retryLimit: z.number().optional() },
-  async (args: { path?: string; label?: string; outputDir?: string; retryLimit?: number }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/recovery-drills', args), null, 2)))
-
-server.tool('state_export', 'Export Gateway durable state as JSON for audit or machine transfer.', {},
-  async () => runTool(async () => JSON.stringify(await fetchJSON('GET', '/storage/export'), null, 2)))
-
-server.tool('restore', 'Restore Gateway state from a verified backup. Requires maintenanceMode=true while daemon is active and destructive-action approval by default. Pass dryRun=true to preview the backup verification and current state that would be replaced without restoring.', { path: z.string(), maintenanceMode: z.boolean().optional(), skipSafetyBackup: z.boolean().optional(), approvedGateId: z.string().optional(), dryRun: z.boolean().optional() },
-  async (args: { path: string; maintenanceMode?: boolean; skipSafetyBackup?: boolean; approvedGateId?: string; dryRun?: boolean }) => runTool(async () => JSON.stringify(await fetchJSON('POST', '/storage/restore', args), null, 2)))
+registerMcpOpsTools(server, runTool, fetchJSON)
 
 server.tool('restart', 'Request Gateway daemon restart. Requires the admin MCP tool tier (admin HTTP capability for non-local requests) and is audited; no human approval gate applies. A service manager must be installed for the daemon to come back automatically.', {},
   async () => runTool(async () => JSON.stringify(await fetchJSON('POST', '/restart', {}), null, 2)))

--- a/products/gateway/src/readiness.ts
+++ b/products/gateway/src/readiness.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { getConfig, getConfigDir } from './config.js'
 import { getHeartbeatStatus } from './heartbeat.js'
 import { getWorkQueueSnapshot, getWorkQueueSnapshotReadOnly } from './scheduler.js'
@@ -94,6 +95,7 @@ export async function buildReadinessReport(client?: any, options: { readOnly?: b
   }
 
   addCheck('daemon_leadership', () => checkDaemonLeadership())
+  addCheck('multi_writer_ownership', () => checkMultiWriterOwnership())
   addCheck('scheduler', () => checkScheduler(config.scheduler, snapshot.counts))
   addCheck('heartbeat', () => checkHeartbeat(heartbeat, config.scheduler.enabled ? config.scheduler.intervalMs : config.heartbeat.intervalMs))
   addCheck('storage', () => checkStorage(options.readOnly))
@@ -212,6 +214,57 @@ function checkDaemonLeadership(): ReadinessCheck {
         ? 'No Gateway daemon owns the local writer lease'
         : 'Gateway leadership state is unavailable',
     details: snapshot as unknown as Record<string, unknown>,
+  }
+}
+
+/**
+ * Informational multi-writer ownership posture (JOE-948/949).
+ * Passes for the supported single-daemon production shape while still surfacing
+ * open migrate hazards so experimental multi-replica is never mistaken for HA.
+ * Does not degrade readiness (warn would permanently mark single-daemon degraded).
+ */
+function checkMultiWriterOwnership(): ReadinessCheck {
+  const registryPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../docs/development/distributed-ownership-proving-registry.json',
+  )
+  try {
+    const raw = fs.readFileSync(registryPath, 'utf8')
+    const registry = JSON.parse(raw) as {
+      status?: string
+      openMigrateHazards?: string[]
+    }
+    const open = Array.isArray(registry.openMigrateHazards) ? registry.openMigrateHazards : []
+    const registryStatus = typeof registry.status === 'string' ? registry.status : 'unknown'
+    if (open.length === 0 && registryStatus === 'ready') {
+      return {
+        name: 'multi_writer_ownership',
+        status: 'pass',
+        severity: 'info',
+        summary: 'Distributed-ownership proving registry is ready (no open migrate hazards)',
+        details: { registryStatus, openMigrateHazards: open },
+      }
+    }
+    return {
+      name: 'multi_writer_ownership',
+      status: 'pass',
+      severity: 'info',
+      summary: `Single-writer production only; experimental multi-replica still fails open migrate hazards (${open.join(', ') || 'none listed'}; registry status=${registryStatus})`,
+      details: {
+        registryStatus,
+        openMigrateHazards: open,
+        productionShape: 'single-daemon-per-state-dir',
+        experimentalMultiReplica: 'lab-only-not-ha',
+      },
+    }
+  } catch (err: any) {
+    return {
+      name: 'multi_writer_ownership',
+      status: 'pass',
+      severity: 'info',
+      summary: `Proving registry unavailable; assume single-daemon production only (${redactSensitiveText(err?.message || String(err))})`,
+      details: { registryPath },
+    }
   }
 }
 

--- a/products/gateway/src/readiness.ts
+++ b/products/gateway/src/readiness.ts
@@ -1,6 +1,5 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { getConfig, getConfigDir } from './config.js'
 import { getHeartbeatStatus } from './heartbeat.js'
 import { getWorkQueueSnapshot, getWorkQueueSnapshotReadOnly } from './scheduler.js'
@@ -19,6 +18,7 @@ import { getCurrentDaemonLeadershipStatus, redactDaemonLeadershipSnapshot } from
 import { buildLocalReadinessCatalog } from './agent-catalog.js'
 import { openCodeFetch } from './opencode-client.js'
 import { withDeadline } from './deadlines.js'
+import { loadDistributedOwnershipProvingRegistry } from './distributed-ownership-registry.js'
 
 export type ReadinessState = 'ready' | 'degraded' | 'not_ready'
 export type ReadinessCheckStatus = 'pass' | 'warn' | 'fail'
@@ -224,47 +224,39 @@ function checkDaemonLeadership(): ReadinessCheck {
  * Does not degrade readiness (warn would permanently mark single-daemon degraded).
  */
 function checkMultiWriterOwnership(): ReadinessCheck {
-  const registryPath = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    '../../../docs/development/distributed-ownership-proving-registry.json',
-  )
-  try {
-    const raw = fs.readFileSync(registryPath, 'utf8')
-    const registry = JSON.parse(raw) as {
-      status?: string
-      openMigrateHazards?: string[]
-    }
-    const open = Array.isArray(registry.openMigrateHazards) ? registry.openMigrateHazards : []
-    const registryStatus = typeof registry.status === 'string' ? registry.status : 'unknown'
-    if (open.length === 0 && registryStatus === 'ready') {
-      return {
-        name: 'multi_writer_ownership',
-        status: 'pass',
-        severity: 'info',
-        summary: 'Distributed-ownership proving registry is ready (no open migrate hazards)',
-        details: { registryStatus, openMigrateHazards: open },
-      }
-    }
+  const loaded = loadDistributedOwnershipProvingRegistry()
+  if (!loaded.ok) {
     return {
       name: 'multi_writer_ownership',
       status: 'pass',
       severity: 'info',
-      summary: `Single-writer production only; experimental multi-replica still fails open migrate hazards (${open.join(', ') || 'none listed'}; registry status=${registryStatus})`,
-      details: {
-        registryStatus,
-        openMigrateHazards: open,
-        productionShape: 'single-daemon-per-state-dir',
-        experimentalMultiReplica: 'lab-only-not-ha',
-      },
+      summary: `Proving registry unavailable; assume single-daemon production only (${redactSensitiveText(loaded.reason)})`,
+      details: { registryPath: loaded.registryPath },
     }
-  } catch (err: any) {
+  }
+  const open = Array.isArray(loaded.registry.openMigrateHazards) ? loaded.registry.openMigrateHazards : []
+  const registryStatus = typeof loaded.registry.status === 'string' ? loaded.registry.status : 'unknown'
+  if (open.length === 0 && registryStatus === 'ready') {
     return {
       name: 'multi_writer_ownership',
       status: 'pass',
       severity: 'info',
-      summary: `Proving registry unavailable; assume single-daemon production only (${redactSensitiveText(err?.message || String(err))})`,
-      details: { registryPath },
+      summary: 'Distributed-ownership proving registry is ready (no open migrate hazards)',
+      details: { registryStatus, openMigrateHazards: open, registryPath: loaded.registryPath },
     }
+  }
+  return {
+    name: 'multi_writer_ownership',
+    status: 'pass',
+    severity: 'info',
+    summary: `Single-writer production only; experimental multi-replica still fails open migrate hazards (${open.join(', ') || 'none listed'}; registry status=${registryStatus})`,
+    details: {
+      registryStatus,
+      openMigrateHazards: open,
+      productionShape: 'single-daemon-per-state-dir',
+      experimentalMultiReplica: 'lab-only-not-ha',
+      registryPath: loaded.registryPath,
+    },
   }
 }
 

--- a/products/gateway/src/scheduler-helpers.ts
+++ b/products/gateway/src/scheduler-helpers.ts
@@ -1,0 +1,365 @@
+/**
+ * Pure / near-pure scheduler helpers (LOC façade split).
+ * Leaf relative to scheduler.ts — stage resolution, failure classification,
+ * dependency source planning, and workdir/tool parsing live here.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { getConfig, type AgentProfile, type AgentTeamConfig, type GatewayConfig } from './config.js'
+import type { EnvironmentSourcePlan, EnvironmentSpec } from './environments.js'
+import { isActiveRunStatus } from './runtime-state-machine.js'
+import type { RunAttributionInput, RunRecord, WorkState, WorkTaskRecord } from './work-store.js'
+import {
+  mergeTaskQualitySpecDefaults,
+  profileForStage,
+  type FailureClass,
+  type StageResult,
+  type TaskQualitySpec,
+  type WorkflowDecision,
+} from './workflow.js'
+
+export type TaskStageResolution =
+  | {
+      ok: true
+      stage: string
+      source: string
+      profileName: string
+      profile: AgentProfile
+      agentTeamName?: string
+      agentTeam?: AgentTeamConfig
+      agentTeamVersion?: string
+      qualitySpec?: TaskQualitySpec
+    }
+  | { ok: false; stage: string; source: string; reason: string; agentTeamName?: string; profileName?: string }
+
+export type RuntimeFailureKind = 'provider_balance' | 'provider_auth' | 'provider_quota' | 'provider_model' | 'transport' | 'unknown'
+
+export function resolveTaskStageAgent(task: WorkTaskRecord, state: WorkState, stage: string, config: GatewayConfig = getConfig()): TaskStageResolution {
+  const roadmap = state.roadmaps.find(row => row.id === task.roadmapId)
+  const contextTeamName = task.agentTeam || roadmap?.agentTeam
+  const contextTeam = contextTeamName ? config.agentTeams[contextTeamName] : undefined
+  if (contextTeamName && !contextTeam) return { ok: false, stage, source: task.agentTeam ? 'task.agentTeam' : 'roadmap.agentTeam', reason: `Agent team not found: ${contextTeamName}`, agentTeamName: contextTeamName }
+
+  const taskProfile = profileOverrideForStage(task.stageProfiles, stage)
+  if (taskProfile) return validateResolvedProfile(task, stage, 'task.stageProfiles', taskProfile, contextTeamName, contextTeam, config)
+
+  if (task.agentTeam && contextTeam) {
+    const profileName = profileForAgentTeamStage(contextTeam, stage)
+    if (!profileName) return { ok: false, stage, source: 'task.agentTeam', reason: `Agent team ${task.agentTeam} has no role for stage ${stage}`, agentTeamName: task.agentTeam }
+    return validateResolvedProfile(task, stage, 'task.agentTeam', profileName, task.agentTeam, contextTeam, config)
+  }
+
+  if (roadmap?.agentTeam) {
+    const roadmapTeam = config.agentTeams[roadmap.agentTeam]
+    if (!roadmapTeam) return { ok: false, stage, source: 'roadmap.agentTeam', reason: `Agent team not found: ${roadmap.agentTeam}`, agentTeamName: roadmap.agentTeam }
+    const profileName = profileForAgentTeamStage(roadmapTeam, stage)
+    if (!profileName) return { ok: false, stage, source: 'roadmap.agentTeam', reason: `Agent team ${roadmap.agentTeam} has no role for stage ${stage}`, agentTeamName: roadmap.agentTeam }
+    return validateResolvedProfile(task, stage, 'roadmap.agentTeam', profileName, roadmap.agentTeam, roadmapTeam, config)
+  }
+
+  return validateResolvedProfile(task, stage, 'scheduler.stageProfiles', profileForStage(stage, config.scheduler), undefined, undefined, config)
+}
+
+function validateResolvedProfile(task: WorkTaskRecord, stage: string, source: string, profileName: string, agentTeamName: string | undefined, agentTeam: AgentTeamConfig | undefined, config: GatewayConfig): TaskStageResolution {
+  const profile = config.profiles[profileName]
+  if (!profile) return { ok: false, stage, source, reason: `Profile not found for stage ${stage}: ${profileName}`, agentTeamName, profileName }
+  const missing = missingCapabilities(agentTeam, stage, profile)
+  if (missing.length) {
+    return { ok: false, stage, source, reason: `Profile ${profileName} does not satisfy agent team ${agentTeamName} requirements for ${stage}: ${missing.join(', ')}`, agentTeamName, profileName }
+  }
+  const qualitySpec = agentTeam ? mergeTaskQualitySpecDefaults(task.qualitySpec, agentTeam.qualitySpecDefaults) : task.qualitySpec
+  return { ok: true, stage, source, profileName, profile, agentTeamName, agentTeam, agentTeamVersion: agentTeam?.revision, qualitySpec }
+}
+
+function profileOverrideForStage(stageProfiles: Record<string, string> | undefined, stage: string): string | undefined {
+  return stageProfiles?.[stage] || stageProfiles?.['default']
+}
+
+function profileForAgentTeamStage(team: AgentTeamConfig, stage: string): string | undefined {
+  return team.roles[stage] || team.roles['default']
+}
+
+function missingCapabilities(team: AgentTeamConfig | undefined, stage: string, profile: AgentProfile): string[] {
+  if (!team) return []
+  const required = [...(team.capabilityRequirements['default'] || []), ...(team.capabilityRequirements[stage] || [])]
+  return required.filter(capability => !profileHasCapability(profile, capability))
+}
+
+function profileHasCapability(profile: AgentProfile, capability: string): boolean {
+  if (profile.agent === capability) return true
+  if (profile.skills.includes(capability)) return true
+  if (profile.capabilities?.includes(capability)) return true
+  if (profile.tools?.includes(capability)) return true
+  if (profile.mcpServers?.includes(capability)) return true
+  const permission = profile.permission || {}
+  return permission[capability] === 'allow' || permission[`${capability}_`] === 'allow' || permission[`${capability}_*`] === 'allow'
+}
+
+export function priorityRank(priority: string): number {
+  return priority === 'HIGH' ? 0 : priority === 'MEDIUM' ? 1 : 2
+}
+
+export function deadlineRank(value?: string): number {
+  const ms = Date.parse(value || '')
+  return Number.isFinite(ms) ? ms : Number.MAX_SAFE_INTEGER
+}
+
+export function dispatchStartLeaseMs(config: { scheduler: { intervalMs: number; leaseMs: number } }, environmentSpec: EnvironmentSpec): number {
+  const prepareTimeoutMs = Number(environmentSpec.resources.timeoutMs || 0)
+  const schedulerBufferMs = Math.max(config.scheduler.intervalMs * 3, 30_000)
+  return Math.max(config.scheduler.leaseMs, prepareTimeoutMs > 0 ? prepareTimeoutMs + schedulerBufferMs : 0)
+}
+
+export function classifyRuntimeFailure(message: string): { kind: RuntimeFailureKind; terminal: boolean; summary: string; failureClass: FailureClass; nextAction: string } {
+  const text = message.toLowerCase()
+  if (/model (not found|not available|unavailable|unknown|unsupported)|provider (not found|not configured|unknown|unsupported|unavailable)|no such model|invalid model|model .*does not exist|provider .*does not exist/.test(text)) return terminalFailure('provider_model', 'Provider/model configuration failure', message, 'needs_credentials', 'Validate the configured provider/model in OpenCode, update the Gateway profile, then retry the task.')
+  if (/insufficient balance|billing|payment required|no credits|credit balance|402/.test(text)) return terminalFailure('provider_balance', 'Provider balance or billing failure', message, 'exceeded_budget', 'Top up or rotate the configured model/provider account, then retry the task.')
+  if (/unauthorized|forbidden|invalid api key|invalid token|authentication|permission denied|401|403/.test(text)) return terminalFailure('provider_auth', 'Provider authentication failure', message, 'needs_credentials', 'Rotate or fix provider credentials, then retry the task.')
+  if (/quota exceeded|rate limit|too many requests|capacity exceeded|429/.test(text)) return terminalFailure('provider_quota', 'Provider quota or rate-limit failure', message, 'exceeded_budget', 'Wait for quota reset or change provider limits before retrying.')
+  if (/fetch failed|econnreset|etimedout|timeout|timed out|socket|network|temporar|503|502|504|unavailable/.test(text)) return { kind: 'transport', terminal: false, summary: `Transient OpenCode transport failure: ${shortFailure(message)}`, failureClass: 'flaky_test', nextAction: 'Gateway will retry with bounded backoff; inspect OpenCode/network health if failures repeat.' }
+  return { kind: 'unknown', terminal: false, summary: `OpenCode runtime failure: ${shortFailure(message)}`, failureClass: 'flaky_test', nextAction: 'Gateway will retry with bounded backoff; inspect the session and provider logs if failures repeat.' }
+}
+
+function terminalFailure(kind: RuntimeFailureKind, label: string, message: string, failureClass: FailureClass, nextAction: string) {
+  return { kind, terminal: true, summary: `${label}: ${shortFailure(message)}`, failureClass, nextAction }
+}
+
+export function shortFailure(message: string): string {
+  return message.replace(/\s+/g, ' ').trim().substring(0, 500)
+}
+
+export function evaluateEnvironmentCapacity(environment: EnvironmentSpec, state: WorkState, config: GatewayConfig): { allowed: boolean; reason: string; used: number; limit: number } {
+  const active = state.runs.filter(run => run.environment && (isActiveRunStatus(run.status) || run.environment.status === 'retained'))
+  const retained = active.filter(run => run.environment?.status === 'retained')
+  const retainedLimit = config.environments.maxRetained
+  if (retainedLimit === 0 ? retained.length > 0 : retained.length >= retainedLimit) return { allowed: false, reason: `retained environment limit exhausted (${retained.length}/${retainedLimit})`, used: retained.length, limit: retainedLimit }
+  const globalLimit = Math.max(1, config.environments.maxConcurrent || config.scheduler.maxConcurrent)
+  if (active.length >= globalLimit) return { allowed: false, reason: `environment concurrency exhausted (${active.length}/${globalLimit})`, used: active.length, limit: globalLimit }
+  const backendLimit = config.environments.backendMaxConcurrent[environment.backend]
+  if (backendLimit) {
+    const sameBackend = active.filter(run => run.environment?.backend === environment.backend).length
+    if (sameBackend >= backendLimit) return { allowed: false, reason: `environment backend ${environment.backend} concurrency exhausted (${sameBackend}/${backendLimit})`, used: sameBackend, limit: backendLimit }
+  }
+  const specLimit = environment.resources.maxConcurrent
+  if (specLimit) {
+    const sameSpec = active.filter(run => run.environment?.specHash === environment.specHash).length
+    if (sameSpec >= specLimit) return { allowed: false, reason: `environment ${environment.name} concurrency exhausted (${sameSpec}/${specLimit})`, used: sameSpec, limit: specLimit }
+  }
+  return { allowed: true, reason: 'environment capacity available', used: active.length, limit: globalLimit }
+}
+
+export function dependencyTaskIdsFor(taskId: string, state: WorkState): string[] {
+  return (state.dependencies || [])
+    .filter(dependency => dependency.taskId === taskId && (dependency.type === 'blocks' || dependency.type === 'blocked_by' || dependency.type === 'parent'))
+    .map(dependency => dependency.dependsOnTaskId)
+    .sort()
+}
+
+export function buildDependencySourcePlan(state: WorkState, workdir: string | undefined, dependencyTaskIds: string[]): EnvironmentSourcePlan {
+  const baseRef = sourceBaseRef(workdir)
+  if (!dependencyTaskIds.length) return { required: false, baseRef, workdir, dependencyTaskIds: [], patches: [], missing: [] }
+  const patches: EnvironmentSourcePlan['patches'] = []
+  const missing: EnvironmentSourcePlan['missing'] = []
+  for (const dependencyTaskId of dependencyTaskIds) {
+    const runs = state.runs
+      .filter(run => run.taskId === dependencyTaskId && run.status === 'passed' && run.result)
+      .sort((a, b) => Date.parse(a.startedAt) - Date.parse(b.startedAt))
+    const beforeCount = patches.length
+    runs.forEach(run => {
+      for (const [index, ref] of patchRefsFromRun(run).entries()) {
+        const patchPath = resolvePatchPath(ref, workdir)
+        if (!patchPath || !fs.existsSync(patchPath)) {
+          missing.push({ taskId: dependencyTaskId, reason: `patch artifact not found: ${ref}` })
+          continue
+        }
+        const content = fs.readFileSync(patchPath, 'utf8')
+        if (!content.trim()) {
+          missing.push({ taskId: dependencyTaskId, reason: `patch artifact is empty: ${ref}` })
+          continue
+        }
+        patches.push({
+          id: `${dependencyTaskId}:${run.id}:${index + 1}`,
+          taskId: dependencyTaskId,
+          runId: run.id,
+          stage: run.stage,
+          ref,
+          path: patchPath,
+          content,
+          changedFiles: changedFilesFromPatch(content),
+        })
+      }
+    })
+    if (patches.length === beforeCount) missing.push({ taskId: dependencyTaskId, reason: 'missing patch artifact' })
+  }
+  return { required: true, baseRef, workdir, dependencyTaskIds, patches, missing }
+}
+
+function patchRefsFromRun(run: RunRecord): string[] {
+  if (!run.result) return []
+  const refs = [
+    ...(run.result.artifacts || []),
+    ...(run.result.evidence || []).map(item => item.ref),
+  ]
+  return uniqueStrings(refs.map(parsePatchRef).filter((ref): ref is string => Boolean(ref)))
+}
+
+function parsePatchRef(value: string | undefined): string | undefined {
+  const text = String(value || '').trim()
+  const prefixed = /^(?:patch|patch-file|diff-file):\s*(.+)$/i.exec(text)
+  if (prefixed) return prefixed[1]!.trim()
+  return /\.(?:patch|diff)$/i.test(text) ? text : undefined
+}
+
+function resolvePatchPath(ref: string, workdir: string | undefined): string | undefined {
+  const fileRef = ref.startsWith('file://') ? new URL(ref).pathname : ref
+  if (!workdir) return undefined
+  const resolved = path.isAbsolute(fileRef) ? fileRef : path.resolve(workdir, fileRef)
+  const relative = path.relative(workdir, resolved)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return undefined
+  return resolved
+}
+
+function changedFilesFromPatch(content: string): string[] {
+  const files: string[] = []
+  for (const line of content.split(/\r?\n/)) {
+    const diff = /^diff --git a\/(.+?) b\/(.+)$/.exec(line)
+    if (diff) files.push(diff[2] === '/dev/null' ? diff[1]! : diff[2]!)
+    const added = /^\+\+\+ b\/(.+)$/.exec(line)
+    if (added && added[1] !== '/dev/null') files.push(added[1]!)
+  }
+  return uniqueStrings(files).sort()
+}
+
+function sourceBaseRef(workdir: string | undefined): string {
+  if (!workdir) return 'none'
+  const result = spawnSync('git', ['-C', workdir, 'rev-parse', 'HEAD'], { encoding: 'utf8', maxBuffer: 1024 * 1024 })
+  const ref = result.status === 0 ? result.stdout.trim() : ''
+  return ref || `workdir:${path.resolve(workdir)}`
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)))
+}
+
+export function requiredToolsForTask(task: WorkTaskRecord, qualitySpec: TaskQualitySpec | undefined): string[] {
+  const spec = qualitySpec || task.qualitySpec
+  const tools = new Set<string>()
+  for (const tool of spec?.requiredTools || []) addTool(tools, tool)
+  for (const value of [task.note || '', task.description || '', ...(spec?.constraints || []), ...(spec?.systemsTouched || [])]) {
+    for (const tool of parseRequiredTools(value)) addTool(tools, tool)
+  }
+  return [...tools].sort()
+}
+
+function parseRequiredTools(value: string): string[] {
+  const tools: string[] = []
+  for (const line of value.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:required tools|preflight tools|tools)\s*:\s*(.+?)\s*$/i)
+    if (match?.[1]) tools.push(...match[1].split(/[,;]/))
+  }
+  return tools
+}
+
+function addTool(tools: Set<string>, value: string): void {
+  const tool = value.replace(/`/g, '').trim().split(/\s+/)[0]?.toLowerCase()
+  if (tool) tools.add(tool)
+}
+
+export function taskWorkdir(task: WorkTaskRecord | undefined): string | undefined {
+  if (!task) return undefined
+  const spec = task.qualitySpec
+  const candidates = [
+    ...(spec?.systemsTouched || []),
+    ...(spec?.constraints || []),
+    ...(spec?.requiredArtifacts || []),
+    task.note || '',
+    task.description || '',
+  ]
+  for (const candidate of candidates) {
+    const dir = extractWorkdir(candidate)
+    if (dir) return dir
+  }
+  return undefined
+}
+
+export function runWorkdir(run: { environment?: { workdir?: string } } | undefined, task: WorkTaskRecord | undefined): string | undefined {
+  return run?.environment?.workdir || taskWorkdir(task)
+}
+
+export function extractWorkdir(value: string): string | undefined {
+  for (const line of value.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:workdir|working directory|checkout|directory)\s*:\s*(.+?)\s*$/i)
+    const candidate = match?.[1]?.trim()
+    if (candidate && path.isAbsolute(candidate)) return canonicalWorkdir(candidate)
+  }
+  const inline = value.match(/\b(?:workdir|checkout)=([^\s,;]+)/i)?.[1]
+  return inline && path.isAbsolute(inline) ? canonicalWorkdir(inline) : undefined
+}
+
+export function canonicalWorkdir(directory: string): string {
+  try { return fs.realpathSync(directory) } catch { return path.resolve(directory) }
+}
+
+export function isNotFoundError(err: any): boolean {
+  const status = Number(err?.status || err?.statusCode || err?.response?.status || err?.data?.statusCode || err?.error?.status)
+  return status === 404 || /(^|\D)404(\D|$)|not found/i.test(String(err?.message || err))
+}
+
+export function sessionAttribution(session: any) {
+  const tokens = session?.tokens || {}
+  return {
+    costUsd: Number(session?.cost || 0),
+    inputTokens: Number(tokens.input || 0),
+    outputTokens: Number(tokens.output || 0),
+    reasoningTokens: Number(tokens.reasoning || 0),
+    cacheReadTokens: Number(tokens.cache?.read || 0),
+    cacheWriteTokens: Number(tokens.cache?.write || 0),
+  }
+}
+
+export function latestAssistantError(messages: any[]): string | undefined {
+  for (const message of [...messages].reverse()) {
+    const role = message?.info?.role || message?.role
+    if (role !== 'assistant') continue
+    const error = message?.info?.error || message?.error
+    if (!error) return undefined
+    return formatAssistantError(error)
+  }
+  return undefined
+}
+
+export function formatAssistantError(error: any): string {
+  const detail = error?.data?.message || error?.message || error?.name || String(error)
+  const status = error?.data?.statusCode ? `HTTP ${error.data.statusCode}: ` : ''
+  return `OpenCode assistant error: ${status}${detail}`
+}
+
+export function runAttribution(run: RunAttributionInput): RunAttributionInput {
+  return {
+    costUsd: run.costUsd,
+    inputTokens: run.inputTokens,
+    outputTokens: run.outputTokens,
+    reasoningTokens: run.reasoningTokens,
+    cacheReadTokens: run.cacheReadTokens,
+    cacheWriteTokens: run.cacheWriteTokens,
+  }
+}
+
+export function optionalAcquisitionString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+export function sessionTitle(session: any): string {
+  return String(session?.title || session?.info?.title || session?.name || '')
+}
+
+export function completionQueueMessage(task: WorkTaskRecord, run: { stage: string }, decision: WorkflowDecision | undefined, result: StageResult): string | undefined {
+  if (!decision) return undefined
+  if (decision.nextStage) return `Scheduler advanced ${task.title}: ${run.stage} -> ${decision.nextStage}`
+  if (decision.retryStage) return `Scheduler retrying ${task.title}: ${run.stage} -> ${decision.retryStage}`
+  if (decision.taskStatus === 'done') return `Scheduler completed: ${task.title}`
+  if (decision.taskStatus === 'blocked') return `Scheduler blocked ${task.title}: ${decision.blockedReason || result.summary}`
+  return undefined
+}
+

--- a/products/gateway/src/scheduler.ts
+++ b/products/gateway/src/scheduler.ts
@@ -2,11 +2,10 @@ import type { DurableOpencodeClient as OpencodeClient } from './opencode-session
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { createHash } from 'node:crypto'
-import { spawnSync } from 'node:child_process'
 import { decideTaskCapacityAdmission, type CapacityAdmission, type CapacitySelection } from './capacity.js'
-import { agentProfileRevision, getConfig, getProfile, type AgentProfile, type AgentTeamConfig, type GatewayConfig } from './config.js'
+import { agentProfileRevision, getConfig, getProfile, type GatewayConfig } from './config.js'
 import { canCurrentDaemonWrite, captureCurrentDaemonLeadershipEpoch, getCurrentDaemonLeadershipStatus } from './daemon-leadership.js'
-import { environmentControllerForBackend, environmentControllerForSpec, environmentPromptContext, redactEnvironmentRecord, resolveEnvironmentSpec, type EnvironmentAttachmentResult, type EnvironmentController, type EnvironmentHydrationResult, type EnvironmentRunRecord, type EnvironmentSourcePlan, type EnvironmentSpec } from './environments.js'
+import { environmentControllerForBackend, environmentControllerForSpec, environmentPromptContext, redactEnvironmentRecord, resolveEnvironmentSpec, type EnvironmentAttachmentResult, type EnvironmentController, type EnvironmentHydrationResult, type EnvironmentRunRecord, type EnvironmentSpec } from './environments.js'
 import { queueEvent } from './wakeup.js'
 import { recordWorkerCompletion } from './observability.js'
 import { trackWorker, updateWorker } from './workers.js'
@@ -49,7 +48,6 @@ import {
   type WorkDependencyRecord,
   workStatePath,
   type RunRecord,
-  type RunAttributionInput,
   currentWorkDbLeadershipEpoch,
   isStaleWorkDbLeadershipError,
   withWorkDbLeadershipEpoch,
@@ -57,17 +55,38 @@ import {
 import { countRunsForTask } from './work-store/queries.js'
 import {
   buildStagePrompt,
-  mergeTaskQualitySpecDefaults,
   parseStageResult,
-  profileForStage,
-  type TaskQualitySpec,
   type StageResult,
   type WorkflowDecision,
-  type FailureClass,
 } from './workflow.js'
 import { resolveReviewGateIsolation } from './review-gate-isolation.js'
 import { buildRuntimeIsolationProfile, runtimeIsolationPromptContext, summarizeRuntimeIsolationProfile, validateRuntimeIsolationSpec } from './runtime-isolation.js'
 import { buildRuntimeCapabilityGrant, runtimeCapabilityGrantPromptContext, summarizeRuntimeCapabilityGrant, type RuntimeCapabilityGrant } from './runtime-capability-grants.js'
+import {
+  buildDependencySourcePlan,
+  classifyRuntimeFailure,
+  completionQueueMessage,
+  deadlineRank,
+  dependencyTaskIdsFor,
+  dispatchStartLeaseMs,
+  evaluateEnvironmentCapacity,
+  isNotFoundError,
+  latestAssistantError,
+  optionalAcquisitionString,
+  priorityRank,
+  requiredToolsForTask,
+  resolveTaskStageAgent,
+  runAttribution,
+  runWorkdir,
+  sessionAttribution,
+  sessionTitle,
+  shortFailure,
+  taskWorkdir,
+  type TaskStageResolution,
+} from './scheduler-helpers.js'
+
+export type { TaskStageResolution } from './scheduler-helpers.js'
+export { resolveTaskStageAgent, dispatchStartLeaseMs, isNotFoundError } from './scheduler-helpers.js'
 
 let schedulerCyclePromise: Promise<SchedulerCycleSnapshots> | null = null
 let schedulerAdmissionOpen = true
@@ -89,20 +108,6 @@ const ACQUISITION_ABSENCE_GRACE_MS = 5 * 60 * 1000
 function loadLiveWorkState(): WorkState {
   return loadWorkState(undefined, { runsScope: 'live' })
 }
-
-export type TaskStageResolution =
-  | {
-      ok: true
-      stage: string
-      source: string
-      profileName: string
-      profile: AgentProfile
-      agentTeamName?: string
-      agentTeam?: AgentTeamConfig
-      agentTeamVersion?: string
-      qualitySpec?: TaskQualitySpec
-    }
-  | { ok: false; stage: string; source: string; reason: string; agentTeamName?: string; profileName?: string }
 
 export interface SchedulerCycleSnapshots {
   /** Whole-state snapshot taken at the start of the cycle, before any mutation. */
@@ -1067,10 +1072,6 @@ async function reconcileAbandonedDispatchAcquisitions(client: OpencodeClient): P
   return reconciled
 }
 
-function optionalAcquisitionString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value : undefined
-}
-
 function reconcileResourceLessEnvironmentAcquisition(acquisition: TaskDispatchAcquisitionRecord, now: number): { cleanupProven: boolean } {
   const environmentName = optionalAcquisitionString(acquisition.metadata['environmentName'])
   const expectedSpecHash = optionalAcquisitionString(acquisition.metadata['specHash'])
@@ -1109,71 +1110,6 @@ function reconcileResourceLessEnvironmentAcquisition(acquisition: TaskDispatchAc
   }
   const createdAt = Date.parse(acquisition.createdAt)
   return { cleanupProven: Number.isFinite(createdAt) && now - createdAt >= ACQUISITION_ABSENCE_GRACE_MS }
-}
-
-function sessionTitle(session: any): string {
-  return String(session?.title || session?.info?.title || session?.name || '')
-}
-
-export function resolveTaskStageAgent(task: WorkTaskRecord, state: WorkState, stage: string, config: GatewayConfig = getConfig()): TaskStageResolution {
-  const roadmap = state.roadmaps.find(row => row.id === task.roadmapId)
-  const contextTeamName = task.agentTeam || roadmap?.agentTeam
-  const contextTeam = contextTeamName ? config.agentTeams[contextTeamName] : undefined
-  if (contextTeamName && !contextTeam) return { ok: false, stage, source: task.agentTeam ? 'task.agentTeam' : 'roadmap.agentTeam', reason: `Agent team not found: ${contextTeamName}`, agentTeamName: contextTeamName }
-
-  const taskProfile = profileOverrideForStage(task.stageProfiles, stage)
-  if (taskProfile) return validateResolvedProfile(task, stage, 'task.stageProfiles', taskProfile, contextTeamName, contextTeam, config)
-
-  if (task.agentTeam && contextTeam) {
-    const profileName = profileForAgentTeamStage(contextTeam, stage)
-    if (!profileName) return { ok: false, stage, source: 'task.agentTeam', reason: `Agent team ${task.agentTeam} has no role for stage ${stage}`, agentTeamName: task.agentTeam }
-    return validateResolvedProfile(task, stage, 'task.agentTeam', profileName, task.agentTeam, contextTeam, config)
-  }
-
-  if (roadmap?.agentTeam) {
-    const roadmapTeam = config.agentTeams[roadmap.agentTeam]
-    if (!roadmapTeam) return { ok: false, stage, source: 'roadmap.agentTeam', reason: `Agent team not found: ${roadmap.agentTeam}`, agentTeamName: roadmap.agentTeam }
-    const profileName = profileForAgentTeamStage(roadmapTeam, stage)
-    if (!profileName) return { ok: false, stage, source: 'roadmap.agentTeam', reason: `Agent team ${roadmap.agentTeam} has no role for stage ${stage}`, agentTeamName: roadmap.agentTeam }
-    return validateResolvedProfile(task, stage, 'roadmap.agentTeam', profileName, roadmap.agentTeam, roadmapTeam, config)
-  }
-
-  return validateResolvedProfile(task, stage, 'scheduler.stageProfiles', profileForStage(stage, config.scheduler), undefined, undefined, config)
-}
-
-function validateResolvedProfile(task: WorkTaskRecord, stage: string, source: string, profileName: string, agentTeamName: string | undefined, agentTeam: AgentTeamConfig | undefined, config: GatewayConfig): TaskStageResolution {
-  const profile = config.profiles[profileName]
-  if (!profile) return { ok: false, stage, source, reason: `Profile not found for stage ${stage}: ${profileName}`, agentTeamName, profileName }
-  const missing = missingCapabilities(agentTeam, stage, profile)
-  if (missing.length) {
-    return { ok: false, stage, source, reason: `Profile ${profileName} does not satisfy agent team ${agentTeamName} requirements for ${stage}: ${missing.join(', ')}`, agentTeamName, profileName }
-  }
-  const qualitySpec = agentTeam ? mergeTaskQualitySpecDefaults(task.qualitySpec, agentTeam.qualitySpecDefaults) : task.qualitySpec
-  return { ok: true, stage, source, profileName, profile, agentTeamName, agentTeam, agentTeamVersion: agentTeam?.revision, qualitySpec }
-}
-
-function profileOverrideForStage(stageProfiles: Record<string, string> | undefined, stage: string): string | undefined {
-  return stageProfiles?.[stage] || stageProfiles?.['default']
-}
-
-function profileForAgentTeamStage(team: AgentTeamConfig, stage: string): string | undefined {
-  return team.roles[stage] || team.roles['default']
-}
-
-function missingCapabilities(team: AgentTeamConfig | undefined, stage: string, profile: AgentProfile): string[] {
-  if (!team) return []
-  const required = [...(team.capabilityRequirements['default'] || []), ...(team.capabilityRequirements[stage] || [])]
-  return required.filter(capability => !profileHasCapability(profile, capability))
-}
-
-function profileHasCapability(profile: AgentProfile, capability: string): boolean {
-  if (profile.agent === capability) return true
-  if (profile.skills.includes(capability)) return true
-  if (profile.capabilities?.includes(capability)) return true
-  if (profile.tools?.includes(capability)) return true
-  if (profile.mcpServers?.includes(capability)) return true
-  const permission = profile.permission || {}
-  return permission[capability] === 'allow' || permission[`${capability}_`] === 'allow' || permission[`${capability}_*`] === 'allow'
 }
 
 function blockTaskForResolutionFailure(task: WorkTaskRecord, resolution: Extract<TaskStageResolution, { ok: false }>): void {
@@ -1228,31 +1164,8 @@ function recordCapacityHold(task: WorkTaskRecord, admission: CapacityAdmission, 
 }
 
 function announceCompletion(task: WorkTaskRecord, run: { stage: string }, decision: WorkflowDecision | undefined, result: StageResult): void {
-  if (!decision) return
-  if (decision.nextStage) {
-    queueEvent(`Scheduler advanced ${task.title}: ${run.stage} -> ${decision.nextStage}`)
-    return
-  }
-  if (decision.retryStage) {
-    queueEvent(`Scheduler retrying ${task.title}: ${run.stage} -> ${decision.retryStage}`)
-    return
-  }
-  if (decision.taskStatus === 'done') {
-    queueEvent(`Scheduler completed: ${task.title}`)
-    return
-  }
-  if (decision.taskStatus === 'blocked') {
-    queueEvent(`Scheduler blocked ${task.title}: ${decision.blockedReason || result.summary}`)
-  }
-}
-
-function priorityRank(priority: string): number {
-  return priority === 'HIGH' ? 0 : priority === 'MEDIUM' ? 1 : 2
-}
-
-function deadlineRank(value?: string): number {
-  const ms = Date.parse(value || '')
-  return Number.isFinite(ms) ? ms : Number.MAX_SAFE_INTEGER
+  const message = completionQueueMessage(task, run, decision, result)
+  if (message) queueEvent(message)
 }
 
 function leaseOptions() {
@@ -1270,12 +1183,6 @@ function leaseOptions() {
     leaseMs: scheduler.leaseMs,
     generation: `leadership:${epoch.scope}:${generation}`,
   }
-}
-
-export function dispatchStartLeaseMs(config: ReturnType<typeof getConfig>, environmentSpec: EnvironmentSpec): number {
-  const prepareTimeoutMs = Number(environmentSpec.resources.timeoutMs || 0)
-  const schedulerBufferMs = Math.max(config.scheduler.intervalMs * 3, 30_000)
-  return Math.max(config.scheduler.leaseMs, prepareTimeoutMs > 0 ? prepareTimeoutMs + schedulerBufferMs : 0)
 }
 
 async function handleRuntimeFailure(client: OpencodeClient, run: { id: string; sessionId: string; stage: string; attempt: number; profile?: string; resolvedProfile?: string }, task: WorkTaskRecord, message: string, directory: string | undefined, source: 'assistant' | 'prompt'): Promise<void> {
@@ -1317,22 +1224,6 @@ async function handleRuntimeFailure(client: OpencodeClient, run: { id: string; s
   } else if (timeline.action === 'blocked') {
     queueEvent(timeline.queueMessage)
   }
-}
-
-type RuntimeFailureKind = 'provider_balance' | 'provider_auth' | 'provider_quota' | 'provider_model' | 'transport' | 'unknown'
-
-function classifyRuntimeFailure(message: string): { kind: RuntimeFailureKind; terminal: boolean; summary: string; failureClass: FailureClass; nextAction: string } {
-  const text = message.toLowerCase()
-  if (/model (not found|not available|unavailable|unknown|unsupported)|provider (not found|not configured|unknown|unsupported|unavailable)|no such model|invalid model|model .*does not exist|provider .*does not exist/.test(text)) return terminalFailure('provider_model', 'Provider/model configuration failure', message, 'needs_credentials', 'Validate the configured provider/model in OpenCode, update the Gateway profile, then retry the task.')
-  if (/insufficient balance|billing|payment required|no credits|credit balance|402/.test(text)) return terminalFailure('provider_balance', 'Provider balance or billing failure', message, 'exceeded_budget', 'Top up or rotate the configured model/provider account, then retry the task.')
-  if (/unauthorized|forbidden|invalid api key|invalid token|authentication|permission denied|401|403/.test(text)) return terminalFailure('provider_auth', 'Provider authentication failure', message, 'needs_credentials', 'Rotate or fix provider credentials, then retry the task.')
-  if (/quota exceeded|rate limit|too many requests|capacity exceeded|429/.test(text)) return terminalFailure('provider_quota', 'Provider quota or rate-limit failure', message, 'exceeded_budget', 'Wait for quota reset or change provider limits before retrying.')
-  if (/fetch failed|econnreset|etimedout|timeout|timed out|socket|network|temporar|503|502|504|unavailable/.test(text)) return { kind: 'transport', terminal: false, summary: `Transient OpenCode transport failure: ${shortFailure(message)}`, failureClass: 'flaky_test', nextAction: 'Gateway will retry with bounded backoff; inspect OpenCode/network health if failures repeat.' }
-  return { kind: 'unknown', terminal: false, summary: `OpenCode runtime failure: ${shortFailure(message)}`, failureClass: 'flaky_test', nextAction: 'Gateway will retry with bounded backoff; inspect the session and provider logs if failures repeat.' }
-}
-
-function terminalFailure(kind: RuntimeFailureKind, label: string, message: string, failureClass: FailureClass, nextAction: string) {
-  return { kind, terminal: true, summary: `${label}: ${shortFailure(message)}`, failureClass, nextAction }
 }
 
 function recordFailureAlert(task: WorkTaskRecord, run: { id: string; stage: string; attempt: number; resolvedProfile?: string; profile?: string }, failure: ReturnType<typeof classifyRuntimeFailure>, source: string): void {
@@ -1484,168 +1375,6 @@ function settleDispatchAcquisitionBestEffort(dispatchId: string, kind: 'environm
   }
 }
 
-function evaluateEnvironmentCapacity(environment: EnvironmentSpec, state: WorkState, config: GatewayConfig): { allowed: boolean; reason: string; used: number; limit: number } {
-  const active = state.runs.filter(run => run.environment && (isActiveRunStatus(run.status) || run.environment.status === 'retained'))
-  const retained = active.filter(run => run.environment?.status === 'retained')
-  const retainedLimit = config.environments.maxRetained
-  if (retainedLimit === 0 ? retained.length > 0 : retained.length >= retainedLimit) return { allowed: false, reason: `retained environment limit exhausted (${retained.length}/${retainedLimit})`, used: retained.length, limit: retainedLimit }
-  const globalLimit = Math.max(1, config.environments.maxConcurrent || config.scheduler.maxConcurrent)
-  if (active.length >= globalLimit) return { allowed: false, reason: `environment concurrency exhausted (${active.length}/${globalLimit})`, used: active.length, limit: globalLimit }
-  const backendLimit = config.environments.backendMaxConcurrent[environment.backend]
-  if (backendLimit) {
-    const sameBackend = active.filter(run => run.environment?.backend === environment.backend).length
-    if (sameBackend >= backendLimit) return { allowed: false, reason: `environment backend ${environment.backend} concurrency exhausted (${sameBackend}/${backendLimit})`, used: sameBackend, limit: backendLimit }
-  }
-  const specLimit = environment.resources.maxConcurrent
-  if (specLimit) {
-    const sameSpec = active.filter(run => run.environment?.specHash === environment.specHash).length
-    if (sameSpec >= specLimit) return { allowed: false, reason: `environment ${environment.name} concurrency exhausted (${sameSpec}/${specLimit})`, used: sameSpec, limit: specLimit }
-  }
-  return { allowed: true, reason: 'environment capacity available', used: active.length, limit: globalLimit }
-}
-
-function dependencyTaskIdsFor(taskId: string, state: WorkState): string[] {
-  return (state.dependencies || [])
-    .filter(dependency => dependency.taskId === taskId && (dependency.type === 'blocks' || dependency.type === 'blocked_by' || dependency.type === 'parent'))
-    .map(dependency => dependency.dependsOnTaskId)
-    .sort()
-}
-
-function buildDependencySourcePlan(state: WorkState, workdir: string | undefined, dependencyTaskIds: string[]): EnvironmentSourcePlan {
-  const baseRef = sourceBaseRef(workdir)
-  if (!dependencyTaskIds.length) return { required: false, baseRef, workdir, dependencyTaskIds: [], patches: [], missing: [] }
-  const patches: EnvironmentSourcePlan['patches'] = []
-  const missing: EnvironmentSourcePlan['missing'] = []
-  for (const dependencyTaskId of dependencyTaskIds) {
-    const runs = state.runs
-      .filter(run => run.taskId === dependencyTaskId && run.status === 'passed' && run.result)
-      .sort((a, b) => Date.parse(a.startedAt) - Date.parse(b.startedAt))
-    const beforeCount = patches.length
-    runs.forEach(run => {
-      for (const [index, ref] of patchRefsFromRun(run).entries()) {
-        const patchPath = resolvePatchPath(ref, workdir)
-        if (!patchPath || !fs.existsSync(patchPath)) {
-          missing.push({ taskId: dependencyTaskId, reason: `patch artifact not found: ${ref}` })
-          continue
-        }
-        const content = fs.readFileSync(patchPath, 'utf8')
-        if (!content.trim()) {
-          missing.push({ taskId: dependencyTaskId, reason: `patch artifact is empty: ${ref}` })
-          continue
-        }
-        patches.push({
-          id: `${dependencyTaskId}:${run.id}:${index + 1}`,
-          taskId: dependencyTaskId,
-          runId: run.id,
-          stage: run.stage,
-          ref,
-          path: patchPath,
-          content,
-          changedFiles: changedFilesFromPatch(content),
-        })
-      }
-    })
-    if (patches.length === beforeCount) missing.push({ taskId: dependencyTaskId, reason: 'missing patch artifact' })
-  }
-  return { required: true, baseRef, workdir, dependencyTaskIds, patches, missing }
-}
-
-function patchRefsFromRun(run: RunRecord): string[] {
-  if (!run.result) return []
-  const refs = [
-    ...(run.result.artifacts || []),
-    ...(run.result.evidence || []).map(item => item.ref),
-  ]
-  return uniqueStrings(refs.map(parsePatchRef).filter((ref): ref is string => Boolean(ref)))
-}
-
-function parsePatchRef(value: string | undefined): string | undefined {
-  const text = String(value || '').trim()
-  const prefixed = /^(?:patch|patch-file|diff-file):\s*(.+)$/i.exec(text)
-  if (prefixed) return prefixed[1]!.trim()
-  return /\.(?:patch|diff)$/i.test(text) ? text : undefined
-}
-
-function resolvePatchPath(ref: string, workdir: string | undefined): string | undefined {
-  const fileRef = ref.startsWith('file://') ? new URL(ref).pathname : ref
-  if (!workdir) return undefined
-  const resolved = path.isAbsolute(fileRef) ? fileRef : path.resolve(workdir, fileRef)
-  const relative = path.relative(workdir, resolved)
-  if (relative.startsWith('..') || path.isAbsolute(relative)) return undefined
-  return resolved
-}
-
-function changedFilesFromPatch(content: string): string[] {
-  const files: string[] = []
-  for (const line of content.split(/\r?\n/)) {
-    const diff = /^diff --git a\/(.+?) b\/(.+)$/.exec(line)
-    if (diff) files.push(diff[2] === '/dev/null' ? diff[1]! : diff[2]!)
-    const added = /^\+\+\+ b\/(.+)$/.exec(line)
-    if (added && added[1] !== '/dev/null') files.push(added[1]!)
-  }
-  return uniqueStrings(files).sort()
-}
-
-function sourceBaseRef(workdir: string | undefined): string {
-  if (!workdir) return 'none'
-  const result = spawnSync('git', ['-C', workdir, 'rev-parse', 'HEAD'], { encoding: 'utf8', maxBuffer: 1024 * 1024 })
-  const ref = result.status === 0 ? result.stdout.trim() : ''
-  return ref || `workdir:${path.resolve(workdir)}`
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return Array.from(new Set(values.filter(Boolean)))
-}
-
-function shortFailure(message: string): string {
-  return message.replace(/\s+/g, ' ').trim().substring(0, 500)
-}
-
-function requiredToolsForTask(task: WorkTaskRecord, qualitySpec: TaskQualitySpec | undefined): string[] {
-  const spec = qualitySpec || task.qualitySpec
-  const tools = new Set<string>()
-  for (const tool of spec?.requiredTools || []) addTool(tools, tool)
-  for (const value of [task.note || '', task.description || '', ...(spec?.constraints || []), ...(spec?.systemsTouched || [])]) {
-    for (const tool of parseRequiredTools(value)) addTool(tools, tool)
-  }
-  return [...tools].sort()
-}
-
-function parseRequiredTools(value: string): string[] {
-  const tools: string[] = []
-  for (const line of value.split(/\r?\n/)) {
-    const match = line.match(/^\s*(?:required tools|preflight tools|tools)\s*:\s*(.+?)\s*$/i)
-    if (match?.[1]) tools.push(...match[1].split(/[,;]/))
-  }
-  return tools
-}
-
-function addTool(tools: Set<string>, value: string): void {
-  const tool = value.replace(/`/g, '').trim().split(/\s+/)[0]?.toLowerCase()
-  if (tool) tools.add(tool)
-}
-
-function taskWorkdir(task: WorkTaskRecord | undefined): string | undefined {
-  if (!task) return undefined
-  const spec = task.qualitySpec
-  const candidates = [
-    ...(spec?.systemsTouched || []),
-    ...(spec?.constraints || []),
-    ...(spec?.requiredArtifacts || []),
-    task.note || '',
-    task.description || '',
-  ]
-  for (const candidate of candidates) {
-    const dir = extractWorkdir(candidate)
-    if (dir) return dir
-  }
-  return undefined
-}
-
-function runWorkdir(run: { environment?: { workdir?: string } } | undefined, task: WorkTaskRecord | undefined): string | undefined {
-  return run?.environment?.workdir || taskWorkdir(task)
-}
-
 /**
  * Gateway-owned fallback workspace for an unbound local-process task: a stable
  * per-project (per-roadmap, else per-task) directory under the state dir, created
@@ -1657,20 +1386,6 @@ function ensureDefaultWorkspace(task: WorkTaskRecord): string {
   const workspace = path.join(path.dirname(workStatePath()), 'workspaces', key)
   fs.mkdirSync(workspace, { recursive: true })
   return workspace
-}
-
-function extractWorkdir(value: string): string | undefined {
-  for (const line of value.split(/\r?\n/)) {
-    const match = line.match(/^\s*(?:workdir|working directory|checkout|directory)\s*:\s*(.+?)\s*$/i)
-    const candidate = match?.[1]?.trim()
-    if (candidate && path.isAbsolute(candidate)) return canonicalWorkdir(candidate)
-  }
-  const inline = value.match(/\b(?:workdir|checkout)=([^\s,;]+)/i)?.[1]
-  return inline && path.isAbsolute(inline) ? canonicalWorkdir(inline) : undefined
-}
-
-function canonicalWorkdir(directory: string): string {
-  try { return fs.realpathSync(directory) } catch { return path.resolve(directory) }
 }
 
 async function abortSession(client: OpencodeClient, sessionId: string, directory?: string): Promise<void> {
@@ -1740,52 +1455,7 @@ function markRecoveredWorkers(state: WorkState, recovered: { runIds: string[] },
   }
 }
 
-export function isNotFoundError(err: any): boolean {
-  const status = Number(err?.status || err?.statusCode || err?.response?.status || err?.data?.statusCode || err?.error?.status)
-  return status === 404 || /(^|\D)404(\D|$)|not found/i.test(String(err?.message || err))
-}
-
 export function getSchedulerLeaseSummary(state: WorkState = loadLiveWorkState()) {
   // Live scope: summarizeWorkLeases only considers active runs.
   return runLeasePort.summarizeLeases(state)
-}
-
-function sessionAttribution(session: any) {
-  const tokens = session?.tokens || {}
-  return {
-    costUsd: Number(session?.cost || 0),
-    inputTokens: Number(tokens.input || 0),
-    outputTokens: Number(tokens.output || 0),
-    reasoningTokens: Number(tokens.reasoning || 0),
-    cacheReadTokens: Number(tokens.cache?.read || 0),
-    cacheWriteTokens: Number(tokens.cache?.write || 0),
-  }
-}
-
-function latestAssistantError(messages: any[]): string | undefined {
-  for (const message of [...messages].reverse()) {
-    const role = message?.info?.role || message?.role
-    if (role !== 'assistant') continue
-    const error = message?.info?.error || message?.error
-    if (!error) return undefined
-    return formatAssistantError(error)
-  }
-  return undefined
-}
-
-function formatAssistantError(error: any): string {
-  const detail = error?.data?.message || error?.message || error?.name || String(error)
-  const status = error?.data?.statusCode ? `HTTP ${error.data.statusCode}: ` : ''
-  return `OpenCode assistant error: ${status}${detail}`
-}
-
-function runAttribution(run: RunAttributionInput): RunAttributionInput {
-  return {
-    costUsd: run.costUsd,
-    inputTokens: run.inputTokens,
-    outputTokens: run.outputTokens,
-    reasoningTokens: run.reasoningTokens,
-    cacheReadTokens: run.cacheReadTokens,
-    cacheWriteTokens: run.cacheWriteTokens,
-  }
 }

--- a/products/gateway/src/work-store.ts
+++ b/products/gateway/src/work-store.ts
@@ -5,7 +5,7 @@ import { getConfig, type HumanGateTimeoutAction } from './config.js'
 import { cleanupFailedEnvironmentRun, environmentControllerForBackend, finalizeEnvironmentRun, normalizeEnvironmentSelector, redactEnvironmentRecord, type EnvironmentRunRecord, type EnvironmentSelector } from './environments.js'
 import { type RunStatus, type StageResult, type WorkStatus } from './workflow.js'
 import { closeWorkDb, queryRows, resetWorkDbInitState, withWorkDb, workStatePath } from './work-store/db.js'
-import { normalizeRoadmapQualitySpec, rowToEvent, rowToHumanGate, rowToSupervisorWakeupReceipt, rowToTaskDispatchReceipt } from './work-store/row-mappers.js'
+import { normalizeRoadmapQualitySpec, rowToHumanGate, rowToSupervisorWakeupReceipt, rowToTaskDispatchReceipt } from './work-store/row-mappers.js'
 import { normalizeOptionalIsoTime, normalizeOptionalString, normalizePriority, normalizeProjectAlias, normalizeRequiredString, normalizeStage, normalizeStringList, normalizeThreadId } from './work-store/validators.js'
 import { redactSensitiveText } from './security.js'
 import { isActiveRunStatus, isTaskActiveStatus, shouldAbortActiveRunForTaskStatus } from './runtime-state-machine.js'
@@ -53,15 +53,9 @@ import { appendWorkEventRow } from './work-store/event-append.js'
 import {
   applyRoadmapSupervisorUpdate,
   compareRoadmapSupervisors,
-  completeSupervisorWakeupReceiptRow,
   createRoadmapSupervisorInState,
   defaultRoadmapSupervisor,
-  nextSupervisorReviewAt,
   reconcileDefaultSupervisorInState,
-  supervisorEligibleForWakeup,
-  supervisorWakeupIdempotencyKey,
-  supervisorWakeupReason,
-  upsertSupervisorWakeupReceiptRow,
 } from './work-store/supervisor-helpers.js'
 import {
   approveRoadmapCompletionProposalInState,
@@ -100,7 +94,6 @@ import {
   createWorkTaskInState,
   validateTaskUpdate,
   addWorkDependencyInState,
-  assertRoadmapAcceptsTasks,
   assertStageInPipeline,
   normalizeOptionalAgentTeam,
   normalizeTaskCreateList,
@@ -133,14 +126,8 @@ export {
 
 import {
   findDelegationReceiptInDb,
-  upsertDelegationReceiptRow,
   appendDelegationProgressForTask,
   appendDelegationProgressForRoadmap,
-  appendDelegationProgressRow,
-  receiptLinks,
-  nextDelegationSchedulerAction,
-  delegationProgressKey,
-  supervisedProjectResultFromReceipt,
   updateDelegationReceiptsForDeletion,
 } from './work-store/delegation-helpers.js'
 import {
@@ -214,7 +201,6 @@ import type {
   ActiveRunControlReason,
   ActiveRunControlResult,
   ActiveRunControlSnapshot,
-  DelegatedWorkMutationInput,
   DelegatedWorkReceipt,
   HumanGateDecisionInput,
   HumanGateDecisionResult,
@@ -235,18 +221,13 @@ import type {
   RoadmapRecord,
   RoadmapSupervisorCreateInput,
   RoadmapSupervisorRecord,
-  RoadmapSupervisorResultApplyInput,
-  RoadmapSupervisorResultApplyResult,
   RoadmapSupervisorStatus,
   RoadmapSupervisorUpdateInput,
-  RoadmapSupervisorWakeupRecord,
   RoadmapUpdateInput,
   RunAttributionInput,
   RunLeaseExpectation,
   RunRecord,
   RunResolutionInput,
-  SupervisedProjectCreateInput,
-  SupervisedProjectCreateResult,
   SupervisorWakeupReceiptRecord,
   SupervisorWakeupReceiptStatus,
   WorkDependencyInput,
@@ -447,253 +428,17 @@ export function createRoadmapWithTasks(input: { title: string; priority?: 'HIGH'
   })
 }
 
-/** One dependency edge in a {@link PlanInitiativeInput}, addressed by task ref. */
-export interface PlanInitiativeDependency {
-  /** The dependent task: a 0-based index into `tasks[]`, or a new task's title, or an existing task id. */
-  taskRef: string | number
-  /** The prerequisite task that must complete first, addressed the same way as {@link taskRef}. */
-  dependsOnRef: string | number
-  type?: WorkDependencyType
-}
-
-/** Full spec for {@link planInitiative}: a roadmap, its tasks, their dependency edges, and an optional supervisor. */
-export interface PlanInitiativeInput {
-  title: string
-  priority?: 'HIGH' | 'MEDIUM' | 'LOW'
-  agentTeam?: string
-  environment?: EnvironmentSelector
-  qualitySpec?: RoadmapQualitySpec
-  tasks?: WorkTaskCreateInput[]
-  dependencies?: PlanInitiativeDependency[]
-  /** When provided (with a sessionId), an Initiative Supervisor is bound in the same transaction. */
-  supervisor?: Omit<RoadmapSupervisorCreateInput, 'roadmapId'>
-}
-
-export interface PlanInitiativeResult {
-  roadmap: RoadmapRecord
-  tasks: WorkTaskRecord[]
-  dependencies: WorkDependencyRecord[]
-  supervisor?: RoadmapSupervisorRecord
-}
-
-/**
- * Atomically create an Initiative (roadmap), its child Issues (tasks), their
- * dependency edges, and — optionally — a bound supervisor, in one work-store
- * write transaction. Collapses roadmap_create_with_tasks + N task_dependency_add
- * (+ roadmap_supervisor_create) into a single all-or-nothing call: any failure
- * (missing task ref, dependency cycle, unknown profile) rolls the whole
- * transaction back so partial initiatives never persist.
- */
-export function planInitiative(input: PlanInitiativeInput, filePath = workStatePath()): PlanInitiativeResult {
-  return mutateWorkState(filePath, (state, db) => {
-    const now = new Date().toISOString()
-    const roadmap = createRoadmapInState(state, db, input, now)
-    const tasks = normalizeTaskCreateList(input.tasks || []).map(task => createWorkTaskInState(state, db, { ...task, roadmapId: task.roadmapId || roadmap.id }, now))
-    recomputeRoadmapStatusInState(state, roadmap.id, now)
-    appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id) }, now)
-
-    const resolveTaskRef = (ref: unknown, label: string): string => {
-      if (typeof ref === 'number') {
-        if (!Number.isInteger(ref) || ref < 0 || ref >= tasks.length) throw new Error(`${label} index out of range: ${ref}`)
-        return tasks[ref]!.id
-      }
-      if (typeof ref === 'string') {
-        const trimmed = ref.trim()
-        if (!trimmed) throw new Error(`${label} is required`)
-        const byTitle = tasks.filter(task => task.title === trimmed)
-        if (byTitle.length === 1) return byTitle[0]!.id
-        if (byTitle.length > 1) throw new Error(`${label} matches multiple new tasks by title: ${trimmed}`)
-        if (state.tasks.some(task => task.id === trimmed)) return trimmed
-        throw new Error(`${label} does not match a new task index/title or an existing task id: ${trimmed}`)
-      }
-      throw new Error(`${label} must be a task index (number) or a task title/id (string)`)
-    }
-
-    const dependencyInputs = Array.isArray(input.dependencies) ? input.dependencies : []
-    const dependencies = dependencyInputs.map((dep, index) => {
-      if (!dep || typeof dep !== 'object' || Array.isArray(dep)) throw new Error(`dependency at index ${index} must be an object`)
-      return addWorkDependencyInState(state, db, {
-        taskId: resolveTaskRef(dep.taskRef, `dependencies[${index}].taskRef`),
-        dependsOnTaskId: resolveTaskRef(dep.dependsOnRef, `dependencies[${index}].dependsOnRef`),
-        type: dep.type,
-      }, now)
-    })
-
-    let supervisor: RoadmapSupervisorRecord | undefined
-    const supervisorInput = input.supervisor
-    if (supervisorInput !== undefined && supervisorInput !== null) {
-      // A supervisor object without a sessionId is a validation error, not a
-      // silent no-op: createRoadmapSupervisorInState throws inside this same
-      // transaction so the whole initiative rolls back (matching the piecewise
-      // roadmap_supervisor_create behavior instead of dropping the supervisor).
-      if (typeof supervisorInput !== 'object' || Array.isArray(supervisorInput)) throw new Error('supervisor must be an object with a sessionId')
-      supervisor = createRoadmapSupervisorInState(state, { ...supervisorInput, roadmapId: roadmap.id }, now)
-      reconcileDefaultSupervisorInState(state, roadmap.id, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
-      appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
-    }
-
-    appendWorkEventRow(db, 'workflow.plan_initiative', roadmap.id, { taskIds: tasks.map(task => task.id), dependencyCount: dependencies.length, supervisorId: supervisor?.supervisorId }, now)
-    return { roadmap, tasks, dependencies, supervisor }
-  })
-}
-
-export function createSupervisedProject(input: SupervisedProjectCreateInput, filePath = workStatePath()): SupervisedProjectCreateResult {
-  return mutateWorkState(filePath, (state, db) => {
-    const idempotencyKey = normalizeOptionalString(input.idempotencyKey, 240)
-    if (idempotencyKey) {
-      const existing = findDelegationReceiptInDb(db, idempotencyKey)
-      if (existing) {
-        if (existing.targetType !== 'project_create') throw new Error(`idempotency key already used for ${existing.targetType}: ${idempotencyKey}`)
-        return { ...supervisedProjectResultFromReceipt(state, existing), idempotencyStatus: 'replayed' }
-      }
-    }
-    const now = new Date().toISOString()
-    const roadmap = createRoadmapInState(state, db, input.roadmap, now)
-    const tasks = normalizeTaskCreateList(input.tasks || []).map(task => createWorkTaskInState(state, db, { ...task, roadmapId: task.roadmapId || roadmap.id }, now))
-    recomputeRoadmapStatusInState(state, roadmap.id, now)
-    appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id) }, now)
-
-    const supervisor = createRoadmapSupervisorInState(state, { ...input.supervisor, roadmapId: roadmap.id }, now)
-    reconcileDefaultSupervisorInState(state, roadmap.id, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
-    appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
-
-    const previous = state.projectBindings.slice()
-    const binding = upsertProjectBindingInState(state, { ...input.binding, roadmapId: roadmap.id, title: input.binding.title || roadmap.title }, now)
-    for (const stale of previous.filter(row => row.id !== binding.id && !state.projectBindings.some(current => current.id === row.id))) deleteProjectBindingChannelRow(db, stale)
-    if (binding.provider && binding.chatId) {
-      upsertChannelBindingRow(db, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, sessionId: binding.sessionId, mode: 'roadmap', roadmapId: binding.roadmapId, title: binding.title || binding.alias }, now)
-      appendWorkEventRow(db, 'channel.binding.upserted', binding.sessionId, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, mode: 'roadmap', roadmapId: binding.roadmapId }, now)
-    }
-    appendWorkEventRow(db, 'project.binding.upserted', binding.roadmapId, { bindingId: binding.id, alias: binding.alias, scope: binding.scope, sessionId: binding.sessionId, provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId }, now)
-    if (input.event?.type) {
-      appendWorkEventRow(db, input.event.type, roadmap.id, {
-        alias: binding.alias,
-        sessionId: supervisor.sessionId,
-        taskIds: tasks.map(task => task.id),
-        ...(input.event.payload || {}),
-      }, now)
-    }
-    if (idempotencyKey) {
-      const receipt: DelegatedWorkReceipt = {
-        idempotencyKey,
-        idempotencyStatus: 'created',
-        targetType: 'project_create',
-        taskIds: tasks.map(task => task.id),
-        roadmapId: roadmap.id,
-        supervisorId: supervisor.supervisorId,
-        projectBindingId: binding.id,
-        parentSessionId: supervisor.sessionId,
-        links: receiptLinks(roadmap, tasks, supervisor, binding),
-        nextSchedulerAction: nextDelegationSchedulerAction(tasks, supervisor),
-      }
-      upsertDelegationReceiptRow(db, receipt, now)
-    }
-    return { roadmap, tasks, supervisor, binding, idempotencyStatus: idempotencyKey ? 'created' : undefined }
-  })
-}
-
-export function createDelegatedWork(input: DelegatedWorkMutationInput, filePath = workStatePath()): DelegatedWorkReceipt {
-  return mutateWorkState(filePath, (state, db) => {
-    const existing = findDelegationReceiptInDb(db, input.idempotencyKey)
-    if (existing) return { ...existing, idempotencyStatus: 'replayed' }
-
-    const now = new Date().toISOString()
-    appendWorkEventRow(db, 'delegation.accepted', input.parentSessionId, {
-      idempotencyKey: input.idempotencyKey,
-      targetType: input.targetType,
-      objective: input.objective,
-      parentSessionId: input.parentSessionId,
-      notificationTarget: input.notificationTarget,
-    }, now)
-
-    let roadmap: RoadmapRecord | undefined
-    let supervisor: RoadmapSupervisorRecord | undefined
-    let binding: ProjectBindingRecord | undefined
-    const tasks: WorkTaskRecord[] = []
-
-    if (input.issue) {
-      tasks.push(createWorkTaskInState(state, db, input.issue, now))
-      roadmap = state.roadmaps.find(row => row.id === input.issue!.roadmapId)
-    } else if (input.project) {
-      if (input.project.roadmapId) {
-        roadmap = state.roadmaps.find(row => row.id === input.project!.roadmapId)
-        if (!roadmap) throw new Error(`roadmap not found: ${input.project.roadmapId}`)
-        assertRoadmapAcceptsTasks(state, roadmap.id)
-        for (const task of normalizeTaskCreateList(input.project.tasks || [])) {
-          tasks.push(createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now))
-        }
-      } else {
-        roadmap = createRoadmapInState(state, db, {
-          title: input.project.title || input.objective,
-          priority: input.project.priority,
-          agentTeam: input.project.agentTeam,
-          environment: input.project.environment,
-          qualitySpec: input.project.qualitySpec,
-        }, now)
-        for (const task of normalizeTaskCreateList(input.project.tasks || [])) {
-          tasks.push(createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now))
-        }
-      }
-      if (roadmap) recomputeRoadmapStatusInState(state, roadmap.id, now)
-      if (roadmap && input.project.supervisor) {
-        supervisor = createRoadmapSupervisorInState(state, { ...input.project.supervisor, roadmapId: roadmap.id }, now)
-        reconcileDefaultSupervisorInState(state, supervisor.roadmapId, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
-        appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
-      }
-      if (roadmap && input.project.binding) {
-        binding = upsertProjectBindingInState(state, { ...input.project.binding, roadmapId: roadmap.id }, now)
-        if (binding.provider && binding.chatId) {
-          upsertChannelBindingRow(db, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, sessionId: binding.sessionId, mode: 'roadmap', roadmapId: binding.roadmapId, title: binding.title || binding.alias }, now)
-          appendWorkEventRow(db, 'channel.binding.upserted', binding.sessionId, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, mode: 'roadmap', roadmapId: binding.roadmapId }, now)
-        }
-        appendWorkEventRow(db, 'project.binding.upserted', binding.roadmapId, { bindingId: binding.id, alias: binding.alias, scope: binding.scope, sessionId: binding.sessionId, provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId }, now)
-      }
-      if (roadmap) appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id), delegated: true }, now)
-    } else {
-      throw new Error('delegation mutation requires issue or project input')
-    }
-
-    const receipt: DelegatedWorkReceipt = {
-      idempotencyKey: input.idempotencyKey,
-      idempotencyStatus: 'created',
-      targetType: input.targetType,
-      taskIds: tasks.map(task => task.id),
-      roadmapId: roadmap?.id,
-      supervisorId: supervisor?.supervisorId,
-      projectBindingId: binding?.id,
-      parentSessionId: input.parentSessionId,
-      links: receiptLinks(roadmap, tasks, supervisor, binding),
-      nextSchedulerAction: nextDelegationSchedulerAction(tasks, supervisor),
-    }
-    upsertDelegationReceiptRow(db, receipt, now)
-    appendWorkEventRow(db, 'delegation.mapped', roadmap?.id || tasks[0]?.id || input.parentSessionId, {
-      ...receipt,
-      idempotencyStatus: 'created',
-      idempotencyKey: input.idempotencyKey,
-      notificationTarget: input.notificationTarget,
-    }, now)
-    appendDelegationProgressRow(db, input.idempotencyKey, 'created', receipt.roadmapId || tasks[0]?.id || input.parentSessionId, {
-      ...receipt,
-      notificationTarget: input.notificationTarget,
-      progressKey: delegationProgressKey(input.idempotencyKey, 'created', receipt.roadmapId || tasks.map(task => task.id).join(',')),
-      summary: `Delegated work accepted: ${input.objective}`,
-    }, now)
-    for (const task of tasks.filter(task => task.manualGate)) {
-      appendDelegationProgressRow(db, input.idempotencyKey, 'gate_opened', task.id, {
-        ...receipt,
-        notificationTarget: input.notificationTarget,
-        taskId: task.id,
-        roadmapId: task.roadmapId,
-        status: task.status,
-        stage: task.currentStage,
-        manualGate: task.manualGate,
-        progressKey: delegationProgressKey(input.idempotencyKey, 'gate_opened', task.id, task.manualGate),
-        summary: `Delegated work is waiting: ${manualGateReason(task.manualGate!)}`,
-      }, now)
-    }
-    return receipt
-  })
-}
+export {
+  planInitiative,
+  createSupervisedProject,
+  createDelegatedWork,
+  acquireDueRoadmapSupervisorWakeups,
+  completeRoadmapSupervisorWakeup,
+  applyRoadmapSupervisorResult,
+  type PlanInitiativeDependency,
+  type PlanInitiativeInput,
+  type PlanInitiativeResult,
+} from './work-store/project-orchestration.js'
 
 export function getDelegationReceipt(idempotencyKey: string, filePath = workStatePath()): DelegatedWorkReceipt | undefined {
   return withWorkDb(filePath, db => findDelegationReceiptInDb(db, idempotencyKey))
@@ -780,210 +525,6 @@ export function archiveRoadmapSupervisor(supervisorId: string, input: { note?: s
     reconcileDefaultSupervisorInState(state, supervisor.roadmapId, undefined, now)
     appendWorkEventRow(db, 'roadmap.supervisor.archived', supervisor.roadmapId, { supervisorId, note: supervisor.note }, now)
     return supervisor
-  })
-}
-
-export function acquireDueRoadmapSupervisorWakeups(input: { now?: number; leaseOwner?: string; leaseMs?: number; limit?: number } = {}, filePath = workStatePath()): RoadmapSupervisorWakeupRecord[] {
-  return mutateWorkState(filePath, (state, db) => {
-    const nowMs = input.now || Date.now()
-    const now = new Date(nowMs).toISOString()
-    const leaseOwner = normalizeOptionalString(input.leaseOwner, 200) || `supervisor-${process.pid}`
-    const leaseMs = Math.max(60 * 1000, Math.min(input.leaseMs || 10 * 60 * 1000, 24 * 60 * 60 * 1000))
-    const limit = Math.max(1, Math.min(input.limit || 5, 50))
-    const cursors = state.supervisors.map(supervisor => supervisor.lastReviewedEventId || 0)
-    const minCursor = cursors.length ? Math.min(...cursors) : 0
-    const events = queryRows(db, 'SELECT * FROM events WHERE id > ? ORDER BY id ASC', minCursor).map(rowToEvent)
-    const wakeups: RoadmapSupervisorWakeupRecord[] = []
-
-    for (const supervisor of state.supervisors.sort(compareRoadmapSupervisors)) {
-      if (wakeups.length >= limit) break
-      if (!supervisorEligibleForWakeup(supervisor, nowMs)) continue
-      const due = supervisorWakeupReason(state, supervisor, events, nowMs)
-      if (!due) continue
-      const idempotencyKey = supervisorWakeupIdempotencyKey(supervisor, due)
-      supervisor.wakeLeaseOwner = leaseOwner
-      supervisor.wakeLeaseExpiresAt = new Date(nowMs + leaseMs).toISOString()
-      supervisor.lastWakeAt = now
-      supervisor.lastWakeReason = due.wakeReason
-      supervisor.lastWakeEventId = due.cursorEventId || supervisor.lastReviewedEventId
-      supervisor.updatedAt = now
-      const receipt = upsertSupervisorWakeupReceiptRow(db, supervisor, due, { idempotencyKey, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt }, now)
-      appendWorkEventRow(db, 'roadmap.supervisor.wakeup_acquired', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, wakeReason: due.wakeReason, reasonDetail: due.reasonDetail, eventIds: due.events.map(event => event.id), cursorEventId: due.cursorEventId, windowKey: due.windowKey, idempotencyKey, receiptId: receipt.id, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt }, now)
-      wakeups.push({ supervisor: { ...supervisor }, reason: due.reason, wakeReason: due.wakeReason, wakeReasonDetail: due.reasonDetail, triggerEvents: due.events, cursorEventId: due.cursorEventId, windowKey: due.windowKey, idempotencyKey, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt, receiptId: receipt.id, notificationPolicyRef: supervisor.notificationPolicyRef })
-    }
-    return wakeups
-  })
-}
-
-export function completeRoadmapSupervisorWakeup(supervisorId: string, input: { leaseOwner?: string; cursorEventId?: number; success?: boolean; note?: string; inspectedInputs?: string[]; changedObjectIds?: string[]; recommendation?: string; nextAction?: string } = {}, filePath = workStatePath()): RoadmapSupervisorRecord | undefined {
-  return mutateWorkState(filePath, (state, db) => {
-    const supervisor = state.supervisors.find(row => row.supervisorId === supervisorId)
-    if (!supervisor) return undefined
-    if (input.leaseOwner && supervisor.wakeLeaseOwner && supervisor.wakeLeaseOwner !== input.leaseOwner) return undefined
-    const now = new Date().toISOString()
-    const success = input.success !== false
-    const wakeLeaseOwner = input.leaseOwner || supervisor.wakeLeaseOwner
-    if (success) {
-      supervisor.lastReviewedEventId = Math.max(supervisor.lastReviewedEventId || 0, input.cursorEventId || supervisor.lastWakeEventId || 0)
-      supervisor.lastReviewAt = now
-      const explicitNextReview = Date.parse(supervisor.nextReviewAt || '')
-      supervisor.nextReviewAt = Number.isFinite(explicitNextReview) && explicitNextReview > Date.parse(now) ? supervisor.nextReviewAt : nextSupervisorReviewAt(supervisor, Date.parse(now))
-    }
-    supervisor.wakeLeaseOwner = undefined
-    supervisor.wakeLeaseExpiresAt = undefined
-    supervisor.note = normalizeOptionalString(input.note, 5000) || supervisor.note
-    supervisor.updatedAt = now
-    const receipt = completeSupervisorWakeupReceiptRow(db, supervisor, {
-      leaseOwner: wakeLeaseOwner,
-      status: success ? 'completed' : 'failed',
-      summary: input.note,
-      inspectedInputs: input.inspectedInputs,
-      changedObjectIds: input.changedObjectIds,
-      recommendation: input.recommendation,
-      nextAction: input.nextAction,
-      cursorEventId: supervisor.lastReviewedEventId || input.cursorEventId || supervisor.lastWakeEventId || 0,
-      nextWakeAt: supervisor.nextReviewAt,
-    }, now)
-    appendWorkEventRow(db, success ? 'roadmap.supervisor.wakeup_completed' : 'roadmap.supervisor.wakeup_failed', supervisor.roadmapId, { supervisorId, cursorEventId: supervisor.lastReviewedEventId, note: input.note, receiptId: receipt?.id, idempotencyKey: receipt?.idempotencyKey, wakeReason: receipt?.wakeReason }, now)
-    return supervisor
-  })
-}
-
-export function applyRoadmapSupervisorResult(supervisorId: string, input: RoadmapSupervisorResultApplyInput, filePath = workStatePath()): RoadmapSupervisorResultApplyResult | undefined {
-  return mutateWorkState(filePath, (state, db) => {
-    const supervisor = state.supervisors.find(row => row.supervisorId === supervisorId)
-    if (!supervisor) return undefined
-    if (supervisor.lastResultHash === input.resultHash) {
-      return { applied: false, appliedActions: [], rejectedActions: ['duplicate_result'], changedObjectIds: [], recommendation: 'duplicate_result', nextAction: 'No action; this supervisor result was already applied.' }
-    }
-    if (!input.turn ||
-      input.turn.supervisorId !== supervisor.supervisorId ||
-      input.turn.roadmapId !== supervisor.roadmapId ||
-      input.turn.leaseOwner !== supervisor.wakeLeaseOwner ||
-      input.turn.cursorEventId !== (supervisor.lastWakeEventId || supervisor.lastReviewedEventId || 0)) {
-      return { applied: false, appliedActions: [], rejectedActions: ['stale_or_mismatched_turn'], changedObjectIds: [], recommendation: 'stale_or_mismatched_turn', nextAction: 'Ignore this supervisor result and wait for a matching turn.' }
-    }
-    const roadmap = state.roadmaps.find(row => row.id === supervisor.roadmapId)
-    if (!roadmap) return undefined
-
-    const now = new Date().toISOString()
-    const appliedActions: string[] = []
-    const rejectedActions: string[] = []
-    const changedObjectIds = new Set<string>([`supervisor:${supervisorId}`, `roadmap:${roadmap.id}`])
-    const actions = input.actions.length ? input.actions : [{ type: 'summary', summary: input.summary }]
-    let handledTasks = false
-    let handledCompletion = false
-
-    for (const action of actions) {
-      if (action.type === 'none' || action.type === 'summary') {
-        appliedActions.push(action.type)
-      } else if (action.type === 'schedule_next_review') {
-        if (!input.nextReviewAt) rejectedActions.push('schedule_next_review:invalid_nextReviewAt')
-        else {
-          applyRoadmapSupervisorUpdate(state, supervisor, { nextReviewAt: input.nextReviewAt }, now)
-          appendWorkEventRow(db, 'roadmap.supervisor.updated', supervisor.roadmapId, { supervisorId, fields: ['nextReviewAt'] }, now)
-          appliedActions.push('schedule_next_review')
-        }
-      } else if (action.type === 'block_roadmap') {
-        roadmap.status = 'blocked'
-        roadmap.updatedAt = now
-        appendWorkEventRow(db, 'roadmap.updated', roadmap.id, { fields: ['status'], qualitySpec: Boolean(roadmap.qualitySpec) }, now)
-        appliedActions.push('block_roadmap')
-      } else if (action.type === 'propose_completion') {
-        if (handledCompletion) rejectedActions.push('propose_completion:duplicate_action')
-        else if (!input.completion || input.completion.recommendation === 'not_done') rejectedActions.push('propose_completion:no_ready_completion')
-        else {
-          handledCompletion = true
-          const proposal: RoadmapCompletionProposalRecord = {
-            id: `completion_${randomUUID()}`,
-            roadmapId: roadmap.id,
-            proposedBy: supervisorId,
-            sessionId: supervisor.sessionId,
-            evidence: normalizeStringList(input.completion.evidence, 2000),
-            unresolvedRisks: normalizeStringList(input.completion.risks, 2000),
-            recommendation: normalizeOptionalString(input.completion.recommendation, 2000) || 'complete',
-            status: 'pending',
-            createdAt: now,
-            updatedAt: now,
-          }
-          state.completionProposals.push(proposal)
-          appendWorkEventRow(db, 'roadmap.completion.proposed', proposal.id, { roadmapId: roadmap.id, proposedBy: proposal.proposedBy, sessionId: proposal.sessionId, evidence: proposal.evidence.length, unresolvedRisks: proposal.unresolvedRisks.length }, now)
-          appendDelegationProgressForRoadmap(db, roadmap.id, 'completion_proposed', proposal.id, {
-            proposalId: proposal.id,
-            roadmapId: roadmap.id,
-            status: proposal.status,
-            sessionId: proposal.sessionId,
-            summary: `Completion proposed for ${roadmap.title}`,
-          }, now)
-          const policy = roadmap.qualitySpec?.completionPolicy || 'assistant_proposes_user_approves'
-          const blockedReasons = completionAutoBlockers(state, db, roadmap, proposal)
-          if (policy === 'auto_when_evidence_complete' && blockedReasons.length === 0) {
-            approveRoadmapCompletionProposalInState(state, db, proposal, roadmap, { actor: 'gateway.auto', source: 'completion_policy', note: 'auto_when_evidence_complete' }, now)
-          } else if (policy === 'auto_when_evidence_complete') {
-            appendWorkEventRow(db, 'roadmap.completion.auto_blocked', proposal.id, { roadmapId: roadmap.id, blockedReasons }, now)
-          }
-          appliedActions.push('propose_completion')
-          changedObjectIds.add(`completion_proposal:${proposal.id}`)
-        }
-      } else if (action.type === 'create_task') {
-        if (handledTasks) rejectedActions.push('create_task:duplicate_action')
-        else if (!input.proposedTasks.length) rejectedActions.push('create_task:no_proposed_tasks')
-        else {
-          handledTasks = true
-          if ((supervisor.completionPolicy as any)?.allowDirectTaskCreate === true) {
-            for (const task of input.proposedTasks) {
-              const created = createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now)
-              changedObjectIds.add(`task:${created.id}`)
-            }
-            appliedActions.push(`create_task:${input.proposedTasks.length}`)
-          } else {
-            appendWorkEventRow(db, 'roadmap.supervisor.tasks_proposed', roadmap.id, { supervisorId, resultHash: input.resultHash, tasks: input.proposedTasks.map(task => ({ title: task.title, priority: task.priority || 'MEDIUM' })) }, now)
-            appliedActions.push(`propose_task:${input.proposedTasks.length}`)
-          }
-        }
-      } else if (action.type === 'ask_question') {
-        appendWorkEventRow(db, 'roadmap.supervisor.questions_requested', roadmap.id, { supervisorId, resultHash: input.resultHash, questions: input.questions, summary: action.summary }, now)
-        appliedActions.push(`ask_question:${input.questions.length}`)
-      } else if (action.type === 'request_permission') {
-        appendWorkEventRow(db, 'roadmap.supervisor.permission_requested', roadmap.id, { supervisorId, resultHash: input.resultHash, summary: action.summary }, now)
-        appliedActions.push('request_permission')
-      } else {
-        rejectedActions.push(`${String(action.type)}:unsupported`)
-      }
-    }
-
-    applyRoadmapSupervisorUpdate(state, supervisor, { note: input.summary, lastResultHash: input.resultHash, lastResultAt: now, lastResultStatus: input.status, lastResultSummary: input.summary }, now)
-    appendWorkEventRow(db, 'roadmap.supervisor.updated', supervisor.roadmapId, { supervisorId, fields: ['note', 'lastResultHash', 'lastResultAt', 'lastResultStatus', 'lastResultSummary'] }, now)
-    appendWorkEventRow(db, 'roadmap.supervisor.result_applied', roadmap.id, { supervisorId, resultHash: input.resultHash, status: input.status, summary: input.summary, appliedActions, rejectedActions }, now)
-    if (rejectedActions.length) appendWorkEventRow(db, 'roadmap.supervisor.action_rejected', roadmap.id, { supervisorId, resultHash: input.resultHash, rejectedActions }, now)
-
-    const success = input.status !== 'failed'
-    const wakeLeaseOwner = input.turn.leaseOwner || supervisor.wakeLeaseOwner
-    if (success) {
-      supervisor.lastReviewedEventId = Math.max(supervisor.lastReviewedEventId || 0, input.turn.cursorEventId || supervisor.lastWakeEventId || 0)
-      supervisor.lastReviewAt = now
-      const explicitNextReview = Date.parse(supervisor.nextReviewAt || '')
-      supervisor.nextReviewAt = Number.isFinite(explicitNextReview) && explicitNextReview > Date.parse(now) ? supervisor.nextReviewAt : nextSupervisorReviewAt(supervisor, Date.parse(now))
-    }
-    supervisor.wakeLeaseOwner = undefined
-    supervisor.wakeLeaseExpiresAt = undefined
-    supervisor.note = normalizeOptionalString(input.summary, 5000) || supervisor.note
-    supervisor.updatedAt = now
-    const changedIds = [...changedObjectIds]
-    const receipt = completeSupervisorWakeupReceiptRow(db, supervisor, {
-      leaseOwner: wakeLeaseOwner,
-      status: success ? 'completed' : 'failed',
-      summary: input.summary,
-      inspectedInputs: [`supervisor:${supervisor.supervisorId}`, `roadmap:${supervisor.roadmapId}`, `cursor:${input.turn.cursorEventId}`, `supervisor_result:${input.resultHash}`],
-      changedObjectIds: changedIds,
-      recommendation: input.recommendation,
-      nextAction: input.nextAction,
-      cursorEventId: supervisor.lastReviewedEventId || input.turn.cursorEventId || supervisor.lastWakeEventId || 0,
-      nextWakeAt: supervisor.nextReviewAt,
-    }, now)
-    appendWorkEventRow(db, success ? 'roadmap.supervisor.wakeup_completed' : 'roadmap.supervisor.wakeup_failed', supervisor.roadmapId, { supervisorId, cursorEventId: supervisor.lastReviewedEventId, note: input.summary, receiptId: receipt?.id, idempotencyKey: receipt?.idempotencyKey, wakeReason: receipt?.wakeReason }, now)
-
-    return { applied: true, appliedActions, rejectedActions, changedObjectIds: changedIds, recommendation: input.recommendation, nextAction: input.nextAction }
   })
 }
 

--- a/products/gateway/src/work-store/project-orchestration.ts
+++ b/products/gateway/src/work-store/project-orchestration.ts
@@ -1,0 +1,521 @@
+/**
+ * Project / initiative / delegation orchestration (LOC façade split).
+ * Leaf relative to work-store.ts — large multi-entity write transactions live here.
+ */
+import { randomUUID } from 'node:crypto'
+import type { EnvironmentSelector } from '../environments.js'
+import { queryRows, workStatePath } from './db.js'
+import { upsertChannelBindingRow } from './channel-bindings.js'
+import {
+  appendDelegationProgressForRoadmap,
+  appendDelegationProgressRow,
+  delegationProgressKey,
+  findDelegationReceiptInDb,
+  nextDelegationSchedulerAction,
+  receiptLinks,
+  supervisedProjectResultFromReceipt,
+  upsertDelegationReceiptRow,
+} from './delegation-helpers.js'
+import { appendWorkEventRow } from './event-append.js'
+import { manualGateReason } from './human-gates.js'
+import {
+  approveRoadmapCompletionProposalInState,
+  completionAutoBlockers,
+  deleteProjectBindingChannelRow,
+  upsertProjectBindingInState,
+} from './project-binding-helpers.js'
+import { rowToEvent } from './row-mappers.js'
+import { mutateWorkState } from './state-io.js'
+import {
+  applyRoadmapSupervisorUpdate,
+  compareRoadmapSupervisors,
+  completeSupervisorWakeupReceiptRow,
+  createRoadmapSupervisorInState,
+  nextSupervisorReviewAt,
+  reconcileDefaultSupervisorInState,
+  supervisorEligibleForWakeup,
+  supervisorWakeupIdempotencyKey,
+  supervisorWakeupReason,
+  upsertSupervisorWakeupReceiptRow,
+} from './supervisor-helpers.js'
+import {
+  addWorkDependencyInState,
+  assertRoadmapAcceptsTasks,
+  createRoadmapInState,
+  createWorkTaskInState,
+  normalizeTaskCreateList,
+  recomputeRoadmapStatusInState,
+} from './task-helpers.js'
+import type {
+  DelegatedWorkMutationInput,
+  DelegatedWorkReceipt,
+  ProjectBindingRecord,
+  RoadmapCompletionProposalRecord,
+  RoadmapQualitySpec,
+  RoadmapRecord,
+  RoadmapSupervisorCreateInput,
+  RoadmapSupervisorRecord,
+  RoadmapSupervisorResultApplyInput,
+  RoadmapSupervisorResultApplyResult,
+  RoadmapSupervisorWakeupRecord,
+  SupervisedProjectCreateInput,
+  SupervisedProjectCreateResult,
+  WorkDependencyRecord,
+  WorkDependencyType,
+  WorkTaskCreateInput,
+  WorkTaskRecord,
+} from './types.js'
+import { normalizeOptionalString, normalizeStringList } from './validators.js'
+
+/** One dependency edge in a {@link PlanInitiativeInput}, addressed by task ref. */
+export interface PlanInitiativeDependency {
+  /** The dependent task: a 0-based index into `tasks[]`, or a new task's title, or an existing task id. */
+  taskRef: string | number
+  /** The prerequisite task that must complete first, addressed the same way as {@link taskRef}. */
+  dependsOnRef: string | number
+  type?: WorkDependencyType
+}
+
+/** Full spec for {@link planInitiative}: a roadmap, its tasks, their dependency edges, and an optional supervisor. */
+export interface PlanInitiativeInput {
+  title: string
+  priority?: 'HIGH' | 'MEDIUM' | 'LOW'
+  agentTeam?: string
+  environment?: EnvironmentSelector
+  qualitySpec?: RoadmapQualitySpec
+  tasks?: WorkTaskCreateInput[]
+  dependencies?: PlanInitiativeDependency[]
+  /** When provided (with a sessionId), an Initiative Supervisor is bound in the same transaction. */
+  supervisor?: Omit<RoadmapSupervisorCreateInput, 'roadmapId'>
+}
+
+export interface PlanInitiativeResult {
+  roadmap: RoadmapRecord
+  tasks: WorkTaskRecord[]
+  dependencies: WorkDependencyRecord[]
+  supervisor?: RoadmapSupervisorRecord
+}
+
+/**
+ * Atomically create an Initiative (roadmap), its child Issues (tasks), their
+ * dependency edges, and — optionally — a bound supervisor, in one work-store
+ * write transaction. Collapses roadmap_create_with_tasks + N task_dependency_add
+ * (+ roadmap_supervisor_create) into a single all-or-nothing call: any failure
+ * (missing task ref, dependency cycle, unknown profile) rolls the whole
+ * transaction back so partial initiatives never persist.
+ */
+export function planInitiative(input: PlanInitiativeInput, filePath = workStatePath()): PlanInitiativeResult {
+  return mutateWorkState(filePath, (state, db) => {
+    const now = new Date().toISOString()
+    const roadmap = createRoadmapInState(state, db, input, now)
+    const tasks = normalizeTaskCreateList(input.tasks || []).map(task => createWorkTaskInState(state, db, { ...task, roadmapId: task.roadmapId || roadmap.id }, now))
+    recomputeRoadmapStatusInState(state, roadmap.id, now)
+    appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id) }, now)
+
+    const resolveTaskRef = (ref: unknown, label: string): string => {
+      if (typeof ref === 'number') {
+        if (!Number.isInteger(ref) || ref < 0 || ref >= tasks.length) throw new Error(`${label} index out of range: ${ref}`)
+        return tasks[ref]!.id
+      }
+      if (typeof ref === 'string') {
+        const trimmed = ref.trim()
+        if (!trimmed) throw new Error(`${label} is required`)
+        const byTitle = tasks.filter(task => task.title === trimmed)
+        if (byTitle.length === 1) return byTitle[0]!.id
+        if (byTitle.length > 1) throw new Error(`${label} matches multiple new tasks by title: ${trimmed}`)
+        if (state.tasks.some(task => task.id === trimmed)) return trimmed
+        throw new Error(`${label} does not match a new task index/title or an existing task id: ${trimmed}`)
+      }
+      throw new Error(`${label} must be a task index (number) or a task title/id (string)`)
+    }
+
+    const dependencyInputs = Array.isArray(input.dependencies) ? input.dependencies : []
+    const dependencies = dependencyInputs.map((dep, index) => {
+      if (!dep || typeof dep !== 'object' || Array.isArray(dep)) throw new Error(`dependency at index ${index} must be an object`)
+      return addWorkDependencyInState(state, db, {
+        taskId: resolveTaskRef(dep.taskRef, `dependencies[${index}].taskRef`),
+        dependsOnTaskId: resolveTaskRef(dep.dependsOnRef, `dependencies[${index}].dependsOnRef`),
+        type: dep.type,
+      }, now)
+    })
+
+    let supervisor: RoadmapSupervisorRecord | undefined
+    const supervisorInput = input.supervisor
+    if (supervisorInput !== undefined && supervisorInput !== null) {
+      // A supervisor object without a sessionId is a validation error, not a
+      // silent no-op: createRoadmapSupervisorInState throws inside this same
+      // transaction so the whole initiative rolls back (matching the piecewise
+      // roadmap_supervisor_create behavior instead of dropping the supervisor).
+      if (typeof supervisorInput !== 'object' || Array.isArray(supervisorInput)) throw new Error('supervisor must be an object with a sessionId')
+      supervisor = createRoadmapSupervisorInState(state, { ...supervisorInput, roadmapId: roadmap.id }, now)
+      reconcileDefaultSupervisorInState(state, roadmap.id, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
+      appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
+    }
+
+    appendWorkEventRow(db, 'workflow.plan_initiative', roadmap.id, { taskIds: tasks.map(task => task.id), dependencyCount: dependencies.length, supervisorId: supervisor?.supervisorId }, now)
+    return { roadmap, tasks, dependencies, supervisor }
+  })
+}
+
+export function createSupervisedProject(input: SupervisedProjectCreateInput, filePath = workStatePath()): SupervisedProjectCreateResult {
+  return mutateWorkState(filePath, (state, db) => {
+    const idempotencyKey = normalizeOptionalString(input.idempotencyKey, 240)
+    if (idempotencyKey) {
+      const existing = findDelegationReceiptInDb(db, idempotencyKey)
+      if (existing) {
+        if (existing.targetType !== 'project_create') throw new Error(`idempotency key already used for ${existing.targetType}: ${idempotencyKey}`)
+        return { ...supervisedProjectResultFromReceipt(state, existing), idempotencyStatus: 'replayed' }
+      }
+    }
+    const now = new Date().toISOString()
+    const roadmap = createRoadmapInState(state, db, input.roadmap, now)
+    const tasks = normalizeTaskCreateList(input.tasks || []).map(task => createWorkTaskInState(state, db, { ...task, roadmapId: task.roadmapId || roadmap.id }, now))
+    recomputeRoadmapStatusInState(state, roadmap.id, now)
+    appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id) }, now)
+
+    const supervisor = createRoadmapSupervisorInState(state, { ...input.supervisor, roadmapId: roadmap.id }, now)
+    reconcileDefaultSupervisorInState(state, roadmap.id, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
+    appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
+
+    const previous = state.projectBindings.slice()
+    const binding = upsertProjectBindingInState(state, { ...input.binding, roadmapId: roadmap.id, title: input.binding.title || roadmap.title }, now)
+    for (const stale of previous.filter(row => row.id !== binding.id && !state.projectBindings.some(current => current.id === row.id))) deleteProjectBindingChannelRow(db, stale)
+    if (binding.provider && binding.chatId) {
+      upsertChannelBindingRow(db, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, sessionId: binding.sessionId, mode: 'roadmap', roadmapId: binding.roadmapId, title: binding.title || binding.alias }, now)
+      appendWorkEventRow(db, 'channel.binding.upserted', binding.sessionId, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, mode: 'roadmap', roadmapId: binding.roadmapId }, now)
+    }
+    appendWorkEventRow(db, 'project.binding.upserted', binding.roadmapId, { bindingId: binding.id, alias: binding.alias, scope: binding.scope, sessionId: binding.sessionId, provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId }, now)
+    if (input.event?.type) {
+      appendWorkEventRow(db, input.event.type, roadmap.id, {
+        alias: binding.alias,
+        sessionId: supervisor.sessionId,
+        taskIds: tasks.map(task => task.id),
+        ...(input.event.payload || {}),
+      }, now)
+    }
+    if (idempotencyKey) {
+      const receipt: DelegatedWorkReceipt = {
+        idempotencyKey,
+        idempotencyStatus: 'created',
+        targetType: 'project_create',
+        taskIds: tasks.map(task => task.id),
+        roadmapId: roadmap.id,
+        supervisorId: supervisor.supervisorId,
+        projectBindingId: binding.id,
+        parentSessionId: supervisor.sessionId,
+        links: receiptLinks(roadmap, tasks, supervisor, binding),
+        nextSchedulerAction: nextDelegationSchedulerAction(tasks, supervisor),
+      }
+      upsertDelegationReceiptRow(db, receipt, now)
+    }
+    return { roadmap, tasks, supervisor, binding, idempotencyStatus: idempotencyKey ? 'created' : undefined }
+  })
+}
+
+export function createDelegatedWork(input: DelegatedWorkMutationInput, filePath = workStatePath()): DelegatedWorkReceipt {
+  return mutateWorkState(filePath, (state, db) => {
+    const existing = findDelegationReceiptInDb(db, input.idempotencyKey)
+    if (existing) return { ...existing, idempotencyStatus: 'replayed' }
+
+    const now = new Date().toISOString()
+    appendWorkEventRow(db, 'delegation.accepted', input.parentSessionId, {
+      idempotencyKey: input.idempotencyKey,
+      targetType: input.targetType,
+      objective: input.objective,
+      parentSessionId: input.parentSessionId,
+      notificationTarget: input.notificationTarget,
+    }, now)
+
+    let roadmap: RoadmapRecord | undefined
+    let supervisor: RoadmapSupervisorRecord | undefined
+    let binding: ProjectBindingRecord | undefined
+    const tasks: WorkTaskRecord[] = []
+
+    if (input.issue) {
+      tasks.push(createWorkTaskInState(state, db, input.issue, now))
+      roadmap = state.roadmaps.find(row => row.id === input.issue!.roadmapId)
+    } else if (input.project) {
+      if (input.project.roadmapId) {
+        roadmap = state.roadmaps.find(row => row.id === input.project!.roadmapId)
+        if (!roadmap) throw new Error(`roadmap not found: ${input.project.roadmapId}`)
+        assertRoadmapAcceptsTasks(state, roadmap.id)
+        for (const task of normalizeTaskCreateList(input.project.tasks || [])) {
+          tasks.push(createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now))
+        }
+      } else {
+        roadmap = createRoadmapInState(state, db, {
+          title: input.project.title || input.objective,
+          priority: input.project.priority,
+          agentTeam: input.project.agentTeam,
+          environment: input.project.environment,
+          qualitySpec: input.project.qualitySpec,
+        }, now)
+        for (const task of normalizeTaskCreateList(input.project.tasks || [])) {
+          tasks.push(createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now))
+        }
+      }
+      if (roadmap) recomputeRoadmapStatusInState(state, roadmap.id, now)
+      if (roadmap && input.project.supervisor) {
+        supervisor = createRoadmapSupervisorInState(state, { ...input.project.supervisor, roadmapId: roadmap.id }, now)
+        reconcileDefaultSupervisorInState(state, supervisor.roadmapId, supervisor.isDefault ? supervisor.supervisorId : undefined, now)
+        appendWorkEventRow(db, 'roadmap.supervisor.created', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, sessionId: supervisor.sessionId, profile: supervisor.profile, isDefault: supervisor.isDefault }, now)
+      }
+      if (roadmap && input.project.binding) {
+        binding = upsertProjectBindingInState(state, { ...input.project.binding, roadmapId: roadmap.id }, now)
+        if (binding.provider && binding.chatId) {
+          upsertChannelBindingRow(db, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, sessionId: binding.sessionId, mode: 'roadmap', roadmapId: binding.roadmapId, title: binding.title || binding.alias }, now)
+          appendWorkEventRow(db, 'channel.binding.upserted', binding.sessionId, { provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId, mode: 'roadmap', roadmapId: binding.roadmapId }, now)
+        }
+        appendWorkEventRow(db, 'project.binding.upserted', binding.roadmapId, { bindingId: binding.id, alias: binding.alias, scope: binding.scope, sessionId: binding.sessionId, provider: binding.provider, chatId: binding.chatId, threadId: binding.threadId }, now)
+      }
+      if (roadmap) appendWorkEventRow(db, 'roadmap.created_with_tasks', roadmap.id, { taskIds: tasks.map(task => task.id), delegated: true }, now)
+    } else {
+      throw new Error('delegation mutation requires issue or project input')
+    }
+
+    const receipt: DelegatedWorkReceipt = {
+      idempotencyKey: input.idempotencyKey,
+      idempotencyStatus: 'created',
+      targetType: input.targetType,
+      taskIds: tasks.map(task => task.id),
+      roadmapId: roadmap?.id,
+      supervisorId: supervisor?.supervisorId,
+      projectBindingId: binding?.id,
+      parentSessionId: input.parentSessionId,
+      links: receiptLinks(roadmap, tasks, supervisor, binding),
+      nextSchedulerAction: nextDelegationSchedulerAction(tasks, supervisor),
+    }
+    upsertDelegationReceiptRow(db, receipt, now)
+    appendWorkEventRow(db, 'delegation.mapped', roadmap?.id || tasks[0]?.id || input.parentSessionId, {
+      ...receipt,
+      idempotencyStatus: 'created',
+      idempotencyKey: input.idempotencyKey,
+      notificationTarget: input.notificationTarget,
+    }, now)
+    appendDelegationProgressRow(db, input.idempotencyKey, 'created', receipt.roadmapId || tasks[0]?.id || input.parentSessionId, {
+      ...receipt,
+      notificationTarget: input.notificationTarget,
+      progressKey: delegationProgressKey(input.idempotencyKey, 'created', receipt.roadmapId || tasks.map(task => task.id).join(',')),
+      summary: `Delegated work accepted: ${input.objective}`,
+    }, now)
+    for (const task of tasks.filter(task => task.manualGate)) {
+      appendDelegationProgressRow(db, input.idempotencyKey, 'gate_opened', task.id, {
+        ...receipt,
+        notificationTarget: input.notificationTarget,
+        taskId: task.id,
+        roadmapId: task.roadmapId,
+        status: task.status,
+        stage: task.currentStage,
+        manualGate: task.manualGate,
+        progressKey: delegationProgressKey(input.idempotencyKey, 'gate_opened', task.id, task.manualGate),
+        summary: `Delegated work is waiting: ${manualGateReason(task.manualGate!)}`,
+      }, now)
+    }
+    return receipt
+  })
+}
+
+export function acquireDueRoadmapSupervisorWakeups(input: { now?: number; leaseOwner?: string; leaseMs?: number; limit?: number } = {}, filePath = workStatePath()): RoadmapSupervisorWakeupRecord[] {
+  return mutateWorkState(filePath, (state, db) => {
+    const nowMs = input.now || Date.now()
+    const now = new Date(nowMs).toISOString()
+    const leaseOwner = normalizeOptionalString(input.leaseOwner, 200) || `supervisor-${process.pid}`
+    const leaseMs = Math.max(60 * 1000, Math.min(input.leaseMs || 10 * 60 * 1000, 24 * 60 * 60 * 1000))
+    const limit = Math.max(1, Math.min(input.limit || 5, 50))
+    const cursors = state.supervisors.map(supervisor => supervisor.lastReviewedEventId || 0)
+    const minCursor = cursors.length ? Math.min(...cursors) : 0
+    const events = queryRows(db, 'SELECT * FROM events WHERE id > ? ORDER BY id ASC', minCursor).map(rowToEvent)
+    const wakeups: RoadmapSupervisorWakeupRecord[] = []
+
+    for (const supervisor of state.supervisors.sort(compareRoadmapSupervisors)) {
+      if (wakeups.length >= limit) break
+      if (!supervisorEligibleForWakeup(supervisor, nowMs)) continue
+      const due = supervisorWakeupReason(state, supervisor, events, nowMs)
+      if (!due) continue
+      const idempotencyKey = supervisorWakeupIdempotencyKey(supervisor, due)
+      supervisor.wakeLeaseOwner = leaseOwner
+      supervisor.wakeLeaseExpiresAt = new Date(nowMs + leaseMs).toISOString()
+      supervisor.lastWakeAt = now
+      supervisor.lastWakeReason = due.wakeReason
+      supervisor.lastWakeEventId = due.cursorEventId || supervisor.lastReviewedEventId
+      supervisor.updatedAt = now
+      const receipt = upsertSupervisorWakeupReceiptRow(db, supervisor, due, { idempotencyKey, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt }, now)
+      appendWorkEventRow(db, 'roadmap.supervisor.wakeup_acquired', supervisor.roadmapId, { supervisorId: supervisor.supervisorId, wakeReason: due.wakeReason, reasonDetail: due.reasonDetail, eventIds: due.events.map(event => event.id), cursorEventId: due.cursorEventId, windowKey: due.windowKey, idempotencyKey, receiptId: receipt.id, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt }, now)
+      wakeups.push({ supervisor: { ...supervisor }, reason: due.reason, wakeReason: due.wakeReason, wakeReasonDetail: due.reasonDetail, triggerEvents: due.events, cursorEventId: due.cursorEventId, windowKey: due.windowKey, idempotencyKey, leaseOwner, leaseExpiresAt: supervisor.wakeLeaseExpiresAt, receiptId: receipt.id, notificationPolicyRef: supervisor.notificationPolicyRef })
+    }
+    return wakeups
+  })
+}
+
+export function completeRoadmapSupervisorWakeup(supervisorId: string, input: { leaseOwner?: string; cursorEventId?: number; success?: boolean; note?: string; inspectedInputs?: string[]; changedObjectIds?: string[]; recommendation?: string; nextAction?: string } = {}, filePath = workStatePath()): RoadmapSupervisorRecord | undefined {
+  return mutateWorkState(filePath, (state, db) => {
+    const supervisor = state.supervisors.find(row => row.supervisorId === supervisorId)
+    if (!supervisor) return undefined
+    if (input.leaseOwner && supervisor.wakeLeaseOwner && supervisor.wakeLeaseOwner !== input.leaseOwner) return undefined
+    const now = new Date().toISOString()
+    const success = input.success !== false
+    const wakeLeaseOwner = input.leaseOwner || supervisor.wakeLeaseOwner
+    if (success) {
+      supervisor.lastReviewedEventId = Math.max(supervisor.lastReviewedEventId || 0, input.cursorEventId || supervisor.lastWakeEventId || 0)
+      supervisor.lastReviewAt = now
+      const explicitNextReview = Date.parse(supervisor.nextReviewAt || '')
+      supervisor.nextReviewAt = Number.isFinite(explicitNextReview) && explicitNextReview > Date.parse(now) ? supervisor.nextReviewAt : nextSupervisorReviewAt(supervisor, Date.parse(now))
+    }
+    supervisor.wakeLeaseOwner = undefined
+    supervisor.wakeLeaseExpiresAt = undefined
+    supervisor.note = normalizeOptionalString(input.note, 5000) || supervisor.note
+    supervisor.updatedAt = now
+    const receipt = completeSupervisorWakeupReceiptRow(db, supervisor, {
+      leaseOwner: wakeLeaseOwner,
+      status: success ? 'completed' : 'failed',
+      summary: input.note,
+      inspectedInputs: input.inspectedInputs,
+      changedObjectIds: input.changedObjectIds,
+      recommendation: input.recommendation,
+      nextAction: input.nextAction,
+      cursorEventId: supervisor.lastReviewedEventId || input.cursorEventId || supervisor.lastWakeEventId || 0,
+      nextWakeAt: supervisor.nextReviewAt,
+    }, now)
+    appendWorkEventRow(db, success ? 'roadmap.supervisor.wakeup_completed' : 'roadmap.supervisor.wakeup_failed', supervisor.roadmapId, { supervisorId, cursorEventId: supervisor.lastReviewedEventId, note: input.note, receiptId: receipt?.id, idempotencyKey: receipt?.idempotencyKey, wakeReason: receipt?.wakeReason }, now)
+    return supervisor
+  })
+}
+
+export function applyRoadmapSupervisorResult(supervisorId: string, input: RoadmapSupervisorResultApplyInput, filePath = workStatePath()): RoadmapSupervisorResultApplyResult | undefined {
+  return mutateWorkState(filePath, (state, db) => {
+    const supervisor = state.supervisors.find(row => row.supervisorId === supervisorId)
+    if (!supervisor) return undefined
+    if (supervisor.lastResultHash === input.resultHash) {
+      return { applied: false, appliedActions: [], rejectedActions: ['duplicate_result'], changedObjectIds: [], recommendation: 'duplicate_result', nextAction: 'No action; this supervisor result was already applied.' }
+    }
+    if (!input.turn ||
+      input.turn.supervisorId !== supervisor.supervisorId ||
+      input.turn.roadmapId !== supervisor.roadmapId ||
+      input.turn.leaseOwner !== supervisor.wakeLeaseOwner ||
+      input.turn.cursorEventId !== (supervisor.lastWakeEventId || supervisor.lastReviewedEventId || 0)) {
+      return { applied: false, appliedActions: [], rejectedActions: ['stale_or_mismatched_turn'], changedObjectIds: [], recommendation: 'stale_or_mismatched_turn', nextAction: 'Ignore this supervisor result and wait for a matching turn.' }
+    }
+    const roadmap = state.roadmaps.find(row => row.id === supervisor.roadmapId)
+    if (!roadmap) return undefined
+
+    const now = new Date().toISOString()
+    const appliedActions: string[] = []
+    const rejectedActions: string[] = []
+    const changedObjectIds = new Set<string>([`supervisor:${supervisorId}`, `roadmap:${roadmap.id}`])
+    const actions = input.actions.length ? input.actions : [{ type: 'summary', summary: input.summary }]
+    let handledTasks = false
+    let handledCompletion = false
+
+    for (const action of actions) {
+      if (action.type === 'none' || action.type === 'summary') {
+        appliedActions.push(action.type)
+      } else if (action.type === 'schedule_next_review') {
+        if (!input.nextReviewAt) rejectedActions.push('schedule_next_review:invalid_nextReviewAt')
+        else {
+          applyRoadmapSupervisorUpdate(state, supervisor, { nextReviewAt: input.nextReviewAt }, now)
+          appendWorkEventRow(db, 'roadmap.supervisor.updated', supervisor.roadmapId, { supervisorId, fields: ['nextReviewAt'] }, now)
+          appliedActions.push('schedule_next_review')
+        }
+      } else if (action.type === 'block_roadmap') {
+        roadmap.status = 'blocked'
+        roadmap.updatedAt = now
+        appendWorkEventRow(db, 'roadmap.updated', roadmap.id, { fields: ['status'], qualitySpec: Boolean(roadmap.qualitySpec) }, now)
+        appliedActions.push('block_roadmap')
+      } else if (action.type === 'propose_completion') {
+        if (handledCompletion) rejectedActions.push('propose_completion:duplicate_action')
+        else if (!input.completion || input.completion.recommendation === 'not_done') rejectedActions.push('propose_completion:no_ready_completion')
+        else {
+          handledCompletion = true
+          const proposal: RoadmapCompletionProposalRecord = {
+            id: `completion_${randomUUID()}`,
+            roadmapId: roadmap.id,
+            proposedBy: supervisorId,
+            sessionId: supervisor.sessionId,
+            evidence: normalizeStringList(input.completion.evidence, 2000),
+            unresolvedRisks: normalizeStringList(input.completion.risks, 2000),
+            recommendation: normalizeOptionalString(input.completion.recommendation, 2000) || 'complete',
+            status: 'pending',
+            createdAt: now,
+            updatedAt: now,
+          }
+          state.completionProposals.push(proposal)
+          appendWorkEventRow(db, 'roadmap.completion.proposed', proposal.id, { roadmapId: roadmap.id, proposedBy: proposal.proposedBy, sessionId: proposal.sessionId, evidence: proposal.evidence.length, unresolvedRisks: proposal.unresolvedRisks.length }, now)
+          appendDelegationProgressForRoadmap(db, roadmap.id, 'completion_proposed', proposal.id, {
+            proposalId: proposal.id,
+            roadmapId: roadmap.id,
+            status: proposal.status,
+            sessionId: proposal.sessionId,
+            summary: `Completion proposed for ${roadmap.title}`,
+          }, now)
+          const policy = roadmap.qualitySpec?.completionPolicy || 'assistant_proposes_user_approves'
+          const blockedReasons = completionAutoBlockers(state, db, roadmap, proposal)
+          if (policy === 'auto_when_evidence_complete' && blockedReasons.length === 0) {
+            approveRoadmapCompletionProposalInState(state, db, proposal, roadmap, { actor: 'gateway.auto', source: 'completion_policy', note: 'auto_when_evidence_complete' }, now)
+          } else if (policy === 'auto_when_evidence_complete') {
+            appendWorkEventRow(db, 'roadmap.completion.auto_blocked', proposal.id, { roadmapId: roadmap.id, blockedReasons }, now)
+          }
+          appliedActions.push('propose_completion')
+          changedObjectIds.add(`completion_proposal:${proposal.id}`)
+        }
+      } else if (action.type === 'create_task') {
+        if (handledTasks) rejectedActions.push('create_task:duplicate_action')
+        else if (!input.proposedTasks.length) rejectedActions.push('create_task:no_proposed_tasks')
+        else {
+          handledTasks = true
+          if ((supervisor.completionPolicy as any)?.allowDirectTaskCreate === true) {
+            for (const task of input.proposedTasks) {
+              const created = createWorkTaskInState(state, db, { ...task, roadmapId: roadmap.id }, now)
+              changedObjectIds.add(`task:${created.id}`)
+            }
+            appliedActions.push(`create_task:${input.proposedTasks.length}`)
+          } else {
+            appendWorkEventRow(db, 'roadmap.supervisor.tasks_proposed', roadmap.id, { supervisorId, resultHash: input.resultHash, tasks: input.proposedTasks.map(task => ({ title: task.title, priority: task.priority || 'MEDIUM' })) }, now)
+            appliedActions.push(`propose_task:${input.proposedTasks.length}`)
+          }
+        }
+      } else if (action.type === 'ask_question') {
+        appendWorkEventRow(db, 'roadmap.supervisor.questions_requested', roadmap.id, { supervisorId, resultHash: input.resultHash, questions: input.questions, summary: action.summary }, now)
+        appliedActions.push(`ask_question:${input.questions.length}`)
+      } else if (action.type === 'request_permission') {
+        appendWorkEventRow(db, 'roadmap.supervisor.permission_requested', roadmap.id, { supervisorId, resultHash: input.resultHash, summary: action.summary }, now)
+        appliedActions.push('request_permission')
+      } else {
+        rejectedActions.push(`${String(action.type)}:unsupported`)
+      }
+    }
+
+    applyRoadmapSupervisorUpdate(state, supervisor, { note: input.summary, lastResultHash: input.resultHash, lastResultAt: now, lastResultStatus: input.status, lastResultSummary: input.summary }, now)
+    appendWorkEventRow(db, 'roadmap.supervisor.updated', supervisor.roadmapId, { supervisorId, fields: ['note', 'lastResultHash', 'lastResultAt', 'lastResultStatus', 'lastResultSummary'] }, now)
+    appendWorkEventRow(db, 'roadmap.supervisor.result_applied', roadmap.id, { supervisorId, resultHash: input.resultHash, status: input.status, summary: input.summary, appliedActions, rejectedActions }, now)
+    if (rejectedActions.length) appendWorkEventRow(db, 'roadmap.supervisor.action_rejected', roadmap.id, { supervisorId, resultHash: input.resultHash, rejectedActions }, now)
+
+    const success = input.status !== 'failed'
+    const wakeLeaseOwner = input.turn.leaseOwner || supervisor.wakeLeaseOwner
+    if (success) {
+      supervisor.lastReviewedEventId = Math.max(supervisor.lastReviewedEventId || 0, input.turn.cursorEventId || supervisor.lastWakeEventId || 0)
+      supervisor.lastReviewAt = now
+      const explicitNextReview = Date.parse(supervisor.nextReviewAt || '')
+      supervisor.nextReviewAt = Number.isFinite(explicitNextReview) && explicitNextReview > Date.parse(now) ? supervisor.nextReviewAt : nextSupervisorReviewAt(supervisor, Date.parse(now))
+    }
+    supervisor.wakeLeaseOwner = undefined
+    supervisor.wakeLeaseExpiresAt = undefined
+    supervisor.note = normalizeOptionalString(input.summary, 5000) || supervisor.note
+    supervisor.updatedAt = now
+    const changedIds = [...changedObjectIds]
+    const receipt = completeSupervisorWakeupReceiptRow(db, supervisor, {
+      leaseOwner: wakeLeaseOwner,
+      status: success ? 'completed' : 'failed',
+      summary: input.summary,
+      inspectedInputs: [`supervisor:${supervisor.supervisorId}`, `roadmap:${supervisor.roadmapId}`, `cursor:${input.turn.cursorEventId}`, `supervisor_result:${input.resultHash}`],
+      changedObjectIds: changedIds,
+      recommendation: input.recommendation,
+      nextAction: input.nextAction,
+      cursorEventId: supervisor.lastReviewedEventId || input.turn.cursorEventId || supervisor.lastWakeEventId || 0,
+      nextWakeAt: supervisor.nextReviewAt,
+    }, now)
+    appendWorkEventRow(db, success ? 'roadmap.supervisor.wakeup_completed' : 'roadmap.supervisor.wakeup_failed', supervisor.roadmapId, { supervisorId, cursorEventId: supervisor.lastReviewedEventId, note: input.summary, receiptId: receipt?.id, idempotencyKey: receipt?.idempotencyKey, wakeReason: receipt?.wakeReason }, now)
+
+    return { applied: true, appliedActions, rejectedActions, changedObjectIds: changedIds, recommendation: input.recommendation, nextAction: input.nextAction }
+  })
+}
+

--- a/products/wiki/package.json
+++ b/products/wiki/package.json
@@ -35,6 +35,7 @@
     "build:web": "node --no-warnings --import tsx packages/web/scripts/build.mjs",
     "check:bundle": "node --no-warnings --import tsx packages/web/scripts/check-bundle.mjs",
     "check:dead-code": "knip --config knip.json --include files,dependencies --reporter compact --no-config-hints",
+    "knip": "pnpm check:dead-code",
     "check:deploy-docs": "node --no-warnings scripts/openwiki-validate-deploy-docs.mjs",
     "check:modules": "node --no-warnings scripts/openwiki-module-size-report.mjs --check",
     "coverage": "node --no-warnings scripts/openwiki-coverage.mjs",

--- a/products/wiki/packages/mcp-server/src/tool-router-helpers.ts
+++ b/products/wiki/packages/mcp-server/src/tool-router-helpers.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure / near-pure helpers peeled from tool-router.ts to keep the router under
+ * the OpenWiki module-size hard budget (800 LOC).
+ */
+import { loadRepository, readProposalDetailWithOptions } from "@openwiki/repo";
+import { pathAllowedByContextBounds } from "@openwiki/policy";
+import { redactOpenWikiRunRecord, type ProposalRecord, type RunRecord } from "@openwiki/core";
+import type { McpPolicyContext } from "./types.ts";
+import {
+  optionalBooleanParam,
+  optionalNumberParam,
+  optionalStringArrayParam,
+  optionalStringObjectProperty,
+  optionalStringParam,
+} from "./params.ts";
+import {
+  assertMcpPathAuthorized,
+  DEFAULT_LOCAL_MCP_ACTOR_ID,
+} from "./policy-adapter.ts";
+
+export function dreamRunInputFromMcp(args: Record<string, unknown>): Record<string, unknown> {
+  const phases = optionalStringArrayParam(args, "phases");
+  const limit = optionalNumberParam(args, "limit");
+  const timeoutMs = optionalNumberParam(args, "timeout_ms");
+  const dryRun = optionalBooleanParam(args, "dry_run");
+  const createProposals = optionalBooleanParam(args, "create_proposals");
+  return {
+    ...(phases === undefined ? {} : { phases }),
+    ...(limit === undefined ? {} : { limit }),
+    ...(timeoutMs === undefined ? {} : { timeout_ms: timeoutMs }),
+    ...(dryRun === undefined ? {} : { dry_run: dryRun }),
+    ...(createProposals === undefined ? {} : { create_proposals: createProposals }),
+    ...optionalStringObjectProperty(args, "provider", "provider"),
+    ...optionalStringObjectProperty(args, "schema_pack", "schema_pack"),
+  };
+}
+
+export function mcpActorId(context: McpPolicyContext, args: Record<string, unknown>): string | undefined {
+  const requestedActorId = optionalStringParam(args, "actor_id");
+  if (context.actorId !== undefined && context.actorId !== DEFAULT_LOCAL_MCP_ACTOR_ID) {
+    return context.actorId;
+  }
+  if (context.role !== undefined || (context.principals !== undefined && context.principals.length > 0)) {
+    return "actor:user:local";
+  }
+  if (requestedActorId !== undefined) {
+    return requestedActorId;
+  }
+  if (context.actorId !== undefined) {
+    return context.actorId;
+  }
+  return undefined;
+}
+
+export async function assertMcpPathsAuthorized(
+  root: string,
+  operation: Parameters<typeof assertMcpPathAuthorized>[1],
+  context: McpPolicyContext,
+  paths: readonly string[],
+): Promise<void> {
+  for (const repoPath of paths) {
+    await assertMcpPathAuthorized(root, operation, context, repoPath);
+  }
+}
+
+export async function readProposalDetailForMcp(root: string, id: string, context: McpPolicyContext): Promise<unknown> {
+  const repo = await loadRepository(root);
+  const proposal = repo.proposals.find((candidate) => candidate.id === id || candidate.uri === id);
+  return readProposalDetailWithOptions(root, id, {
+    authorizePath(repoPath) {
+      if (proposal !== undefined && !proposalArtifactBelongsToProposal(proposal, repoPath)) {
+        throw new Error(`OpenWiki proposal artifact path is not bound to proposal ${proposal.id}: ${repoPath}`);
+      }
+      if (!pathAllowedByContextBounds(repo.policy, context, repoPath)) {
+        throw new Error(`OpenWiki policy bounds do not allow proposal artifact path ${repoPath}`);
+      }
+    },
+  });
+}
+
+export function proposalArtifactBelongsToProposal(proposal: ProposalRecord, repoPath: string): boolean {
+  const stem = proposal.id.replace(/:/g, "_").replace(/-/g, "_");
+  return (
+    repoPath === `proposals/diffs/${stem}.diff` ||
+    repoPath === `proposals/reports/${stem}.json` ||
+    repoPath === `proposals/validation/${stem}.json` ||
+    repoPath.startsWith(`proposals/snapshots/${stem}/`)
+  );
+}
+
+export function redactRunJobResult<T extends { run: RunRecord }>(result: T, context: McpPolicyContext): T {
+  return {
+    ...result,
+    run: redactRunForMcp(result.run, context),
+  };
+}
+
+export function redactRunToolResponseForMcp(value: unknown, context: McpPolicyContext): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value) && "run" in value) {
+    const record = value as { run?: unknown };
+    if (isRunRecord(record.run)) {
+      return {
+        ...value,
+        run: redactRunForMcp(record.run, context),
+      };
+    }
+  }
+  return value;
+}
+
+export function redactRunForMcp(run: RunRecord, context: McpPolicyContext): RunRecord {
+  return redactOpenWikiRunRecord(run, { includeSensitiveOperationalMetadata: context.role === "admin" || context.scopes.includes("wiki:admin") });
+}
+
+export function isRunRecord(value: unknown): value is RunRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value) && (value as { type?: unknown }).type === "run";
+}

--- a/products/wiki/packages/mcp-server/src/tool-router.ts
+++ b/products/wiki/packages/mcp-server/src/tool-router.ts
@@ -2,14 +2,13 @@ import { configureGitRemote, diffVersions, getHistory, gitPull, gitPush, gitRemo
 import { createRun, runLocalJob } from "@openwiki/jobs";
 import { readCurrentIndexStoreGraph, readCurrentIndexStoreWorkspaceRegistry } from "@openwiki/index-store";
 import { readCurrentPostgresGraph, readCurrentPostgresRecord, readCurrentPostgresSource, readCurrentPostgresWorkspaceRegistry } from "@openwiki/postgres-runtime";
-import { assertAuthorized, inboxProcessRunInputId, pathAllowedByContextBounds, runJobAllowedFromMcp, runJobAuthorizationOperations, runJobAuthorizationSpec, runJobRequiresInboxItem } from "@openwiki/policy";
-import { listGraphEdges, loadRepository, readClaim, readDecision, readPage, readProposal, readProposalDetailWithOptions, readSource, readSourceContent, readWorkspaceRegistry, withRepositoryReadCache } from "@openwiki/repo";
+import { assertAuthorized, inboxProcessRunInputId, runJobAllowedFromMcp, runJobAuthorizationOperations, runJobAuthorizationSpec, runJobRequiresInboxItem } from "@openwiki/policy";
+import { listGraphEdges, loadRepository, readClaim, readDecision, readPage, readProposal, readSource, readSourceContent, readWorkspaceRegistry, withRepositoryReadCache } from "@openwiki/repo";
 import { searchWiki } from "@openwiki/search";
 import { publishStaticSite } from "@openwiki/static-export";
 import { validateRepository } from "@openwiki/validation";
 import { applyProposal, askWithCitations, commitChanges, dreamRunStatus, ignoreInboxItem, processInboxItem, readInboxWorkflow, redactThinkSearchExplainForPolicy, retryInboxItem, syncWorkspaceNow, thinkWithCitations, withWriteCoordination } from "@openwiki/workflows";
-import { redactOpenWikiRunRecord, synthesisTargetPath, writeOpenWikiLog, type ClaimRecord, type DecisionRecord, type PageRecord, type ProposalRecord, type RunRecord, type SearchRequest } from "@openwiki/core";
-import type { McpPolicyContext } from "./types.ts";
+import { synthesisTargetPath, writeOpenWikiLog, type ClaimRecord, type DecisionRecord, type PageRecord, type ProposalRecord, type SearchRequest } from "@openwiki/core";
 import {
   objectParams,
   stringParam,
@@ -44,7 +43,6 @@ import {
   toolAllowed,
   openWikiOperation,
   policyContextForMcp,
-  DEFAULT_LOCAL_MCP_ACTOR_ID,
   filterSearchResponseForMcp,
   assertMcpVisibleRecord,
   assertMcpInboxActionAuthorized,
@@ -83,6 +81,15 @@ import {
   traceClaimForMcp,
   fetchSourceFromMcp,
 } from "./tool-handlers.ts";
+import {
+  assertMcpPathsAuthorized,
+  dreamRunInputFromMcp,
+  mcpActorId,
+  readProposalDetailForMcp,
+  redactRunForMcp,
+  redactRunJobResult,
+  redactRunToolResponseForMcp,
+} from "./tool-router-helpers.ts";
 import { MCP_LIST_LIMIT_MAX, type McpServerOptions } from "./types.ts";
 
 const SOURCE_FETCH_AUTH_PATHS = ["sources/manifests", "sources/raw"] as const;
@@ -632,102 +639,4 @@ async function callToolInner(
     default:
       throw new Error(`Unsupported OpenWiki tool: ${name}`);
   }
-}
-
-function dreamRunInputFromMcp(args: Record<string, unknown>): Record<string, unknown> {
-  const phases = optionalStringArrayParam(args, "phases");
-  const limit = optionalNumberParam(args, "limit");
-  const timeoutMs = optionalNumberParam(args, "timeout_ms");
-  const dryRun = optionalBooleanParam(args, "dry_run");
-  const createProposals = optionalBooleanParam(args, "create_proposals");
-  return {
-    ...(phases === undefined ? {} : { phases }),
-    ...(limit === undefined ? {} : { limit }),
-    ...(timeoutMs === undefined ? {} : { timeout_ms: timeoutMs }),
-    ...(dryRun === undefined ? {} : { dry_run: dryRun }),
-    ...(createProposals === undefined ? {} : { create_proposals: createProposals }),
-    ...optionalStringObjectProperty(args, "provider", "provider"),
-    ...optionalStringObjectProperty(args, "schema_pack", "schema_pack"),
-  };
-}
-
-function mcpActorId(context: McpPolicyContext, args: Record<string, unknown>): string | undefined {
-  const requestedActorId = optionalStringParam(args, "actor_id");
-  if (context.actorId !== undefined && context.actorId !== DEFAULT_LOCAL_MCP_ACTOR_ID) {
-    return context.actorId;
-  }
-  if (context.role !== undefined || (context.principals !== undefined && context.principals.length > 0)) {
-    return "actor:user:local";
-  }
-  if (requestedActorId !== undefined) {
-    return requestedActorId;
-  }
-  if (context.actorId !== undefined) {
-    return context.actorId;
-  }
-  return undefined;
-}
-
-async function assertMcpPathsAuthorized(
-  root: string,
-  operation: Parameters<typeof assertMcpPathAuthorized>[1],
-  context: McpPolicyContext,
-  paths: readonly string[],
-): Promise<void> {
-  for (const repoPath of paths) {
-    await assertMcpPathAuthorized(root, operation, context, repoPath);
-  }
-}
-
-async function readProposalDetailForMcp(root: string, id: string, context: McpPolicyContext): Promise<unknown> {
-  const repo = await loadRepository(root);
-  const proposal = repo.proposals.find((candidate) => candidate.id === id || candidate.uri === id);
-  return readProposalDetailWithOptions(root, id, {
-    authorizePath(repoPath) {
-      if (proposal !== undefined && !proposalArtifactBelongsToProposal(proposal, repoPath)) {
-        throw new Error(`OpenWiki proposal artifact path is not bound to proposal ${proposal.id}: ${repoPath}`);
-      }
-      if (!pathAllowedByContextBounds(repo.policy, context, repoPath)) {
-        throw new Error(`OpenWiki policy bounds do not allow proposal artifact path ${repoPath}`);
-      }
-    },
-  });
-}
-
-function proposalArtifactBelongsToProposal(proposal: ProposalRecord, repoPath: string): boolean {
-  const stem = proposal.id.replace(/:/g, "_").replace(/-/g, "_");
-  return (
-    repoPath === `proposals/diffs/${stem}.diff` ||
-    repoPath === `proposals/reports/${stem}.json` ||
-    repoPath === `proposals/validation/${stem}.json` ||
-    repoPath.startsWith(`proposals/snapshots/${stem}/`)
-  );
-}
-
-function redactRunJobResult<T extends { run: RunRecord }>(result: T, context: McpPolicyContext): T {
-  return {
-    ...result,
-    run: redactRunForMcp(result.run, context),
-  };
-}
-
-function redactRunToolResponseForMcp(value: unknown, context: McpPolicyContext): unknown {
-  if (value !== null && typeof value === "object" && !Array.isArray(value) && "run" in value) {
-    const record = value as { run?: unknown };
-    if (isRunRecord(record.run)) {
-      return {
-        ...value,
-        run: redactRunForMcp(record.run, context),
-      };
-    }
-  }
-  return value;
-}
-
-function redactRunForMcp(run: RunRecord, context: McpPolicyContext): RunRecord {
-  return redactOpenWikiRunRecord(run, { includeSensitiveOperationalMetadata: context.role === "admin" || context.scopes.includes("wiki:admin") });
-}
-
-function isRunRecord(value: unknown): value is RunRecord {
-  return value !== null && typeof value === "object" && !Array.isArray(value) && (value as { type?: unknown }).type === "run";
 }

--- a/scripts/check-import-cycles.mjs
+++ b/scripts/check-import-cycles.mjs
@@ -33,6 +33,16 @@ export const SCAN_ROOTS = [
   'packages/ui/src',
   // post-#959: widen ratchet toward runtime packages once proven cycle-free
   'packages/shared/src',
+  // post-#961 hardening: packages/runtime-host/src intentionally NOT added —
+  // known value-import cycle (not cycle-free at widen time):
+  //   runtime.ts
+  //     -> runtime-config-builder.ts
+  //       -> custom-agents-utils.ts
+  //         -> runtime-tools.ts
+  //           -> runtime.ts
+  // Break that cycle (e.g. extract pure tool-id helpers from runtime-tools, or
+  // move getClientForDirectory consumers off the runtime composition root)
+  // before ratcheting SCAN_ROOTS to include runtime-host.
 ]
 
 const SOURCE_EXTENSIONS = ['.ts', '.tsx']

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -57,6 +57,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'ipc-handlers.ts',
   'ipc-runtime-context.ts',
   'keyed-serializer.ts',
+  'local-workspace-session.ts',
   'main-window-controller.ts',
   'main-window-lifecycle.ts',
   'main-window-security.ts',


### PR DESCRIPTION
## Summary

Single hardening PR closing the post-#961 audit backlog (`docs/evidence/post-961-master-full-audit-2026-07-23.md`).

### P0 (public package honesty)
- Private-beta package remains **COMPLETE** + **`no-go`** (validator fail-closed; no invented go evidence)

### P1
- MCP `state_export` uses `/storage/export?localAdmin=true` (JOE-952 dual-intent)
- Integration tests for storage export + raw session messages
- Hard budget ratchets after #961 extracts; budget `mcp` / `channel-commands` / `channel-sync`
- Soft 1500 façades: `scheduler`, `work-store`, `channel-commands`; MCP ops tools extracted

### P2
- Progressive `getLocalSessionPort()` wired into artifact IPC path
- Wiki tool-router helpers peel (~642 LOC)
- Durable Mission Control HTML CSP + security headers
- Multi-writer readiness/doctor informational check; HA docs honesty
- Product knip in `ci-gateway` / `ci-wiki`
- Cycle SCAN_ROOTS: document residual runtime-host cycle (not silently widened)

### P3
- Classic/chart/HTTPS MCP residuals reaffirmed; Dependabot #960 superseded note
- API docs + OpenAPI dual-intent for storage export

### Explicit non-claims
- Hosted private-beta **go**, multi-AZ HA, dual-stack protocol delete, full classic burn-down

## Test plan
- [x] `pnpm --filter cowork-gateway typecheck`
- [x] vitest: daemon-routes, module-boundaries, export/rate-limit guards
- [x] wiki typecheck
- [x] private-beta validate, import-cycles, god-module LOC, lint.mjs
- [x] product knip / dead-code
- [ ] Full CI green on this PR