### PR TITLE
ci+sec(joe-969/932/962/946): weekly gateway matrix, dual-stack PR gate, residual reaffirm

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,8 @@
 
 Required when this PR touches **channel security or protocol** (signatures, SSRF/webhook URLs, auth tokens, rate limits, constant-time compares, trusted-target allowlists). See `docs/product-channel-ownership.md`.
 
+CI gate (JOE-932): `scripts/check-dual-channel-pr-checklist.mjs` runs on PRs that touch Durable channels, monorepo providers, or shared channel-security kernels. Unrelated PRs skip. Satisfy by ticking below, or put `Dual-stack checklist: exempt` in Notes with a one-line rationale.
+
 - [ ] N/A — not a channel security/protocol change
 - [ ] Reviewed **monorepo providers** (`packages/gateway-provider-*`, `packages/gateway-channel`, `apps/channel-gateway`)
 - [ ] Reviewed **Durable Gateway channels** (`products/gateway/src/channels/*` and related security)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
             git diff-tree --check --root --no-commit-id -r HEAD -- . ':(exclude)products/**'
           fi
 
+      # JOE-932: dual-stack checklist required only when channel security paths change.
+      # Unrelated monorepo PRs skip (exit 0). Docs: docs/product-channel-ownership.md
+      - name: Dual-channel security PR checklist
+        if: github.event_name == 'pull_request'
+        env:
+          OPEN_COWORK_PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Prefer the Pulls Files API so shallow checkout (fetch-depth: 2) still works.
+          FILES="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename' 2>/dev/null || true)"
+          if [ -z "$FILES" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" 2>/dev/null || true)"
+          fi
+          export OPEN_COWORK_CHANGED_FILES="$FILES"
+          node scripts/check-dual-channel-pr-checklist.mjs
+
       - name: Dependency review
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/weekly-gateway.yml
+++ b/.github/workflows/weekly-gateway.yml
@@ -1,0 +1,95 @@
+name: Weekly Gateway Matrix
+
+# JOE-969: Path-filtered `ci-gateway.yml` remains intentional for PR cost.
+# This weekly full-matrix job runs `pnpm test:gateway` (and the Durable
+# Gateway typecheck/build smoke) even when monorepo scripts change without
+# touching products/gateway/**, so regressions outside the path filter stay
+# visible. Failures open/comment a GitHub issue — not silent.
+
+on:
+  schedule:
+    # Monday 04:17 UTC — offset from monthly maintenance (1st 02:00) and evals.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: weekly-gateway
+  cancel-in-progress: true
+
+jobs:
+  gateway-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Product boundaries
+        run: pnpm boundaries:check
+
+      # products/gateway depends on @open-cowork/shared (dist-only package exports).
+      - name: Build shared workspace package
+        run: pnpm --filter @open-cowork/shared build
+
+      - name: Build Gateway
+        run: pnpm --filter cowork-gateway build
+
+      - name: Typecheck Gateway
+        run: pnpm --filter cowork-gateway typecheck
+
+      - name: Dead code (knip)
+        run: pnpm --filter cowork-gateway knip
+
+      - name: Test Gateway (full matrix)
+        id: gateway-test
+        run: pnpm test:gateway
+
+      - name: Release check (if present)
+        run: pnpm --filter cowork-gateway release:check
+
+      - name: Standalone install smoke
+        run: node products/gateway/scripts/standalone-smoke.mjs
+
+      - name: Alert on weekly gateway matrix failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Weekly gateway matrix red (pnpm test:gateway)"
+          body="$(cat <<EOF
+          Weekly Gateway Matrix found Durable Gateway checks red outside path-filtered PR CI.
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          Path-filtered \`ci-gateway.yml\` remains intentional for PR cost (JOE-969).
+          This scheduled job is the backstop when monorepo scripts or shared packages
+          change without touching \`products/gateway/**\`.
+
+          Reproduce locally:
+          \`\`\`
+          pnpm --filter @open-cowork/shared build
+          pnpm test:gateway
+          \`\`\`
+          EOF
+          )"
+          existing="$(gh issue list --state open --search "${title} in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -50,9 +50,15 @@ Path-filtered workflows (not always required on Desktop-only PRs):
 - `CI Gateway` (`.github/workflows/ci-gateway.yml`) — `products/gateway/**` (includes standalone smoke)
 - `CI Wiki` (`.github/workflows/ci-wiki.yml`) — `products/wiki/**` (includes standalone smoke)
 
+**Weekly backstop (not a PR merge gate):**
+
+- `Weekly Gateway Matrix` (`.github/workflows/weekly-gateway.yml`, JOE-969) — scheduled Monday run of `pnpm test:gateway` + Durable Gateway build/typecheck/standalone smoke outside path filters. Failures open/comment a GitHub issue. Use this when monorepo scripts change without touching `products/gateway/**`.
+
 Product release workflows (independent of Desktop `v*` tags):
 
 - `Release Gateway` (`.github/workflows/release-gateway.yml`) — `gateway@v*` / manual
 - `Release Wiki` (`.github/workflows/release-wiki.yml`) — `wiki@v*` / manual
 
 Core `CI` workflow remains the branch-protection baseline for monorepo master.
+
+**Dual-channel checklist (JOE-932):** On PRs that touch channel security paths, `CI` / `validate` runs `scripts/check-dual-channel-pr-checklist.mjs` (PR-body gate). Unrelated PRs skip. Not a separate required-check name — it is part of the existing `validate` job.

--- a/docs/packaging-and-releases.md
+++ b/docs/packaging-and-releases.md
@@ -125,6 +125,12 @@ The repository includes:
     OpenCode SDK/runtime drift
   - exists to catch maintenance issues without a noisy nightly signal
 
+- `weekly-gateway.yml` (JOE-969)
+  - runs every Monday (and `workflow_dispatch`)
+  - runs full Durable Gateway matrix: `pnpm test:gateway`, typecheck, knip,
+    release:check, standalone smoke — **outside** path-filtered `ci-gateway.yml`
+  - failures open/comment a GitHub issue so path-filter misses are not silent
+
 ## Verify a download
 
 Release assets include `SHA256SUMS.txt`. After downloading an artifact

--- a/docs/product-channel-ownership.md
+++ b/docs/product-channel-ownership.md
@@ -68,3 +68,42 @@ allowlists, credential redaction for channel diagnostics) must:
 
 Do not land a security fix in only one stack without an explicit “other stack
 N/A / follow-up” note in the PR body.
+
+### CI gate (JOE-932)
+
+On `pull_request` to `master`, the monorepo `CI` workflow runs:
+
+```bash
+node scripts/check-dual-channel-pr-checklist.mjs
+```
+
+with the PR body and the changed-file list. The gate is **inactive** (exit 0)
+for unrelated monorepo PRs.
+
+**Activates when the PR touches any of:**
+
+| Surface | Paths |
+| --- | --- |
+| Durable channels | `products/gateway/src/channels/**` |
+| Monorepo providers | `packages/gateway-provider-*/**`, `packages/gateway-channel/**`, `apps/channel-gateway/**`, `apps/standalone-gateway/**` |
+| Shared security kernels / guards | `packages/shared/src/node/channel-webhook-security.ts`, `packages/shared/src/node/webhook-rate-limiter.ts`, `scripts/check-dual-channel-security.mjs`, this doc, PR template |
+
+**How to satisfy**
+
+1. Tick **N/A** when the change is not channel security/protocol, **or**
+2. Tick the stack(s) reviewed and **Both stacks fixed** (or note single-stack ownership / follow-up in **Notes**), **or**
+3. Put `Dual-stack checklist: exempt` in **Notes** with a one-line rationale (intentional single-stack protocol work, docs-only ownership wording, etc.).
+
+Local dry-run:
+
+```bash
+OPEN_COWORK_CHANGED_FILES=$'products/gateway/src/channels/whatsapp.ts' \
+OPEN_COWORK_PR_BODY="$(cat <<'EOF'
+- [x] N/A — not a channel security/protocol change
+EOF
+)" \
+node scripts/check-dual-channel-pr-checklist.mjs
+```
+
+Kernel wiring regressions (copy-paste HMAC / Ed25519) remain covered by
+`scripts/check-dual-channel-security.mjs` via `pnpm boundaries:check`.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -175,13 +175,13 @@ runtime registration, so public-looking hostnames that resolve into
 private networks at those policy checkpoints are skipped before OpenCode
 receives the MCP entry.
 
-**DNS pin / residual SSRF (JOE-826, revalidated 2026-07-21 / JOE-962):** At
+**DNS pin / residual SSRF (JOE-826, revalidated 2026-07-23 / JOE-962):** At
 runtime handoff, cleartext `http:` MCP entries are rewritten to connect to a
 policy-validated resolved address while preserving the original `Host` header
 (`pinHttpMcpRemoteEntry` in `packages/runtime-host/src/runtime-mcp.ts`). That
 closes the DNS-rebinding window for HTTP.
 
-**HTTPS residual (accepted — reaffirmed post-#961 hardening):** OpenCode owns the TLS
+**HTTPS residual (accepted — reaffirmed 2026-07-23 / JOE-962):** OpenCode owns the TLS
 transport; IP-pinning would break SNI and certificate hostname checks, so
 `https:` MCPs stay hostname-based after the pre-connect DNS policy check
 (`evaluateHttpMcpUrlResolved` still rejects private/link-local/metadata
@@ -191,6 +191,10 @@ resolver is compromised or TTL is hostile. **Operators who need stronger
 guarantees** should terminate TLS at a trusted reverse proxy with a fixed
 upstream IP, or restrict MCPs to known static endpoints. Cloud-metadata targets
 remain hard-denied on every policy check regardless of protocol.
+
+Regression coverage: `tests/runtime-mcp-opt-in.test.ts` (HTTP pin + HTTPS
+hostname retention), `tests/mcp-url-policy.test.ts` (DNS-resolved private /
+metadata denial). Re-run those suites when touching MCP handoff.
 
 **Reopen when:** OpenCode exposes a connect-IP + SNI/Host override for remote
 MCP transport, or we add an optional local HTTPS MITM pin path for lab-only
@@ -328,16 +332,20 @@ lifecycle, lease/fencing contract, recovery behavior, and threat model live in
 
 ## Chart frame isolation
 
-**Parent SPA CSP (JOE-946 / P2-7):** Cloud `writeBrowserRendererHtml` and the
-desktop main-window CSP keep `script-src 'self'` with **no** `'unsafe-eval'`.
-Interactive Vega must not execute in the parent document.
+**Parent SPA CSP (JOE-946 / P2-7, reaffirmed 2026-07-23):** Cloud
+`writeBrowserRendererHtml` and the desktop main-window CSP keep
+`script-src 'self'` with **no** `'unsafe-eval'`. Interactive Vega must not
+execute in the parent document. Regression: `tests/http-response-writers.test.ts`,
+`tests/content-security-policy.test.ts`.
 
-**Chart iframe residual (accepted — reaffirmed post-#961 hardening):** Chart rendering
-uses Vega, which compiles its specs with `new Function()` (the reactive
-dataflow interpreter evaluates expressions at runtime). That means the **chart
-iframe** must allow `unsafe-eval` — there is no AOT path without reimplementing
-Vega or compiling charts server-side. Parent SPA CSP continues to forbid
-`unsafe-eval` (JOE-946).
+**Chart iframe residual (accepted — reaffirmed 2026-07-23 / JOE-946):** Chart
+rendering uses Vega, which compiles its specs with `new Function()` (the
+reactive dataflow interpreter evaluates expressions at runtime). That means the
+**chart iframe** must allow `unsafe-eval` — there is no AOT path without
+reimplementing Vega or compiling charts server-side. Parent SPA CSP continues
+to forbid `unsafe-eval` (JOE-946). Full residual closure (server-side compile /
+WASM no-eval Vega) remains a future capacity item, not an incomplete parent CSP
+bug.
 
 We scope the residual risk by keeping charts inside a dedicated iframe
 (`chart-frame.html` / cloud chart-frame response) with a separate, stricter CSP
@@ -512,6 +520,10 @@ URL credentials, or local home-directory paths.
   ignores cannot rot silently. Prefer real upgrades/`pnpm.overrides` over
   permanent `ignoreGhsas`. Every ignore entry must carry an expiry comment in
   the PR description (and ideally a tracking issue).
+- **Weekly Durable Gateway matrix (JOE-969):** `.github/workflows/weekly-gateway.yml`
+  runs `pnpm test:gateway` (plus Durable build/typecheck/standalone smoke) on a
+  Monday schedule outside path-filtered `ci-gateway.yml`. Failures open/comment
+  a GitHub issue so monorepo-only script drift cannot hide gateway breakage.
 - Renderer bundles are split per-feature so a CVE in a heavy, rarely
   loaded dependency (e.g. a Vega module) does not block a patch
   release of the shell.

--- a/scripts/check-dual-channel-pr-checklist.mjs
+++ b/scripts/check-dual-channel-pr-checklist.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * JOE-932: When a PR touches dual-stack channel security paths, require the
+ * dual-channel checklist in the PR body to be filled (or an explicit exempt).
+ *
+ * Not a merge-required status on every PR — only activates for relevant diffs.
+ *
+ * Usage:
+ *   node scripts/check-dual-channel-pr-checklist.mjs [--files path1,path2] [--body-file path]
+ *
+ * Env (CI):
+ *   OPEN_COWORK_PR_BODY          — PR body markdown
+ *   OPEN_COWORK_CHANGED_FILES    — newline- or comma-separated relative paths
+ *   OPEN_COWORK_DUAL_CHANNEL_FORCE — set to "1" to force the gate on (tests)
+ *
+ * Exit 0 when gate inactive or checklist satisfied; exit 1 with guidance otherwise.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const scriptLog = (...args) => {
+  process.stdout.write(args.map(String).join(' ') + String.fromCharCode(10))
+}
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** @param {string[]} argv */
+export function parseArgs(argv = process.argv.slice(2)) {
+  const out = { files: null, bodyFile: null }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--files' && argv[i + 1]) {
+      out.files = argv[++i]
+    } else if (a === '--body-file' && argv[i + 1]) {
+      out.bodyFile = argv[++i]
+    }
+  }
+  return out
+}
+
+/**
+ * Paths that count as Durable Gateway channel surface.
+ * @param {string} p
+ */
+export function isDurableChannelPath(p) {
+  const n = p.replace(/\\/g, '/')
+  return (
+    n.startsWith('products/gateway/src/channels/')
+    || n === 'products/gateway/src/channels'
+  )
+}
+
+/**
+ * Paths that count as monorepo provider / channel-gateway surface.
+ * @param {string} p
+ */
+export function isMonorepoProviderPath(p) {
+  const n = p.replace(/\\/g, '/')
+  return (
+    /^packages\/gateway-provider-[^/]+\//.test(n)
+    || n.startsWith('packages/gateway-channel/')
+    || n.startsWith('apps/channel-gateway/')
+    || n.startsWith('apps/standalone-gateway/')
+  )
+}
+
+/**
+ * Shared channel security kernels / dual-stack guards.
+ * @param {string} p
+ */
+export function isSharedChannelSecurityPath(p) {
+  const n = p.replace(/\\/g, '/')
+  return (
+    n === 'packages/shared/src/node/channel-webhook-security.ts'
+    || n === 'packages/shared/src/node/webhook-rate-limiter.ts'
+    || n === 'scripts/check-dual-channel-security.mjs'
+    || n === 'scripts/check-dual-channel-pr-checklist.mjs'
+    || n === 'docs/product-channel-ownership.md'
+    || n === '.github/pull_request_template.md'
+  )
+}
+
+/**
+ * @param {string[]} files
+ * @returns {{ active: boolean, reason: string }}
+ */
+export function shouldRequireDualChannelChecklist(files) {
+  if (process.env.OPEN_COWORK_DUAL_CHANNEL_FORCE === '1') {
+    return { active: true, reason: 'OPEN_COWORK_DUAL_CHANNEL_FORCE=1' }
+  }
+  const normalized = files.map((f) => f.replace(/\\/g, '/').replace(/^\.\//, ''))
+  const durable = normalized.some(isDurableChannelPath)
+  const monorepo = normalized.some(isMonorepoProviderPath)
+  const shared = normalized.some(isSharedChannelSecurityPath)
+
+  if (shared) {
+    return { active: true, reason: 'shared channel security / dual-stack docs or guards changed' }
+  }
+  if (durable && monorepo) {
+    return { active: true, reason: 'both Durable channels and monorepo providers changed' }
+  }
+  // Single-stack security touch still benefits from checklist (N/A or single-stack note).
+  if (durable || monorepo) {
+    return {
+      active: true,
+      reason: durable
+        ? 'Durable Gateway channel paths changed (confirm other stack N/A or reviewed)'
+        : 'monorepo provider/channel paths changed (confirm other stack N/A or reviewed)',
+    }
+  }
+  return { active: false, reason: 'no dual-stack channel security paths in diff' }
+}
+
+/**
+ * Parse GitHub-style task list checkboxes (both `- [x]` and `* [X]`).
+ * @param {string} body
+ * @param {RegExp} linePattern — matched against the full checklist line text after the checkbox
+ */
+function isChecked(body, linePattern) {
+  const lines = body.split(/\r?\n/)
+  for (const line of lines) {
+    const m = line.match(/^\s*[-*]\s*\[([ xX])\]\s*(.+)$/)
+    if (!m) continue
+    const checked = m[1].toLowerCase() === 'x'
+    if (checked && linePattern.test(m[2])) return true
+  }
+  return false
+}
+
+/**
+ * @param {string} body
+ * @returns {{ ok: boolean, detail: string }}
+ */
+export function evaluateDualChannelChecklist(body) {
+  const text = (body || '').trim()
+  if (!text) {
+    return {
+      ok: false,
+      detail: 'PR body is empty — fill Dual-channel security checklist in .github/pull_request_template.md',
+    }
+  }
+
+  // Explicit exempt for intentional single-stack-only or non-security protocol work.
+  if (
+    /dual[- ]stack\s+checklist:\s*(exempt|n\/a|skip)/i.test(text)
+    || /dual[- ]channel\s+checklist:\s*(exempt|n\/a|skip)/i.test(text)
+  ) {
+    return { ok: true, detail: 'explicit dual-stack checklist exempt in PR body' }
+  }
+
+  const na = isChecked(text, /^N\/A\b/i)
+  if (na) {
+    return { ok: true, detail: 'N/A — not a channel security/protocol change' }
+  }
+
+  const monorepo = isChecked(text, /Reviewed\s+\*\*monorepo providers\*\*/i)
+    || isChecked(text, /Reviewed monorepo providers/i)
+  const durable = isChecked(text, /Reviewed\s+\*\*Durable Gateway channels\*\*/i)
+    || isChecked(text, /Reviewed Durable Gateway channels/i)
+  const bothOrSingle = isChecked(text, /Both stacks fixed/i)
+    || isChecked(text, /explicit single-stack ownership/i)
+  const notesHasSingleStack = /single-stack|other stack\s+(n\/a|N\/A)|follow-up|ownership noted/i.test(text)
+
+  if ((monorepo || durable) && (bothOrSingle || notesHasSingleStack || (monorepo && durable))) {
+    return {
+      ok: true,
+      detail: monorepo && durable
+        ? 'both stacks reviewed'
+        : 'single-stack reviewed with ownership / follow-up signal',
+    }
+  }
+
+  if (monorepo || durable || bothOrSingle) {
+    return {
+      ok: false,
+      detail:
+        'partial dual-channel checklist — check both stacks (or one stack + single-stack ownership note in Notes), or mark N/A',
+    }
+  }
+
+  return {
+    ok: false,
+    detail:
+      'dual-channel security paths changed but Dual-channel security checklist is unchecked. '
+      + 'Tick N/A, complete the checklist, or add `Dual-stack checklist: exempt` with rationale. '
+      + 'See docs/product-channel-ownership.md.',
+  }
+}
+
+/**
+ * @param {string | null} filesArg
+ * @returns {string[]}
+ */
+export function resolveChangedFiles(filesArg) {
+  if (filesArg) {
+    return filesArg.split(/[\n,]/).map((s) => s.trim()).filter(Boolean)
+  }
+  const fromEnv = process.env.OPEN_COWORK_CHANGED_FILES
+  if (fromEnv) {
+    return fromEnv.split(/[\n,]/).map((s) => s.trim()).filter(Boolean)
+  }
+  // Local fallback: files changed vs merge-base with master (best-effort).
+  try {
+    const base = execFileSync('git', ['merge-base', 'HEAD', 'origin/master'], {
+      cwd: root,
+      encoding: 'utf8',
+    }).trim()
+    const out = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], {
+      cwd: root,
+      encoding: 'utf8',
+    })
+    return out.split('\n').map((s) => s.trim()).filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * @param {string | null} bodyFile
+ * @returns {string}
+ */
+export function resolvePrBody(bodyFile) {
+  if (bodyFile) {
+    return readFileSync(resolve(bodyFile), 'utf8')
+  }
+  if (typeof process.env.OPEN_COWORK_PR_BODY === 'string') {
+    return process.env.OPEN_COWORK_PR_BODY
+  }
+  return ''
+}
+
+/**
+ * @param {{ files?: string[] | null, body?: string | null, force?: boolean }} input
+ */
+export function runDualChannelPrChecklistCheck(input = {}) {
+  const files = input.files ?? resolveChangedFiles(null)
+  const body = input.body ?? resolvePrBody(null)
+  const gate = shouldRequireDualChannelChecklist(files)
+  if (!gate.active) {
+    return { active: false, ok: true, reason: gate.reason, detail: 'gate inactive' }
+  }
+  const result = evaluateDualChannelChecklist(body)
+  return {
+    active: true,
+    ok: result.ok,
+    reason: gate.reason,
+    detail: result.detail,
+  }
+}
+
+function main() {
+  const args = parseArgs()
+  const files = resolveChangedFiles(args.files)
+  const body = resolvePrBody(args.bodyFile)
+  const result = runDualChannelPrChecklistCheck({ files, body })
+
+  if (!result.active) {
+    scriptLog(`Dual-channel PR checklist: skip (${result.reason})`)
+    process.exit(0)
+  }
+
+  if (result.ok) {
+    scriptLog(`Dual-channel PR checklist: OK — ${result.detail} [${result.reason}]`)
+    process.exit(0)
+  }
+
+  console.error(`Dual-channel PR checklist: FAIL — ${result.detail}`)
+  console.error(`  Trigger: ${result.reason}`)
+  console.error('  Template: .github/pull_request_template.md → Dual-channel security checklist')
+  console.error('  Docs: docs/product-channel-ownership.md')
+  process.exit(1)
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  main()
+}

--- a/scripts/check-dual-channel-security.mjs
+++ b/scripts/check-dual-channel-security.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 /**
- * JOE-932 (light): fail closed if Durable Gateway re-implements native Meta /
- * Discord webhook verify instead of importing the shared kernel.
+ * Dual-stack kernel wiring guard (complements JOE-932 PR-body checklist):
+ * fail closed if Durable Gateway re-implements native Meta / Discord webhook
+ * verify instead of importing the shared kernel.
  *
- * Not a full dual-stack CI bot — only catches copy-paste regressions on the
- * highest-risk security paths after JOE-934.
+ * PR checklist gate: scripts/check-dual-channel-pr-checklist.mjs (CI on
+ * channel-security path diffs). This script only catches copy-paste regressions
+ * on the highest-risk security paths after JOE-934.
  */
 import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'

--- a/tests/content-security-policy.test.ts
+++ b/tests/content-security-policy.test.ts
@@ -14,6 +14,7 @@ test('buildContentSecurityPolicy keeps the packaged renderer self-contained and 
 
   assert.match(devPolicy, /script-src 'self'/)
   assert.match(devPolicy, /script-src[^;]*'unsafe-inline'/)
+  // JOE-946: parent main-window CSP must never allow unsafe-eval (Vega is chart-iframe only).
   assert.doesNotMatch(devPolicy, /unsafe-eval/)
   assert.doesNotMatch(packagedPolicy, /unsafe-eval/)
   assert.doesNotMatch(packagedPolicy, /unsafe-inline'[^;]*;[^;]*script-src/)
@@ -25,6 +26,19 @@ test('buildContentSecurityPolicy keeps the packaged renderer self-contained and 
   assert.match(packagedPolicy, /img-src 'self' data: blob: open-cowork-asset:/)
   assert.match(packagedPolicy, /frame-src 'self'/)
   assert.doesNotMatch(packagedPolicy, /img-src[^;]*https:/)
+})
+
+test('parent SPA CSP and chart-frame CSP isolation contract (JOE-946 reaffirmation)', () => {
+  const parent = buildContentSecurityPolicy()
+  const chart = buildChartFrameContentSecurityPolicy()
+
+  // Parent: no eval. Chart frame: eval scoped + no network egress.
+  assert.doesNotMatch(parent, /unsafe-eval/)
+  assert.match(chart, /'unsafe-eval'/)
+  assert.match(chart, /connect-src 'none'/)
+  assert.match(chart, /frame-ancestors 'self'/)
+  // Parent keeps frame-src self so the chart iframe can load; chart is not the parent.
+  assert.match(parent, /frame-src 'self'/)
 })
 
 test('index.html does not ship a meta CSP (main process attaches the authoritative header)', () => {

--- a/tests/dual-channel-pr-checklist.test.ts
+++ b/tests/dual-channel-pr-checklist.test.ts
@@ -1,0 +1,96 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  evaluateDualChannelChecklist,
+  isDurableChannelPath,
+  isMonorepoProviderPath,
+  isSharedChannelSecurityPath,
+  shouldRequireDualChannelChecklist,
+} from '../scripts/check-dual-channel-pr-checklist.mjs'
+
+test('path classifiers cover durable, monorepo, and shared security surfaces', () => {
+  assert.equal(isDurableChannelPath('products/gateway/src/channels/whatsapp.ts'), true)
+  assert.equal(isDurableChannelPath('products/gateway/src/server.ts'), false)
+  assert.equal(isMonorepoProviderPath('packages/gateway-provider-telegram/src/telegram-provider.ts'), true)
+  assert.equal(isMonorepoProviderPath('packages/gateway-channel/src/webhook-rate-limiter.ts'), true)
+  assert.equal(isMonorepoProviderPath('packages/shared/src/index.ts'), false)
+  assert.equal(isSharedChannelSecurityPath('packages/shared/src/node/channel-webhook-security.ts'), true)
+  assert.equal(isSharedChannelSecurityPath('scripts/check-dual-channel-security.mjs'), true)
+})
+
+test('gate activates for shared security, both stacks, or either stack alone', () => {
+  assert.equal(
+    shouldRequireDualChannelChecklist(['docs/getting-started.md']).active,
+    false,
+  )
+  assert.equal(
+    shouldRequireDualChannelChecklist([
+      'packages/shared/src/node/channel-webhook-security.ts',
+    ]).active,
+    true,
+  )
+  assert.equal(
+    shouldRequireDualChannelChecklist([
+      'products/gateway/src/channels/discord.ts',
+      'packages/gateway-provider-discord/src/discord-provider.ts',
+    ]).active,
+    true,
+  )
+  assert.equal(
+    shouldRequireDualChannelChecklist(['products/gateway/src/channels/whatsapp.ts']).active,
+    true,
+  )
+  assert.equal(
+    shouldRequireDualChannelChecklist([
+      'packages/gateway-provider-slack/src/slack-provider.ts',
+    ]).active,
+    true,
+  )
+})
+
+test('checklist accepts N/A, full dual review, single-stack + notes, or explicit exempt', () => {
+  assert.equal(
+    evaluateDualChannelChecklist(`
+## Dual-channel security checklist
+- [x] N/A — not a channel security/protocol change
+`).ok,
+    true,
+  )
+
+  assert.equal(
+    evaluateDualChannelChecklist(`
+- [x] Reviewed **monorepo providers** (\`packages/gateway-provider-*\`)
+- [x] Reviewed **Durable Gateway channels** (\`products/gateway/src/channels/*\`)
+- [x] Shared primitives preferred
+- [x] Both stacks fixed **or** explicit single-stack ownership noted in Notes with follow-up
+`).ok,
+    true,
+  )
+
+  assert.equal(
+    evaluateDualChannelChecklist(`
+- [x] Reviewed **Durable Gateway channels** (\`products/gateway/src/channels/*\`)
+## Notes
+- single-stack ownership: Durable only; monorepo N/A for this webhook path
+`).ok,
+    true,
+  )
+
+  assert.equal(
+    evaluateDualChannelChecklist(`
+## Notes
+Dual-stack checklist: exempt — docs-only tweak to ownership matrix wording
+`).ok,
+    true,
+  )
+
+  assert.equal(
+    evaluateDualChannelChecklist(`
+- [ ] N/A — not a channel security/protocol change
+- [ ] Reviewed **monorepo providers**
+`).ok,
+    false,
+  )
+
+  assert.equal(evaluateDualChannelChecklist('').ok, false)
+})

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -30,6 +30,7 @@ const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.me
 const docsWorkflow = readFileSync(new URL('../.github/workflows/docs.yml', import.meta.url), 'utf8')
 const releaseWorkflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8')
 const monthlyMaintenanceWorkflow = readFileSync(new URL('../.github/workflows/monthly-maintenance.yml', import.meta.url), 'utf8')
+const weeklyGatewayWorkflow = readFileSync(new URL('../.github/workflows/weekly-gateway.yml', import.meta.url), 'utf8')
 const dependabotConfig = readFileSync(new URL('../.github/dependabot.yml', import.meta.url), 'utf8')
 const npmrc = readFileSync(new URL('../.npmrc', import.meta.url), 'utf8')
 const readmeDocs = readFileSync(new URL('../README.md', import.meta.url), 'utf8')
@@ -174,7 +175,7 @@ test('contributor setup docs and dependency update governance match enforced eng
   }
   assert.match(readmeDocs, /\[!\[pnpm 10\.32\.1\]/)
   assert.doesNotMatch(readmeDocs, /\[!\[pnpm 10\+\]/)
-  for (const workflow of [ciWorkflow, docsWorkflow, releaseWorkflow, monthlyMaintenanceWorkflow]) {
+  for (const workflow of [ciWorkflow, docsWorkflow, releaseWorkflow, monthlyMaintenanceWorkflow, weeklyGatewayWorkflow]) {
     assert.match(workflow, /version: 10\.32\.1/)
   }
 
@@ -381,6 +382,19 @@ test('packaged e2e script fails before smoke discovery without a packaged execut
     /export async function assertRuntimeComponentProvenance/,
     'desktop smoke helpers must expose a runtime component provenance assertion',
   )
+})
+
+test('weekly gateway matrix and dual-channel PR checklist are wired (JOE-969 / JOE-932)', () => {
+  assert.match(weeklyGatewayWorkflow, /pnpm test:gateway/)
+  assert.match(weeklyGatewayWorkflow, /cron: "17 4 \* \* 1"/)
+  assert.match(weeklyGatewayWorkflow, /Weekly gateway matrix red/)
+  assert.match(weeklyGatewayWorkflow, /workflow_dispatch/)
+  assert.match(ciWorkflow, /check-dual-channel-pr-checklist\.mjs/)
+  assert.match(ciWorkflow, /OPEN_COWORK_PR_BODY/)
+  assert.match(securityModelDocs, /weekly-gateway\.yml/)
+  assert.match(securityModelDocs, /JOE-969/)
+  assert.match(securityModelDocs, /revalidated 2026-07-23 \/ JOE-962/)
+  assert.match(securityModelDocs, /reaffirmed 2026-07-23 \/ JOE-946/)
 })
 
 test('ci and release workflows use canonical release gate scripts', () => {

--- a/tests/runtime-mcp-opt-in.test.ts
+++ b/tests/runtime-mcp-opt-in.test.ts
@@ -210,12 +210,13 @@ test('resolveCustomMcpRuntimeEntryForRuntime pins cleartext HTTP MCP to resolved
   assert.equal(pinned.headers?.Host, 'mcp.example.com:8080')
   assert.equal(pinned.headers?.Authorization, 'Bearer t')
 
-  // HTTPS is not IP-pinned (SNI/cert require the original hostname).
+  // HTTPS is not IP-pinned (SNI/cert require the original hostname) — JOE-962 residual.
   const httpsPinned = pinHttpMcpRemoteEntry({
     url: new URL('https://mcp.example.com/api'),
     resolvedAddresses: ['203.0.113.10'],
   })
   assert.equal(httpsPinned.url, 'https://mcp.example.com/api')
+  assert.equal(httpsPinned.headers, undefined)
 
   const entry = await resolveCustomMcpRuntimeEntryForRuntime({
     scope: 'machine',
@@ -234,6 +235,38 @@ test('resolveCustomMcpRuntimeEntryForRuntime pins cleartext HTTP MCP to resolved
     assert.equal(entry.headers?.Host, 'mcp.example.com')
     assert.equal(entry.headers?.['x-api-key'], 'k')
   }
+})
+
+test('resolveCustomMcpRuntimeEntryForRuntime keeps HTTPS hostname after public DNS policy (JOE-962 residual)', async () => {
+  // HTTPS residual: policy still re-resolves at handoff and rejects private/metadata
+  // answers, but the connect URL stays the original hostname (OpenCode TLS/SNI).
+  const httpsEntry = await resolveCustomMcpRuntimeEntryForRuntime({
+    scope: 'machine',
+    name: 'https-host',
+    type: 'http',
+    url: 'https://mcp.example.com/tools',
+    headers: { 'x-api-key': 'k' },
+  }, {
+    resolveHostname: async () => [{ address: '8.8.8.8', family: 4 }],
+  })
+  assert.ok(httpsEntry)
+  assert.equal(httpsEntry?.type, 'remote')
+  if (httpsEntry?.type === 'remote') {
+    assert.equal(httpsEntry.url, 'https://mcp.example.com/tools')
+    assert.equal(httpsEntry.headers?.['x-api-key'], 'k')
+    // No synthetic Host pin for HTTPS (would fight SNI/cert hostname checks).
+    assert.equal(httpsEntry.headers?.Host, undefined)
+  }
+
+  const rebindDenied = await resolveCustomMcpRuntimeEntryForRuntime({
+    scope: 'machine',
+    name: 'https-rebind',
+    type: 'http',
+    url: 'https://mcp.example.com/api',
+  }, {
+    resolveHostname: async () => [{ address: '10.0.0.5', family: 4 }],
+  })
+  assert.equal(rebindDenied, null)
 })
 
 test('evaluateBuiltInMcp — local MCP missing required credentials is skipped as not-configured', () => {


### PR DESCRIPTION
## Summary

- **JOE-969:** Add `weekly-gateway.yml` (Monday schedule + `workflow_dispatch`) to run full Durable Gateway matrix (`pnpm test:gateway`, build/typecheck/knip/standalone smoke) **outside** path-filtered `ci-gateway.yml`. Failures open/comment a GitHub issue so monorepo-only script drift cannot hide gateway breakage.
- **JOE-932:** Add `scripts/check-dual-channel-pr-checklist.mjs` and wire it into `CI` / `validate` on PRs. Activates only for Durable channels, monorepo providers, or shared channel-security kernels; unrelated PRs skip. Satisfy via template checklist, single-stack Notes, or `Dual-stack checklist: exempt`.
- **JOE-962:** Revalidate HTTPS MCP residual (no IP-pin over TLS/SNI; policy still fails closed on private/metadata DNS). Tests + dated `security-model.md` reaffirmation (2026-07-23).
- **JOE-946:** Reaffirm parent SPA CSP has **no** `unsafe-eval`; chart iframe residual stays accepted with isolation tests + dated docs. Full Vega no-eval rewrite remains future capacity.

## Validation

- [x] `node --test tests/dual-channel-pr-checklist.test.ts tests/content-security-policy.test.ts tests/package-scripts.test.ts`
- [x] `node --test tests/runtime-mcp-opt-in.test.ts`
- [x] `node scripts/check-dual-channel-security.mjs`
- [ ] `pnpm test` (CI)
- [ ] `pnpm typecheck` (CI)
- [ ] `pnpm lint` (CI)
- [x] `git diff --check`

## Dual-channel security checklist

- [x] Reviewed **monorepo providers** (`packages/gateway-provider-*`, `packages/gateway-channel`, `apps/channel-gateway`) — no provider protocol code in this PR
- [x] Reviewed **Durable Gateway channels** (`products/gateway/src/channels/*` and related security) — no channel protocol code in this PR
- [x] Shared primitives preferred (`@open-cowork/shared`, `gateway-channel`) over copy-paste
- [x] Both stacks fixed **or** explicit single-stack ownership noted in Notes with follow-up

## User-visible impact

- [x] No user-visible behavior change
- [x] Docs change
- [x] Packaging / release change (scheduled workflow only)

## Notes

- CI hygiene batch prefers one PR to limit Actions cost.
- Dual-stack checklist: this PR implements the JOE-932 gate + ownership docs; no webhook signature / SSRF protocol behavior changes.
- HTTPS MCP residual (JOE-962) and chart iframe `unsafe-eval` residual (JOE-946) re-accepted with reopen criteria documented in `docs/security-model.md`.
- Not in this PR: JOE-996 HA migrate, JOE-994 protocol unify epic, JOE-993 private-beta campaign evidence.

Linear: JOE-969, JOE-932, JOE-962, JOE-946