### PR TITLE
ci: CodeQL monthly-only (not a PR/merge gate)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,13 @@
 name: CodeQL
 
+# Monthly deep scan only. Full monorepo CodeQL regularly times out / burns
+# multi-hour Action minutes on PR and per-push paths; product gates stay on CI.
+# Manual re-run: workflow_dispatch.
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   schedule:
-    - cron: '23 3 * * 1'
+    # 03:23 UTC on the 1st of each month
+    - cron: '23 3 1 * *'
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -20,9 +21,8 @@ concurrency:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    # Cost control after monorepo product import: keep PR jobs bounded.
-    # Do not raise multi-hour budgets for PR CodeQL.
-    timeout-minutes: ${{ github.event_name == 'pull_request' && 45 || 90 }}
+    # Deep monorepo pack; monthly only so a long budget is acceptable.
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -42,21 +42,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Initialize CodeQL (pull request)
-        if: github.event_name == 'pull_request'
+      - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
-          # Faster pack + exclude products/** (see codeql-config.yml).
-          queries: security-extended
-          config-file: .github/codeql/codeql-config.yml
-
-      - name: Initialize CodeQL (master / schedule)
-        if: github.event_name != 'pull_request'
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-        with:
-          languages: ${{ matrix.language }}
-          # Deeper pack once per merge/week; full monorepo graph (no paths-ignore).
           queries: security-and-quality
 
       - name: Build

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -18,11 +18,14 @@ checks:
 | `windows-package` | CI | Windows NSIS packaging and packaged-app smoke validation. |
 | `docs` | CI | Strict MkDocs build for every PR. |
 | `coverage` | CI | Coverage ratchet and PR coverage summary. |
-| `analyze (javascript-typescript)` | CodeQL | JavaScript/TypeScript security and quality analysis. |
 
-Keep these names in sync with `.github/workflows/ci.yml` and
-`.github/workflows/codeql.yml`. If a workflow job is renamed, update branch
-protection in GitHub before merging the rename.
+Keep these names in sync with `.github/workflows/ci.yml`. If a workflow job is
+renamed, update branch protection in GitHub before merging the rename.
+
+**CodeQL is not a required PR/merge check.** Full monorepo CodeQL regularly
+times out and burns multi-hour Action minutes. `.github/workflows/codeql.yml`
+runs a deep `security-and-quality` scan **monthly** (and on `workflow_dispatch`)
+only — not on every PR or every `master` push.
 
 ## Recommended Settings
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -62,9 +62,9 @@ and linked from the release Go/No-Go report.
 - [ ] `git diff --check`
 - [ ] working tree is clean
 - [ ] release actor is listed in `OPEN_COWORK_RELEASE_ALLOWED_ACTORS`, the tag
-      commit has every required CI/CodeQL check green, and the
-      `release-publish` protected environment approval path is ready for GitHub
-      Release and GHCR publishing jobs
+      commit has every required CI check green (CodeQL is monthly-only, not a
+      per-tag gate), and the `release-publish` protected environment approval
+      path is ready for GitHub Release and GHCR publishing jobs
 
 ### Documentation
 

--- a/scripts/validate-release-gates.mjs
+++ b/scripts/validate-release-gates.mjs
@@ -57,7 +57,7 @@ const requiredBranchChecks = [
   { check: 'windows-package', workflow: 'CI' },
   { check: 'docs', workflow: 'CI' },
   { check: 'coverage', workflow: 'CI' },
-  { check: 'analyze (javascript-typescript)', workflow: 'CodeQL' },
+  // CodeQL is monthly-only; not a branch-protection required check.
 ]
 
 const publicSafeFiles = [
@@ -365,9 +365,12 @@ function assertBranchProtectionContract() {
   assertExactArray('branch protection required checks', rows, requiredBranchChecks)
   for (const { check, workflow } of requiredBranchChecks) {
     if (workflow === 'CI') assertWorkflowJob(ciWorkflowPath, check)
-    else if (workflow === 'CodeQL') assertWorkflowJob(codeqlWorkflowPath, 'analyze')
   }
+  // CodeQL remains monthly security hygiene (not a PR/merge gate).
+  assertWorkflowJob(codeqlWorkflowPath, 'analyze')
   assertIncludes(codeqlWorkflowPath, 'language: [javascript-typescript]')
+  assertIncludes(codeqlWorkflowPath, "cron: '23 3 1 * *'")
+  assertIncludes(codeqlWorkflowPath, 'workflow_dispatch')
   assertIncludes(codeqlWorkflowPath, 'wait-for-processing: ${{ github.event.repository.private == false }}')
 }
 

--- a/scripts/verify-release-checks.mjs
+++ b/scripts/verify-release-checks.mjs
@@ -8,7 +8,7 @@ const DEFAULT_REQUIRED_CHECKS = [
   'windows-package',
   'docs',
   'coverage',
-  'analyze (javascript-typescript)',
+  // CodeQL is monthly-only (not a per-release commit gate). See codeql.yml.
 ]
 const TRUSTED_CHECK_APP_SLUG = 'github-actions'
 const CHECK_RUNS_PAGE_SIZE = 100


### PR DESCRIPTION
## Summary
- CodeQL no longer runs on every PR or `master` push (repo size regularly times out / multi-hour burns).
- Monthly deep `security-and-quality` scan (`cron: 23 3 1 * *`) plus `workflow_dispatch`.
- Removed `analyze (javascript-typescript)` from docs/scripts branch-protection and release-check contracts.
- Live branch protection contexts updated to match (no longer requires CodeQL for merge).

## Test plan
- [x] `node scripts/validate-release-gates.mjs`
- [ ] CI green on this PR (no CodeQL job expected)
- [ ] Confirm branch protection required checks list no longer includes `analyze`