### PR TITLE
fix(joe-995/992/943): progressive port, façade peels, event-pump kernel

### DIFF
--- a/apps/desktop/src/main/cloud-subscription-manager.ts
+++ b/apps/desktop/src/main/cloud-subscription-manager.ts
@@ -3,6 +3,7 @@ import type {
   CloudTransportSubscription,
   CloudTransportWorkspaceEvent,
 } from '@open-cowork/cloud-server/transport-adapter'
+import { attemptReconnectDelayMs } from '@open-cowork/runtime-host'
 import type { CloudWorkspaceSessionAdapter } from './cloud-workspace-adapter.ts'
 import type { WorkspaceInfo } from '@open-cowork/shared'
 
@@ -206,9 +207,13 @@ export class CloudSubscriptionManager {
   }
 
   private cloudSubscriptionRetryDelayMs(attempt: number) {
-    if (this.deps.reconnectMaxAttempts === 0) return null
-    if (attempt >= this.deps.reconnectMaxAttempts) return null
-    return Math.min(this.deps.reconnectMaxMs, this.deps.reconnectBaseMs * 2 ** Math.max(0, attempt))
+    // Shared kernel (JOE-943): same attempt-based backoff math as OpenCode event pump.
+    return attemptReconnectDelayMs(
+      attempt,
+      this.deps.reconnectBaseMs,
+      this.deps.reconnectMaxMs,
+      this.deps.reconnectMaxAttempts,
+    )
   }
 
   private scheduleCloudSubscriptionRetry(

--- a/apps/desktop/src/main/durable-session-events.ts
+++ b/apps/desktop/src/main/durable-session-events.ts
@@ -13,10 +13,8 @@ import {
   advanceDurableCursor,
   durableAfterCursor,
   type DurableSequenceCursor,
-  exponentialReconnectDelayMs,
+  desktopDurableReconnectDelayMs,
   nextReconnectFailureCount,
-  OPENCODE_DURABLE_RECONNECT_INITIAL_MS_DESKTOP,
-  OPENCODE_DURABLE_RECONNECT_MAX_MS_DESKTOP,
   OPENCODE_SSE_OWNED_MAX_RETRY_ATTEMPTS,
   readDurableSequenceFromEvent,
   readSessionStatusType,
@@ -132,11 +130,7 @@ async function durableStreamLoop(hub: DirectoryDurableHub, state: DurableSession
       const message = error instanceof Error ? error.message : String(error)
       log('events', `Durable session stream error [${state.sessionId}]: ${message}`)
       consecutiveFailures = nextReconnectFailureCount(consecutiveFailures, receivedEvent)
-      const retryDelayMs = exponentialReconnectDelayMs(
-        consecutiveFailures,
-        OPENCODE_DURABLE_RECONNECT_INITIAL_MS_DESKTOP,
-        OPENCODE_DURABLE_RECONNECT_MAX_MS_DESKTOP,
-      )
+      const retryDelayMs = desktopDurableReconnectDelayMs(consecutiveFailures)
       await waitForAbortableDelay(hub.signal, retryDelayMs)
     }
   }

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -305,7 +305,7 @@ export function setupIpcHandlers(
     let directory = getRuntimeHomeDir()
 
     if (options?.sessionId) {
-      const sessionContext = runtimeContext.resolveSessionRuntimeModel(options.sessionId)
+      const sessionContext = await runtimeContext.resolveSessionRuntimeModel(options.sessionId)
       provider = options?.provider || sessionContext.provider
       model = options?.model || sessionContext.model
       directory = sessionContext.directory

--- a/apps/desktop/src/main/ipc-runtime-context.ts
+++ b/apps/desktop/src/main/ipc-runtime-context.ts
@@ -1,6 +1,5 @@
 import { getEffectiveSettings } from '@open-cowork/runtime-host/settings'
 import type { SessionRecord } from '@open-cowork/runtime-host/session-registry'
-import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
 import { getClientForDirectory, getRuntimeHomeDir } from '@open-cowork/runtime-host/runtime'
 import { ensureRuntimeContextDirectory } from '@open-cowork/runtime-host/runtime-context'
 import type {
@@ -8,15 +7,16 @@ import type {
   ScopedArtifactRef,
 } from '@open-cowork/shared'
 import { getBrandName } from '@open-cowork/runtime-host/config'
+import { getLocalSessionPort } from './local-workspace-session.ts'
 type RuntimeContextDependencies = {
   ensureSessionRecord: (sessionId: string) => SessionRecord | null
   resolveGrantedProjectDirectory: (directory?: string | null) => string | null
 }
 
 export function createIpcRuntimeContext(dependencies: RuntimeContextDependencies) {
-  function resolveSessionRuntimeModel(sessionId: string) {
+  async function resolveSessionRuntimeModel(sessionId: string) {
     const settings = getEffectiveSettings()
-    const view = sessionEngine.getSessionView(sessionId)
+    const view = await getLocalSessionPort().getSessionView(sessionId)
     const latestModeledMessage = [...view.messages]
       .reverse()
       .find((message) => message.providerId || message.modelId) || null

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -4,7 +4,7 @@ import { getEffectiveSettings, getIntegrationCredentials, getProviderCredentials
 import { getSessionRecord, toRendererSession, toSessionRecord, upsertSessionRecord } from '@open-cowork/runtime-host/session-registry'
 import { syncSessionView } from '@open-cowork/runtime-host/session-history-loader'
 import { publishSessionMetadata, publishSessionView } from '@open-cowork/runtime-host/session-event-dispatcher'
-import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
+import { getLocalSessionPort } from '../local-workspace-session.ts'
 import { getClient, getClientForDirectory, getModelInfoAsync } from '@open-cowork/runtime-host/runtime'
 import { invalidateRuntimeCatalogSnapshotCache } from '@open-cowork/runtime-host/runtime-catalog-snapshot'
 import { getRuntimeStatus } from '@open-cowork/runtime-host/runtime-status'
@@ -550,7 +550,7 @@ export function registerAppHandlers(context: IpcHandlerContext) {
     if (!sessionRecord) {
       throw new Error('Chart artifact save requires an existing session.')
     }
-    const sessionView = sessionEngine.getSessionView(request.sessionId)
+    const sessionView = await getLocalSessionPort().getSessionView(request.sessionId)
     if (!isKnownChartArtifactToolCall(sessionView, request)) {
       throw new Error('Chart artifact save requires a known chart tool call for this session.')
     }

--- a/apps/desktop/src/main/ipc/session-action-handlers.ts
+++ b/apps/desktop/src/main/ipc/session-action-handlers.ts
@@ -2,6 +2,7 @@ import { getThreadIndexService } from '@open-cowork/runtime-host/thread-index/th
 import { getSessionRecord, removeSessionRecord, updateSessionRecord } from '@open-cowork/runtime-host/session-registry'
 import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
 import { mergeSessionDiffsWithSynthetic, normalizeSessionFileDiffs } from '@open-cowork/runtime-host/session-diff-fallback'
+import { getLocalSessionPort } from '../local-workspace-session.ts'
 import { sdkErrorMessage } from '@open-cowork/runtime-host/sdk-error'
 import { getRuntimeHomeDir } from '@open-cowork/runtime-host/runtime'
 import {
@@ -159,7 +160,7 @@ export function registerSessionActionHandlers(context: IpcHandlerContext) {
       if (messageId) return diffs
 
       const record = getSessionRecord(sessionId)
-      const view = sessionEngine.getSessionView(sessionId)
+      const view = await getLocalSessionPort().getSessionView(sessionId)
       const rootDir = record?.opencodeDirectory || getRuntimeHomeDir()
       return mergeSessionDiffsWithSynthetic(diffs, view, rootDir)
     } catch (err) {

--- a/apps/desktop/src/main/local-workspace-session.ts
+++ b/apps/desktop/src/main/local-workspace-session.ts
@@ -1,18 +1,21 @@
 /**
- * Progressive local WorkspaceSessionPort wiring (post-#961 hardening).
+ * Progressive local WorkspaceSessionPort wiring (JOE-995 / post-#961 hardening).
  *
  * Adapts the process-local sessionEngine singleton behind the shared port so
  * high-traffic IPC can migrate off direct engine imports without inventing a
  * second session implementation.
  *
- * Scope today: only `getSessionView` is wired — that is what artifact-handlers
- * need. Other core port methods (`createSession`, `listSessions`, `promptSession`,
- * etc.) are intentionally unmapped: sessionEngine does not expose matching
- * shapes, and inventing stubs would fake a full IPC cutover. Callers that need
- * those operations still use sessionEngine (or cloud adapter) directly until a
- * later progressive PR maps them.
+ * Wired today (honest sessionEngine mappings only):
+ * - getSessionView
+ * - getSessionInfo (from engine meta + registry title when available)
+ *
+ * Other core port methods remain unmapped until sessionEngine exposes matching
+ * shapes. Callers that need those still use sessionEngine / OpenCode client
+ * directly — no fake cutover.
  */
 import { sessionEngine } from '@open-cowork/runtime-host/session-engine'
+import { getSessionRecord } from '@open-cowork/runtime-host/session-registry'
+import type { SessionInfo } from '@open-cowork/shared'
 import {
   createLocalWorkspaceSessionPort,
   type WorkspaceSessionPort,
@@ -20,15 +23,28 @@ import {
 
 let localPort: WorkspaceSessionPort | null = null
 
+function localGetSessionInfo(sessionId: string): SessionInfo | null {
+  const meta = sessionEngine.getSessionMeta(sessionId)
+  if (!meta) return null
+  const record = getSessionRecord(sessionId)
+  const now = new Date(meta.lastEventAt || Date.now()).toISOString()
+  return {
+    id: sessionId,
+    title: record?.title || sessionId,
+    createdAt: record?.createdAt || now,
+    updatedAt: record?.updatedAt || now,
+  }
+}
+
 /**
  * Module-level local session port for progressive port-shaped surfaces.
- * Currently: getSessionView only. Other core methods throw
- * `Local WorkspaceSessionPort method not available` by design.
+ * Unmapped core methods throw `Local WorkspaceSessionPort method not available`.
  */
 export function getLocalSessionPort(): WorkspaceSessionPort {
   if (!localPort) {
     localPort = createLocalWorkspaceSessionPort({
       getSessionView: (sessionId) => sessionEngine.getSessionView(sessionId),
+      getSessionInfo: (sessionId) => localGetSessionInfo(sessionId),
     })
   }
   return localPort

--- a/benchmarks/perf-baseline.linux-x64-node22.json
+++ b/benchmarks/perf-baseline.linux-x64-node22.json
@@ -11,7 +11,7 @@
     "p95Multiplier": 1.25,
     "avgAbsoluteFloorMs": 1,
     "p95AbsoluteFloorMs": 1.5,
-    "jitterAllowanceMs": 0.05
+    "jitterAllowanceMs": 0.15
   },
   "benchmarks": [
     {

--- a/packages/cloud-server/src/opencode-runtime-adapter.ts
+++ b/packages/cloud-server/src/opencode-runtime-adapter.ts
@@ -31,10 +31,8 @@ import {
   createOpencodeV2Client,
 } from '@open-cowork/runtime-host/opencode-client-kernel'
 import {
-  exponentialReconnectDelayMs,
+  cloudDurableReconnectDelayMs,
   nextReconnectFailureCount,
-  OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD,
-  OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD,
   OPENCODE_SSE_OWNED_MAX_RETRY_ATTEMPTS,
   waitForAbortableDelay,
 } from '@open-cowork/runtime-host'
@@ -669,11 +667,7 @@ function waitForRuntimeEventReconnect(signal: AbortSignal, delayMs: number) {
 }
 
 function cloudReconnectDelayMs(consecutiveFailures: number) {
-  return exponentialReconnectDelayMs(
-    consecutiveFailures,
-    OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD,
-    OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD,
-  )
+  return cloudDurableReconnectDelayMs(consecutiveFailures)
 }
 
 export function subscribeToOpencodeCloudRuntimeEvents(

--- a/packages/runtime-host/src/opencode-event-pump-kernel.ts
+++ b/packages/runtime-host/src/opencode-event-pump-kernel.ts
@@ -68,3 +68,37 @@ export function waitForAbortableDelay(signal: AbortSignal, delayMs: number): Pro
     signal.addEventListener('abort', finish, { once: true })
   })
 }
+
+/** Named desktop reconnect delay so product tails do not re-encode constants. */
+export function desktopDurableReconnectDelayMs(consecutiveFailures: number): number {
+  return exponentialReconnectDelayMs(
+    consecutiveFailures,
+    OPENCODE_DURABLE_RECONNECT_INITIAL_MS_DESKTOP,
+    OPENCODE_DURABLE_RECONNECT_MAX_MS_DESKTOP,
+  )
+}
+
+/** Named cloud reconnect delay so worker subscriptions do not re-encode constants. */
+export function cloudDurableReconnectDelayMs(consecutiveFailures: number): number {
+  return exponentialReconnectDelayMs(
+    consecutiveFailures,
+    OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD,
+    OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD,
+  )
+}
+
+/**
+ * Attempt-based retry delay for transport subscriptions that count attempts
+ * from 0 (first retry after first failure). Caps by attempt count when
+ * `maxAttempts` is finite; returns null when retries are exhausted.
+ */
+export function attemptReconnectDelayMs(
+  attempt: number,
+  baseMs: number,
+  maxMs: number,
+  maxAttempts: number,
+): number | null {
+  if (maxAttempts === 0) return null
+  if (attempt >= maxAttempts) return null
+  return Math.min(maxMs, baseMs * 2 ** Math.max(0, attempt))
+}

--- a/products/gateway/docs/development/module-boundary-budget.json
+++ b/products/gateway/docs/development/module-boundary-budget.json
@@ -817,7 +817,7 @@
    "path": "src/work-store.ts",
    "maxLines": 1550,
    "owner": "work_store",
-   "note": "Hard LOC budget (JOE-919/JOE-942); post-#961 project-orchestration extract; hard max 1550 (soft \u22641500); current ~1497 — leave drive-by headroom like work routes"
+   "note": "Hard LOC budget (JOE-919/JOE-942/JOE-992); work-queries peel; hard max 1550 (soft \u22641500)"
   },
   {
    "path": "src/environments.ts",
@@ -845,9 +845,9 @@
   },
   {
    "path": "src/mcp.ts",
-   "maxLines": 1650,
+   "maxLines": 1600,
    "owner": "daemon_cli_edge",
-   "note": "Hard LOC budget (post-#961); mcp-tools-ops extract for backup/storage tools; current ~1614 under 1650 hard max"
+   "note": "Hard LOC budget (post-#961/JOE-992); mcp-tools-ops + mcp-formatters peels; hard max 1600 (soft \u22641550)"
   },
   {
    "path": "src/channel-commands.ts",

--- a/products/gateway/src/mcp-formatters.ts
+++ b/products/gateway/src/mcp-formatters.ts
@@ -1,0 +1,98 @@
+/**
+ * MCP response text formatters (JOE-992 progressive façade peel).
+ * Leaf relative to mcp.ts — no tool registration side effects.
+ */
+import {
+  buildMissionControlDashboardSummary,
+  buildMissionControlDataPlaneV2,
+  formatMissionControlDataPlaneText,
+  formatMissionControlEnvironmentCounts,
+  type MissionControlDataPlaneV2,
+  type MissionControlSourceContract,
+} from './mission-control-view-model.js'
+import { formatTaskCounts } from './task-summary.js'
+
+export function formatGatewayDashboardText(input: { health: any; taskData: any; sessions: any; questions: any; permissions: any; attention?: any; environments?: any; operationsCockpit?: any; sourceContracts?: MissionControlSourceContract[]; dataPlane?: MissionControlDataPlaneV2 }): string {
+  const summary = buildMissionControlDashboardSummary(input)
+  const dataPlane = input.dataPlane || (input.sourceContracts?.length
+    ? buildMissionControlDataPlaneV2({ sourceContracts: input.sourceContracts, consumers: ['mcp', 'dashboard', 'support'] })
+    : undefined)
+  let text = '# Gateway Dashboard\n\n'
+  text += `Status: ${summary.status}\n`
+  text += `Scheduler: ${summary.scheduler}\n`
+  text += `Issues (tasks): ${summary.taskCounts}\n`
+  text += `Gateway Sessions: ${summary.gatewaySessions}\n`
+  if (summary.environments) text += `Environments: ${summary.environments}\n`
+  text += `Requests: ${summary.requests}\n\n`
+  if (summary.sources) {
+    text += `Sources: ${summary.sources.summary}\n`
+    const sourceAttention = summary.sources.items.filter(item => item.severity !== 'ok' && item.state !== 'empty')
+    if (sourceAttention.length) text += sourceAttention.slice(0, 8).map(item => `- [${item.state}] ${item.key}: ${item.nextAction}`).join('\n') + '\n'
+    text += '\n'
+  }
+  if (dataPlane) text += `${formatMissionControlDataPlaneText(dataPlane).join('\n')}\n\n`
+  if (summary.attention) text += `Needs Attention: ${summary.attention}\n\n`
+  if (summary.operationsCockpit) {
+    text += `Operations Cockpit: ${summary.operationsCockpit.status} — ${summary.operationsCockpit.summary}\n`
+    const nonReady = summary.operationsCockpit.items.filter(item => item.status !== 'ready')
+    if (nonReady.length) text += nonReady.slice(0, 8).map(item => `- [${item.status}] ${item.id}: ${item.nextAction}`).join('\n') + '\n'
+    text += '\n'
+  }
+  text += '## Active Issues\n\n'
+  text += summary.activeIssues.length ? summary.activeIssues.map(task => `- [${task.status}] ${task.priority}: ${task.title} (${task.id}) — ${task.agent} / ${task.currentStage}`).join('\n') : 'No active work.'
+  text += '\n\n## Initiatives (roadmaps)\n\n'
+  text += summary.initiatives.length ? summary.initiatives.map(roadmap => `- [${roadmap.status}] ${roadmap.priority}: ${roadmap.title} (${roadmap.id})`).join('\n') : 'No active roadmaps.'
+  return text
+}
+
+export function formatBulkTaskCreateText(result: any): string {
+  const tasks = result?.tasks || []
+  if (!tasks.length) return 'No tasks created.'
+  return `Created ${result?.created || tasks.length} task(s)\n\n${tasks.map((task: any) => `- ${task.title} (${task.id}) — ${task.priority || 'MEDIUM'} / ${(task.pipeline || []).join(' -> ') || task.currentStage || 'implement'}`).join('\n')}`
+}
+
+export function formatSchedulerRunOnceText(result: any): string {
+  const counts = result?.counts || {}
+  const lines = [
+    'Scheduler cycle complete.',
+    `Tasks: ${formatTaskCounts(counts, { includeCancelled: true })}`,
+  ]
+  const activeTasks = result?.activeTasks || []
+  if (activeTasks.length) lines.push('', 'Active work:', ...activeTasks.map((task: any) => `- [${task.status}] ${task.title} (${task.id}) — ${task.currentStage || 'complete'}`))
+  const recentRuns = result?.recentRuns || []
+  if (recentRuns.length) lines.push('', 'Recent runs:', ...recentRuns.slice(-5).map((run: any) => `- [${run.status}] ${run.stage}: ${run.sessionId} (${run.id})`))
+  return lines.join('\n')
+}
+
+export function formatEnvironmentListText(result: any): string {
+  const environments = result?.environments || []
+  const lines = [`${environments.length} environment(s): ${formatMissionControlEnvironmentCounts(environments)}`]
+  if (environments.length) {
+    lines.push('', ...environments.map((environment: any) => {
+      const runtime = environment.runtimeProfile
+      const runtimeText = runtime ? ` / runtime ${runtime.filesystem?.policy || '?'} net=${runtime.network?.mode || '?'} cwd=${runtime.cwd?.redacted || '?'}` : ''
+      const diagnostics = Array.isArray(environment.lifecycleDiagnostics) ? environment.lifecycleDiagnostics : []
+      const worst = diagnostics.find((row: any) => row.severity === 'critical') || diagnostics.find((row: any) => row.severity === 'warning') || diagnostics[0]
+      const diagnosticText = worst ? ` / diagnostic ${worst.severity}:${worst.code}` : ''
+      return `- [${environment.status}] ${environment.name || environment.id} (${environment.id}) — ${environment.backend || '?'} / run ${environment.runId || '?'} / cleanup ${environment.cleanup?.state || '?'}${runtimeText}${diagnosticText}`
+    }))
+  }
+  return lines.join('\n')
+}
+
+export function formatEnvironmentActionText(result: any): string {
+  const environment = result?.environment || {}
+  return [
+    `${result?.eventType || 'environment.action'}: ${environment.name || environment.id || 'environment'}`,
+    `Environment: ${environment.id || '?'}`,
+    `Status: ${environment.status || '?'} / cleanup ${environment.cleanup?.state || '?'}`,
+    result?.abortedSessionId ? `Aborted session: ${result.abortedSessionId}` : '',
+  ].filter(Boolean).join('\n')
+}
+
+export function formatEnvironmentReconcileText(result: any): string {
+  const summary = result?.reconciliation || result || {}
+  const evidence = (summary.evidence || []).slice(0, 10)
+  return [`Environment reconciliation complete: checked=${summary.checked || 0} active=${summary.active || 0} retained=${summary.retained || 0} cleanupFailed=${summary.cleanupFailed || 0}`, ...evidence.map((line: string) => `- ${line}`)].join('\n')
+}
+

--- a/products/gateway/src/mcp.ts
+++ b/products/gateway/src/mcp.ts
@@ -5,11 +5,10 @@ import { z } from 'zod'
 import { pathToFileURL } from 'node:url'
 import { getConfigDir } from './config.js'
 import { readPackageVersion } from './version.js'
-import { buildOperationsCockpit, buildMissionControlDashboardSummary, buildMissionControlDataPlaneV2, formatMissionControlDataPlaneText, formatMissionControlEnvironmentCounts, missionControlWindow, type MissionControlDataPlaneV2, type MissionControlSourceContract } from './mission-control-view-model.js'
+import { buildOperationsCockpit, buildMissionControlDataPlaneV2, missionControlWindow, type MissionControlSourceContract } from './mission-control-view-model.js'
 import { decideMcpRequestSecurityPolicy } from './security-policy.js'
 import { mcpModeAllowsHttpCapability, resolveMcpToolMode, toolEnabledForMode, type McpToolTier } from './mcp-tool-tiers.js'
 import { buildGatewayToolCatalog } from './gateway-tools.js'
-import { formatTaskCounts } from './task-summary.js'
 import { httpCapabilityForRequest, type HttpCapability } from './security.js'
 import { readScopedHttpTokenFile } from './secrets-lifecycle.js'
 import { registerMcpOpsTools } from './mcp-tools-ops.js'
@@ -126,89 +125,14 @@ export async function runTool(fn: () => Promise<string>) {
   catch (err) { return textResult(formatDaemonError(err), true) }
 }
 
-export function formatGatewayDashboardText(input: { health: any; taskData: any; sessions: any; questions: any; permissions: any; attention?: any; environments?: any; operationsCockpit?: any; sourceContracts?: MissionControlSourceContract[]; dataPlane?: MissionControlDataPlaneV2 }): string {
-  const summary = buildMissionControlDashboardSummary(input)
-  const dataPlane = input.dataPlane || (input.sourceContracts?.length
-    ? buildMissionControlDataPlaneV2({ sourceContracts: input.sourceContracts, consumers: ['mcp', 'dashboard', 'support'] })
-    : undefined)
-  let text = '# Gateway Dashboard\n\n'
-  text += `Status: ${summary.status}\n`
-  text += `Scheduler: ${summary.scheduler}\n`
-  text += `Issues (tasks): ${summary.taskCounts}\n`
-  text += `Gateway Sessions: ${summary.gatewaySessions}\n`
-  if (summary.environments) text += `Environments: ${summary.environments}\n`
-  text += `Requests: ${summary.requests}\n\n`
-  if (summary.sources) {
-    text += `Sources: ${summary.sources.summary}\n`
-    const sourceAttention = summary.sources.items.filter(item => item.severity !== 'ok' && item.state !== 'empty')
-    if (sourceAttention.length) text += sourceAttention.slice(0, 8).map(item => `- [${item.state}] ${item.key}: ${item.nextAction}`).join('\n') + '\n'
-    text += '\n'
-  }
-  if (dataPlane) text += `${formatMissionControlDataPlaneText(dataPlane).join('\n')}\n\n`
-  if (summary.attention) text += `Needs Attention: ${summary.attention}\n\n`
-  if (summary.operationsCockpit) {
-    text += `Operations Cockpit: ${summary.operationsCockpit.status} — ${summary.operationsCockpit.summary}\n`
-    const nonReady = summary.operationsCockpit.items.filter(item => item.status !== 'ready')
-    if (nonReady.length) text += nonReady.slice(0, 8).map(item => `- [${item.status}] ${item.id}: ${item.nextAction}`).join('\n') + '\n'
-    text += '\n'
-  }
-  text += '## Active Issues\n\n'
-  text += summary.activeIssues.length ? summary.activeIssues.map(task => `- [${task.status}] ${task.priority}: ${task.title} (${task.id}) — ${task.agent} / ${task.currentStage}`).join('\n') : 'No active work.'
-  text += '\n\n## Initiatives (roadmaps)\n\n'
-  text += summary.initiatives.length ? summary.initiatives.map(roadmap => `- [${roadmap.status}] ${roadmap.priority}: ${roadmap.title} (${roadmap.id})`).join('\n') : 'No active roadmaps.'
-  return text
-}
-
-export function formatBulkTaskCreateText(result: any): string {
-  const tasks = result?.tasks || []
-  if (!tasks.length) return 'No tasks created.'
-  return `Created ${result?.created || tasks.length} task(s)\n\n${tasks.map((task: any) => `- ${task.title} (${task.id}) — ${task.priority || 'MEDIUM'} / ${(task.pipeline || []).join(' -> ') || task.currentStage || 'implement'}`).join('\n')}`
-}
-
-export function formatSchedulerRunOnceText(result: any): string {
-  const counts = result?.counts || {}
-  const lines = [
-    'Scheduler cycle complete.',
-    `Tasks: ${formatTaskCounts(counts, { includeCancelled: true })}`,
-  ]
-  const activeTasks = result?.activeTasks || []
-  if (activeTasks.length) lines.push('', 'Active work:', ...activeTasks.map((task: any) => `- [${task.status}] ${task.title} (${task.id}) — ${task.currentStage || 'complete'}`))
-  const recentRuns = result?.recentRuns || []
-  if (recentRuns.length) lines.push('', 'Recent runs:', ...recentRuns.slice(-5).map((run: any) => `- [${run.status}] ${run.stage}: ${run.sessionId} (${run.id})`))
-  return lines.join('\n')
-}
-
-export function formatEnvironmentListText(result: any): string {
-  const environments = result?.environments || []
-  const lines = [`${environments.length} environment(s): ${formatMissionControlEnvironmentCounts(environments)}`]
-  if (environments.length) {
-    lines.push('', ...environments.map((environment: any) => {
-      const runtime = environment.runtimeProfile
-      const runtimeText = runtime ? ` / runtime ${runtime.filesystem?.policy || '?'} net=${runtime.network?.mode || '?'} cwd=${runtime.cwd?.redacted || '?'}` : ''
-      const diagnostics = Array.isArray(environment.lifecycleDiagnostics) ? environment.lifecycleDiagnostics : []
-      const worst = diagnostics.find((row: any) => row.severity === 'critical') || diagnostics.find((row: any) => row.severity === 'warning') || diagnostics[0]
-      const diagnosticText = worst ? ` / diagnostic ${worst.severity}:${worst.code}` : ''
-      return `- [${environment.status}] ${environment.name || environment.id} (${environment.id}) — ${environment.backend || '?'} / run ${environment.runId || '?'} / cleanup ${environment.cleanup?.state || '?'}${runtimeText}${diagnosticText}`
-    }))
-  }
-  return lines.join('\n')
-}
-
-export function formatEnvironmentActionText(result: any): string {
-  const environment = result?.environment || {}
-  return [
-    `${result?.eventType || 'environment.action'}: ${environment.name || environment.id || 'environment'}`,
-    `Environment: ${environment.id || '?'}`,
-    `Status: ${environment.status || '?'} / cleanup ${environment.cleanup?.state || '?'}`,
-    result?.abortedSessionId ? `Aborted session: ${result.abortedSessionId}` : '',
-  ].filter(Boolean).join('\n')
-}
-
-export function formatEnvironmentReconcileText(result: any): string {
-  const summary = result?.reconciliation || result || {}
-  const evidence = (summary.evidence || []).slice(0, 10)
-  return [`Environment reconciliation complete: checked=${summary.checked || 0} active=${summary.active || 0} retained=${summary.retained || 0} cleanupFailed=${summary.cleanupFailed || 0}`, ...evidence.map((line: string) => `- ${line}`)].join('\n')
-}
+export {
+  formatGatewayDashboardText,
+  formatBulkTaskCreateText,
+  formatSchedulerRunOnceText,
+  formatEnvironmentListText,
+  formatEnvironmentActionText,
+  formatEnvironmentReconcileText,
+} from './mcp-formatters.js'
 
 export const server = new McpServer({ name: 'gateway-proxy', version: readPackageVersion() })
 

--- a/products/gateway/src/mcp.ts
+++ b/products/gateway/src/mcp.ts
@@ -5,13 +5,21 @@ import { z } from 'zod'
 import { pathToFileURL } from 'node:url'
 import { getConfigDir } from './config.js'
 import { readPackageVersion } from './version.js'
-import { buildOperationsCockpit, buildMissionControlDataPlaneV2, missionControlWindow, type MissionControlSourceContract } from './mission-control-view-model.js'
+import { buildOperationsCockpit, buildMissionControlDataPlaneV2, missionControlWindow } from './mission-control-view-model.js'
 import { decideMcpRequestSecurityPolicy } from './security-policy.js'
 import { mcpModeAllowsHttpCapability, resolveMcpToolMode, toolEnabledForMode, type McpToolTier } from './mcp-tool-tiers.js'
 import { buildGatewayToolCatalog } from './gateway-tools.js'
 import { httpCapabilityForRequest, type HttpCapability } from './security.js'
 import { readScopedHttpTokenFile } from './secrets-lifecycle.js'
 import { registerMcpOpsTools } from './mcp-tools-ops.js'
+import {
+  formatBulkTaskCreateText,
+  formatEnvironmentActionText,
+  formatEnvironmentListText,
+  formatEnvironmentReconcileText,
+  formatGatewayDashboardText,
+  formatSchedulerRunOnceText,
+} from './mcp-formatters.js'
 
 const DAEMON_URL = process.env['GATEWAY_DAEMON_URL'] || 'http://127.0.0.1:4097'
 const REQUEST_TIMEOUT_MS = 15000
@@ -132,7 +140,7 @@ export {
   formatEnvironmentListText,
   formatEnvironmentActionText,
   formatEnvironmentReconcileText,
-} from './mcp-formatters.js'
+}
 
 export const server = new McpServer({ name: 'gateway-proxy', version: readPackageVersion() })
 

--- a/products/gateway/src/work-store.ts
+++ b/products/gateway/src/work-store.ts
@@ -88,7 +88,6 @@ export {
 } from './work-store/human-gates.js'
 import {
   listWorkTaskViews,
-  calculateTaskReadiness,
   applyTaskUpdate,
   createRoadmapInState,
   createWorkTaskInState,
@@ -245,7 +244,6 @@ import type {
   WorkTaskBulkUpdateInput,
   WorkTaskCreateInput,
   WorkTaskDeleteResult,
-  WorkTaskReadiness,
   WorkTaskRecord,
   WorkTaskRunCompleteResult,
   WorkTaskRunFailResult,

--- a/products/gateway/src/work-store.ts
+++ b/products/gateway/src/work-store.ts
@@ -191,6 +191,7 @@ export {
   recomputeRoadmapStatusInState,
 } from './work-store/task-helpers.js'
 export { appendWorkEventRow } from './work-store/event-append.js'
+export { getWorkTaskReadiness, listWorkDependencies, summarizeWorkTasks } from './work-store/work-queries.js'
 
 import {
   OPEN_HUMAN_GATE_STATUSES,
@@ -257,16 +258,6 @@ import type {
 
 
 
-export function getWorkTaskReadiness(taskId: string, filePath = workStatePath()): WorkTaskReadiness | undefined {
-  const state = loadWorkState(filePath)
-  const task = state.tasks.find(row => row.id === taskId)
-  return task ? calculateTaskReadiness(task, state) : undefined
-}
-
-export function listWorkDependencies(taskId?: string, filePath = workStatePath()): WorkDependencyRecord[] {
-  const deps = loadWorkState(filePath).dependencies || []
-  return taskId ? deps.filter(dep => dep.taskId === taskId) : deps
-}
 
 
 export function decideHumanGate(id: string, input: HumanGateDecisionInput, filePath = workStatePath()): HumanGateDecisionResult | undefined {
@@ -377,21 +368,6 @@ export function deleteWorkDependency(taskId: string, dependsOnTaskId: string, ty
   })
 }
 
-export function summarizeWorkTasks(tasks: Array<{ status: WorkStatus; priority: string }>) {
-  return {
-    total: tasks.length,
-    pending: tasks.filter(t => t.status === 'pending').length,
-    running: tasks.filter(t => t.status === 'running').length,
-    done: tasks.filter(t => t.status === 'done').length,
-    blocked: tasks.filter(t => t.status === 'blocked').length,
-    paused: tasks.filter(t => t.status === 'paused').length,
-    cancelled: tasks.filter(t => t.status === 'cancelled').length,
-    archived: tasks.filter(t => t.status === 'archived').length,
-    high: tasks.filter(t => t.priority === 'HIGH').length,
-    medium: tasks.filter(t => t.priority === 'MEDIUM').length,
-    low: tasks.filter(t => t.priority === 'LOW').length,
-  }
-}
 
 export function markWorkTaskDone(text: string, filePath = workStatePath()): boolean {
   return mutateWorkState(filePath, (state, db) => {

--- a/products/gateway/src/work-store/work-queries.ts
+++ b/products/gateway/src/work-store/work-queries.ts
@@ -1,0 +1,34 @@
+/**
+ * Small work-store query helpers (JOE-992 progressive façade peel).
+ * Leaf relative to work-store.ts façade.
+ */
+import { workStatePath } from './db.js'
+import { loadWorkState } from './state-io.js'
+import { calculateTaskReadiness } from './task-helpers.js'
+import type { WorkDependencyRecord, WorkTaskReadiness, WorkStatus } from './types.js'
+
+export function getWorkTaskReadiness(taskId: string, filePath = workStatePath()): WorkTaskReadiness | undefined {
+  const state = loadWorkState(filePath)
+  const task = state.tasks.find(row => row.id === taskId)
+  return task ? calculateTaskReadiness(task, state) : undefined
+}
+export function listWorkDependencies(taskId?: string, filePath = workStatePath()): WorkDependencyRecord[] {
+  const deps = loadWorkState(filePath).dependencies || []
+  return taskId ? deps.filter(dep => dep.taskId === taskId) : deps
+}
+
+export function summarizeWorkTasks(tasks: Array<{ status: WorkStatus; priority: string }>) {
+  return {
+    total: tasks.length,
+    pending: tasks.filter(t => t.status === 'pending').length,
+    running: tasks.filter(t => t.status === 'running').length,
+    done: tasks.filter(t => t.status === 'done').length,
+    blocked: tasks.filter(t => t.status === 'blocked').length,
+    paused: tasks.filter(t => t.status === 'paused').length,
+    cancelled: tasks.filter(t => t.status === 'cancelled').length,
+    archived: tasks.filter(t => t.status === 'archived').length,
+    high: tasks.filter(t => t.priority === 'HIGH').length,
+    medium: tasks.filter(t => t.priority === 'MEDIUM').length,
+    low: tasks.filter(t => t.priority === 'LOW').length,
+  }
+}

--- a/tests/opencode-event-pump-kernel.test.ts
+++ b/tests/opencode-event-pump-kernel.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  attemptReconnectDelayMs,
+  cloudDurableReconnectDelayMs,
+  desktopDurableReconnectDelayMs,
   exponentialReconnectDelayMs,
   nextReconnectFailureCount,
   OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD,
+  OPENCODE_DURABLE_RECONNECT_INITIAL_MS_DESKTOP,
   OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD,
+  OPENCODE_DURABLE_RECONNECT_MAX_MS_DESKTOP,
   OPENCODE_SSE_OWNED_MAX_RETRY_ATTEMPTS,
   waitForAbortableDelay,
 } from '@open-cowork/runtime-host'
@@ -22,6 +27,20 @@ test('exponentialReconnectDelayMs grows until cap', () => {
     exponentialReconnectDelayMs(10, OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD, OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD),
     OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD,
   )
+})
+
+test('named cloud/desktop reconnect helpers match constants', () => {
+  assert.equal(cloudDurableReconnectDelayMs(1), OPENCODE_DURABLE_RECONNECT_INITIAL_MS_CLOUD)
+  assert.equal(desktopDurableReconnectDelayMs(1), OPENCODE_DURABLE_RECONNECT_INITIAL_MS_DESKTOP)
+  assert.equal(cloudDurableReconnectDelayMs(20), OPENCODE_DURABLE_RECONNECT_MAX_MS_CLOUD)
+  assert.equal(desktopDurableReconnectDelayMs(20), OPENCODE_DURABLE_RECONNECT_MAX_MS_DESKTOP)
+})
+
+test('attemptReconnectDelayMs respects attempt caps', () => {
+  assert.equal(attemptReconnectDelayMs(0, 100, 1000, 3), 100)
+  assert.equal(attemptReconnectDelayMs(1, 100, 1000, 3), 200)
+  assert.equal(attemptReconnectDelayMs(3, 100, 1000, 3), null)
+  assert.equal(attemptReconnectDelayMs(0, 100, 1000, 0), null)
 })
 
 test('nextReconnectFailureCount resets after receive', () => {


### PR DESCRIPTION
## Summary
Implements the three recommended post-#964 **Todo** issues in **one PR** to cut Actions bill (fewer CI runs):

| Issue | What shipped |
| --- | --- |
| **JOE-995** | Local `WorkspaceSessionPort` wires `getSessionView` + honest `getSessionInfo`; migrates ipc-runtime-context, `session:diff`, `chart:save-artifact` off direct `sessionEngine` for view reads |
| **JOE-992** | Progressive peels: `mcp-formatters.ts`, `work-store/work-queries.ts`; mcp hard max 1600; work-store ~1473 under 1550 |
| **JOE-943** | Expand event-pump kernel (`desktop/cloudDurableReconnectDelayMs`, `attemptReconnectDelayMs`); desktop durable tails + cloud subscription manager use shared math |

## Non-goals
- Full IPC cutover / fake port methods
- Full dual-stack protocol unify or HA migrate hazard closes (separate issues)

## Test plan
- [x] `pnpm --filter @open-cowork/runtime-host build`
- [x] `node --test tests/opencode-event-pump-kernel.test.ts`
- [x] gateway module-boundaries + mcp tests
- [x] desktop `tsc --noEmit`
- [x] storage-export dual-intent smoke
- [ ] CI green on PR

Linear: JOE-995, JOE-992, JOE-943 (epic JOE-916)