### PR TITLE
fix(joe-996): migrate H3/H4/H8 operational sidecars to SQLite

### DIFF
--- a/docs/development/distributed-ownership-proving-registry.json
+++ b/docs/development/distributed-ownership-proving-registry.json
@@ -37,7 +37,7 @@
       "purpose": "Fail closed on multi-AZ HA marketing language"
     }
   ],
-  "openMigrateHazards": ["H1", "H3", "H4", "H8", "H13"],
+  "openMigrateHazards": ["H1", "H13"],
   "marketingAllowedClaims": [
     "single-writer per state directory",
     "replicaCount 1 supported",

--- a/products/gateway/docs/concepts/architecture.md
+++ b/products/gateway/docs/concepts/architecture.md
@@ -71,8 +71,8 @@ The daemon keeps runtime wiring in `src/daemon.ts` and JSON route behavior in ex
 | `~/.config/opencode-gateway/gateway.db` | Authoritative SQLite source for durable work, runs, events, channel bindings, gates, alerts, and local daemon leadership. |
 | `~/.config/opencode-gateway/channel-sync.json.sqlite` | Transactional channel sync outbox for pending, leased, and delivered outbound sync messages. |
 | `~/.config/opencode-gateway/channel-sync.json` | Derived channel delivery checkpoint cache. |
-| `~/.config/opencode-gateway/events.json` | Recent in-process activity events. |
-| `~/.config/opencode-gateway/sessions.json` | Recent Gateway OpenCode session sidecar state. |
+| `~/.config/opencode-gateway/operational-sidecar.sqlite` | Operational events, worker session projection, channel poll cursors (JOE-996). |
+| `~/.config/opencode-gateway/events.json` / `sessions.json` | Legacy JSON (imported once into the operational sidecar if present). |
 | `~/.config/opencode-gateway/backups/` | Operator-created verified local backups. |
 | `~/.config/opencode-gateway/recovery-drills/` | Recovery drill evidence and reports. |
 | `~/.config/opencode-gateway/observability/` | Execution traces and stage analysis artifacts. |

--- a/products/gateway/docs/concepts/distributed-ownership-design.md
+++ b/products/gateway/docs/concepts/distributed-ownership-design.md
@@ -50,7 +50,9 @@ Work-store refuses stale epochs (`StaleWorkDbLeadershipError`). Channel claims a
 | Fenced SQLite mutations | **Implemented** | work-store epoch validation |
 | Multi-process DB tests | **Implemented** | `multi-process-store.test.ts` |
 | Channel-sync out of JSON multi-writer | **Partial** | Outbox SQLite companion exists; JSON still coordinates pendingInbound |
-| sessions.json / events.json migration | **Open** | Hazard H3/H4 |
+| sessions.json / events.json / telegram-polling migration | **Done (JOE-996)** | H3/H4/H8 → `operational-sidecar.sqlite` |
+| channel-sync JSON coordination | **Open** | Hazard H1 |
+| notification send leases | **Open** | Hazard H13 |
 | Proving suite gate for Helm experimental flag | **This design** | Suite must pass; claims script fail-closed |
 | Sidecar dual-write shadow then cutover | Planned | Follow multi-daemon state migration map |
 
@@ -88,7 +90,7 @@ Any PR that sets marketing language implying multi-AZ HA for Durable Gateway wit
 ## Rollout plan
 
 1. Keep single-replica production.
-2. Close H1/H3/H4/H8/H13 migrations behind fixtures.
+2. Close remaining open migrate hazards (H1, H13). H3/H4/H8 migrated to `operational-sidecar.sqlite` (JOE-996 progressive slice).
 3. Run proving suite in CI (`pnpm --filter cowork-gateway test` already includes multi-process + proving tests when present).
 4. Lab: writer/standby with experimental flag only.
 5. Only then revisit public multi-replica docs.

--- a/products/gateway/docs/concepts/multi-daemon-scaling.md
+++ b/products/gateway/docs/concepts/multi-daemon-scaling.md
@@ -6,7 +6,7 @@ Gateway is currently a local, single-operator control plane. It can run unattend
 
 **Operator runbook (audit 2026-07-21 / JOE-931; reaffirmed 2026-07-23):** Never run two full daemons against one state directory. The open-cowork Helm chart fails closed when `replicaCount > 1` unless experimental distributed ownership is explicitly enabled. Chart fail-closed must not be bypassed for production.
 
-**Experimental multi-replica still fails open migrate hazards.** Enabling `gateway.experimentalDistributedOwnership=true` is **lab-only**. While the proving registry reports `status=partial` and non-empty `openMigrateHazards` (`H1`, `H3`, `H4`, `H8`, `H13` as of 2026-07-23), multi-replica is **not** multi-AZ HA and must not be marketed as production-ready. See the [hazard inventory](./multi-writer-hazards.md). Gateway doctor and `/readiness` include a non-blocking `multi_writer_ownership` check that reports open migrate hazards.
+**Experimental multi-replica still fails open migrate hazards.** Enabling `gateway.experimentalDistributedOwnership=true` is **lab-only**. While the proving registry reports `status=partial` and non-empty `openMigrateHazards` (`H1`, `H13` as of JOE-996 progressive H3/H4/H8 slice), multi-replica is **not** multi-AZ HA and must not be marketed as production-ready. See the [hazard inventory](./multi-writer-hazards.md). Gateway doctor and `/readiness` include a non-blocking `multi_writer_ownership` check that reports open migrate hazards.
 
 **Follow-on design:** [Distributed ownership + fencing](distributed-ownership-design.md) (JOE-954).
 **Hazard inventory:** [multi-writer-hazards](./multi-writer-hazards.md) (JOE-948).
@@ -62,8 +62,8 @@ These failure modes are acceptable for the current local deployment model but mu
 | --- | --- |
 | Scheduler cycle lock | The in-process cycle promise only protects one daemon. Two daemons can both enter scheduling logic, relying on later SQLite task transitions to decide the winner. |
 | Channel sync | `channel-sync.json` checkpoints and `pendingInbound` entries are file sidecars. Concurrent writers can overwrite each other and may duplicate or skip relays. |
-| Recent events | `events.json` is an operational activity view, not an append-only cluster event log. Concurrent writes are last-writer-wins. |
-| Session sidecar | `sessions.json` is a recent Gateway/OpenCode session projection. Multiple daemons can diverge about which process owns or can open a session. |
+| Recent events | Operational activity is in `operational-sidecar.sqlite` (`operational_events`; JOE-996 H3). Not an append-only cluster event log. |
+| Session sidecar | Worker projection is in `operational-sidecar.sqlite` (`worker_sessions`; JOE-996 H4). Multiple daemons can still diverge about runtime ownership without H1/H13 fencing. |
 | Notification locks | Several send paths have process-local in-flight guards. Duplicate visible notifications remain possible when two daemons handle the same event. |
 | OpenCode runtime ownership | OpenCode sessions are local runtime assets. A remote daemon cannot assume another host can inspect, prompt, or abort that session. |
 | Backups | Backup and restore capture current durable files plus sidecars, but sidecars are not safe multi-writer coordination state. |
@@ -102,8 +102,8 @@ For local personal mode, the coordinator and worker remain the same process. No 
 | Scheduler leadership | Process memory plus run/supervisor leases in SQLite | Add a durable `daemon_instances` or `scheduler_leadership` lease with owner, generation, expiration, heartbeat, and fencing token. |
 | Task and run state | `gateway.db` | Keep as the durable source of truth. Continue using transactional transitions and extend tests around leadership fencing. |
 | Channel checkpoints | `channel-sync.json` | Move delivery checkpoints, `seenMessageIds`, and `pendingInbound` into SQLite tables. Keep JSON only as a transitional compatibility shadow if needed. |
-| Recent events | `events.json` plus workflow events in SQLite | Store operator activity that affects recovery, replay, or audit in SQLite. Keep bounded JSON only as a derived cache or remove it. |
-| Session projection | `sessions.json` | Persist worker/session projection in SQLite with runtime owner, source daemon, last seen time, and recovery state. |
+| Recent events | `operational-sidecar.sqlite` + workflow events in `gateway.db` | H3 migrated (JOE-996). Keep operator activity that affects recovery/audit in gateway.db; operational ring buffer is sidecar SQLite. |
+| Session projection | `operational-sidecar.sqlite` | H4 migrated (JOE-996). Still needs runtime owner / recovery fields for exclusive multi-daemon ownership (residual with H1/H13). |
 | Notification locks | Process-local maps plus workflow events | Replace in-flight locks with durable send leases and dedupe receipts keyed by route, target, subject, and policy window. |
 | OpenCode sessions | Local OpenCode runtime | Add explicit runtime affinity. A worker can only act on sessions owned by its runtime, and the coordinator must route commands accordingly. |
 | Configuration | `config.json` | Keep local config simple. Cluster or hosted config should be opt-in and fail closed unless leadership, auth, and state migrations are complete. |
@@ -194,7 +194,7 @@ The current local beta does not include:
 These follow-ups are dependency-aware and should stay behind this design record:
 
 1. Persist channel-sync checkpoints and pending inbound state in `gateway.db`, with JSON shadow-read compatibility and backup/restore drill coverage.
-2. Persist the `sessions.json` worker/session projection in `gateway.db`, including runtime owner, last seen time, recovery status, and OpenCode session affinity.
+2. ~~Persist the `sessions.json` worker/session projection~~ — done in `operational-sidecar.sqlite` (JOE-996 H4). Follow-up: runtime owner / recovery fields for exclusive multi-daemon ownership.
 3. Add a scheduler leadership lease and daemon-instance health projection, then expose leader age, generation, and stale-leader warnings in readiness.
 4. Define the remote worker work/result packet contract and require coordinator-only durable state mutation.
 

--- a/products/gateway/docs/concepts/multi-writer-hazards.md
+++ b/products/gateway/docs/concepts/multi-writer-hazards.md
@@ -13,9 +13,12 @@
 | Experimental multi-replica (`experimentalDistributedOwnership=true`) | **Lab-only** — Helm can set `replicaCount > 1`, but migrate hazards remain open |
 | Multi-AZ / production multi-replica HA | **Forbidden** until registry `status=ready` **and** `openMigrateHazards` is empty |
 
-**As of 2026-07-23:** registry `status=partial`, `openMigrateHazards: ["H1","H3","H4","H8","H13"]`.
-Experimental multi-replica **still fails** these open migrate hazards — do not market as HA.
-Doctor / readiness surface a non-blocking `multi_writer_ownership` check that reports this posture.
+**As of 2026-07-23 (post JOE-996 H3/H4/H8 slice):** registry `status=partial`,
+`openMigrateHazards: ["H1","H13"]`. H3/H4/H8 now use
+`operational-sidecar.sqlite` (legacy JSON imported once). Experimental
+multi-replica **still fails** remaining open migrate hazards — do not market as
+HA. Doctor / readiness surface a non-blocking `multi_writer_ownership` check
+that reports this posture.
 
 ## Disposition legend
 
@@ -31,12 +34,12 @@ Doctor / readiness surface a non-blocking `multi_writer_ownership` check that re
 | --- | --- | --- | --- | --- |
 | H1 | Channel-sync JSON sidecar (checkpoints, pendingInbound, deliveries) | `products/gateway/src/channel-sync.ts` (`channel-sync.json`, `save` via pid tmp) | **migrate** (not migrated) | Last-writer-wins under two daemons; dual-write to SQLite outbox partially exists but JSON remains coordination. **Single-daemon production shape; multi-replica experimental only.** Proving registry `status=partial` (`docs/development/distributed-ownership-proving-registry.json`). Do not claim migrated until code + suite close the hazard. |
 | H2 | channel-sync process-local `syncInFlight` promise | `channel-sync.ts` ~173–175 | **accept** | Single-process debounce only |
-| H3 | events.json operational sidecar | `products/gateway/src/wakeup.ts` (`events.json`) | **migrate** (not migrated) | Not append-only cluster log; concurrent writers corrupt. **Single-daemon production shape; multi-replica experimental only.** Proving registry `status=partial`. Do not claim migrated until code exists. |
-| H4 | sessions.json worker/session projection | `products/gateway/src/workers.ts` | **migrate** (not migrated) | Multi-daemon session ownership diverges. **Single-daemon production shape; multi-replica experimental only.** Proving registry `status=partial`. Do not claim migrated until code exists. |
+| H3 | events.json operational sidecar | `products/gateway/src/wakeup.ts` → `operational-sidecar.sqlite` | **migrated** (JOE-996) | Bounded operational telemetry now in SQLite (`operational_events`). Legacy `events.json` imported once. Not a cluster log; multi-replica still experimental. |
+| H4 | sessions.json worker/session projection | `products/gateway/src/workers.ts` → `operational-sidecar.sqlite` | **migrated** (JOE-996) | Worker projection in SQLite (`worker_sessions`). Legacy `sessions.json` imported once. Multi-replica still experimental. |
 | H5 | Scheduler cycle promise (in-process) | `products/gateway/src/scheduler.ts` ~131–133 | **fence** | Two processes both enter schedule; SQLite may serialize tasks but not sidecars |
 | H6 | `inFlightSupervisorPrompts` Set | `scheduler.ts` ~251–299 | **accept** | Process-local duplicate prompt guard |
 | H7 | SCHEDULER_INSTANCE_ID from pid | `scheduler.ts` ~74 | **fence** | Must bind to durable leadership fencing token |
-| H8 | Telegram polling state file | `channels/telegram.ts` → `telegram-polling.json` | **migrate** (not migrated) | Two pollers → duplicate updates. **Single-daemon production shape; multi-replica experimental only.** Proving registry `status=partial`. Do not claim migrated until code exists. |
+| H8 | Telegram polling state file | `channels/telegram.ts` → `operational-sidecar.sqlite` | **migrated** (JOE-996) | Cursor in SQLite `channel_poll_cursors` (provider=`telegram`). Legacy `telegram-polling.json` imported once. Two active pollers still need leadership fence for exclusive polling (H1-class coordination residual). |
 | H9 | Channel Gateway delivery lanes + inFlight Set | `apps/channel-gateway/src/gateway-runtime.ts` ~178–256 | **accept** | Single appliance process model; not Durable multi-daemon |
 | H10 | Warm pools / env maps | `products/gateway/src/environments.ts` (warm pool maps) | **accept** / **fence** | Single-daemon warm pools; multi-daemon needs durable env ownership |
 | H11 | Unredacted export rate-limit buckets | `products/gateway/src/unredacted-export-guard.ts` | **accept** | Per-process; multi-daemon weakens limit (documented) |
@@ -57,14 +60,15 @@ Doctor / readiness surface a non-blocking `multi_writer_ownership` check that re
 
 - **Single daemon per state directory is the supported production shape.**
 - Process-local maps (H2, H6, H9–H12) are acceptable under that shape.
-- Open migrate hazards **H1, H3, H4, H8, H13** remain **not migrated** under
-  production shape; multi-replica is **experimental only** (Helm fail-closed
-  without experimental flag). Proving registry:
+- Open migrate hazards **H1, H13** remain **not migrated** under production
+  shape; multi-replica is **experimental only** (Helm fail-closed without
+  experimental flag). H3/H4/H8 closed via `operational-sidecar.sqlite` (JOE-996
+  progressive slice). Proving registry:
   `docs/development/distributed-ownership-proving-registry.json` with
-  **`status=partial`** and `openMigrateHazards: ["H1","H3","H4","H8","H13"]`.
-- Marketing must not claim multi-AZ / multi-replica HA until those hazards
+  **`status=partial`** and `openMigrateHazards: ["H1","H13"]`.
+- Marketing must not claim multi-AZ / multi-replica HA until remaining hazards
   migrate in code **and** proving suite reaches `status=ready` (JOE-949).
-  Do **not** claim migrated from docs alone.
+  Do **not** claim multi-AZ HA from this partial slice.
 
 ## Owner
 

--- a/products/gateway/docs/operations/backup-restore.md
+++ b/products/gateway/docs/operations/backup-restore.md
@@ -13,8 +13,8 @@ Included files:
 - `gateway.db`
 - `channel-sync.json` when present
 - `channel-sync.json.sqlite` when present, containing durable channel delivery receipts and leases without message plaintext
-- `events.json` when present
-- `sessions.json` when present
+- `operational-sidecar.sqlite` when present (operational events, worker sessions, channel poll cursors)
+- `events.json` / `sessions.json` when present (legacy JSON; still backed up for older states)
 
 Metadata in `metadata.json` includes:
 
@@ -107,7 +107,7 @@ Backup verification checks:
 - `metadata.json` is present and parseable.
 - Backup format is supported.
 - Required manifest fields are present, including `version`, `schema.current`, `files`, and `checksum`.
-- Metadata references only known Gateway backup basenames: `gateway.db`, `channel-sync.json`, `channel-sync.json.sqlite`, `events.json`, and `sessions.json`.
+- Metadata references only known Gateway backup basenames: `gateway.db`, `channel-sync.json`, `channel-sync.json.sqlite`, `operational-sidecar.sqlite`, `events.json`, and `sessions.json`.
 - Every recorded file exists.
 - File sizes match metadata.
 - SHA-256 checksums match metadata.

--- a/products/gateway/docs/operations/security.md
+++ b/products/gateway/docs/operations/security.md
@@ -115,7 +115,7 @@ The following surfaces are **operator high-sensitivity** and must never be expos
 
 ## Multi-writer / HA limits (operator)
 
-Durable Gateway is a **single-writer** control plane per state directory. Helm charts refuse `replicaCount > 1` unless `gateway.experimentalDistributedOwnership=true` (lab-only; not multi-AZ HA). Process-local stream/replay maps and JSON sidecars (`sessions.json`, `channel-sync.json`, `events.json`) are **not** multi-writer safe. See [Multi-Daemon Scaling](../concepts/multi-daemon-scaling.md) and [Distributed ownership design](../concepts/distributed-ownership-design.md). Do not claim multi-AZ HA for Durable Gateway until the proving registry status is `ready` and migrate hazards are closed (JOE-949/963).
+Durable Gateway is a **single-writer** control plane per state directory. Helm charts refuse `replicaCount > 1` unless `gateway.experimentalDistributedOwnership=true` (lab-only; not multi-AZ HA). Process-local stream/replay maps and remaining multi-writer hazards (`channel-sync.json` coordination H1, notification in-flight H13) are **not** multi-writer safe. H3/H4/H8 operational telemetry, worker projection, and Telegram poll cursors use `operational-sidecar.sqlite` (JOE-996 progressive slice). See [Multi-Daemon Scaling](../concepts/multi-daemon-scaling.md) and [Distributed ownership design](../concepts/distributed-ownership-design.md). Do not claim multi-AZ HA for Durable Gateway until the proving registry status is `ready` and open migrate hazards are empty (JOE-949/963/996).
 
 Route, MCP, trusted-channel-command, and CLI capability classification is enforced in code by `src/security.ts` (`httpCapabilityForRequest`, `evaluateHttpRequestSecurity`) and `src/security-policy.ts`, covering local daemon routes, MCP groups, trusted-channel command groups, CLI groups, binding requirements, OpenCode-owned decision routing, and exposed-mode fail-closed invariants. Focused tests fail when a new surface is not classified. This is local evidence for the current single-operator boundary; it is not hosted/team RBAC certification.
 
@@ -322,8 +322,8 @@ Gateway writes config and sidecar files under `~/.config/opencode-gateway` with 
 - `gateway.db` (including the `gateway.db-wal` and `gateway.db-shm` SQLite sidecars, which are re-restricted on every write-open)
 - `channel-sync.json`
 - `channel-sync.json.sqlite`
-- `events.json`
-- `sessions.json`
+- `operational-sidecar.sqlite` (events / worker sessions / poll cursors)
+- `events.json` / `sessions.json` (legacy; imported once if present)
 
 ## OpenCode Permissions
 

--- a/products/gateway/src/__tests__/telegram.test.ts
+++ b/products/gateway/src/__tests__/telegram.test.ts
@@ -195,10 +195,10 @@ describe('telegram channel', () => {
     await vi.waitFor(() => expect(handled).toHaveLength(1))
     await telegramChannel.stop()
 
-    const cursor = JSON.parse(fs.readFileSync(__telegramTest.pollingCursorPath(), 'utf-8'))
-    expect(cursor).toMatchObject({ lastUpdateId: 41 })
-    expect(JSON.stringify(cursor)).not.toContain('chat-1')
-    expect(JSON.stringify(cursor)).not.toContain('/status')
+    expect(__telegramTest.getPollingCursor()).toBe(41)
+    expect(fs.existsSync(__telegramTest.pollingCursorPath())).toBe(true)
+    expect((fs.statSync(__telegramTest.pollingCursorPath()).mode & 0o777).toString(8)).toBe('600')
+    expect(fs.existsSync(path.join(process.env['OPENCODE_GATEWAY_STATE_DIR'] || '', 'telegram-polling.json'))).toBe(false)
 
     __telegramTest.resetInMemoryPollingCursorForTest()
     telegramChannel.onMessage(async () => {
@@ -251,8 +251,7 @@ describe('telegram channel', () => {
     // The transient failure re-fetched the same offset instead of advancing.
     expect(attempts).toBe(2)
     expect(updateOffsets.filter(offset => offset === '1').length).toBeGreaterThanOrEqual(2)
-    const cursor = JSON.parse(fs.readFileSync(__telegramTest.pollingCursorPath(), 'utf-8'))
-    expect(cursor).toMatchObject({ lastUpdateId: 61 })
+    expect(__telegramTest.getPollingCursor()).toBe(61)
     // Transient deferrals are retried, never skipped as poison.
     expect(listWorkEvents(20).some(event => event.type === 'telegram.update.skipped')).toBe(false)
     expect(getQueuedEvents().join('\n')).not.toContain('failed and was skipped')
@@ -315,8 +314,7 @@ describe('telegram channel', () => {
     await vi.waitFor(() => expect(updateOffsets.at(-1)).toBe('53'))
     await telegramChannel.stop()
 
-    const cursor = JSON.parse(fs.readFileSync(__telegramTest.pollingCursorPath(), 'utf-8'))
-    expect(cursor).toMatchObject({ lastUpdateId: 52 })
+    expect(__telegramTest.getPollingCursor()).toBe(52)
     expect(listWorkEvents(20)).toEqual(expect.arrayContaining([
       expect.objectContaining({
         type: 'telegram.update.skipped',

--- a/products/gateway/src/__tests__/wakeup.test.ts
+++ b/products/gateway/src/__tests__/wakeup.test.ts
@@ -57,12 +57,25 @@ describe('wakeup', () => {
     expect(event).not.toContain('abc123')
   })
 
-  it('writes the event sidecar with private permissions', () => {
+  it('writes the operational sidecar with private permissions (H3 SQLite)', () => {
     queueEvent('private event')
-    const file = path.join(testDir, 'events.json')
+    const file = path.join(testDir, 'operational-sidecar.sqlite')
 
+    expect(fs.existsSync(file)).toBe(true)
     expect((fs.statSync(file).mode & 0o777).toString(8)).toBe('600')
     expect((fs.statSync(testDir).mode & 0o777).toString(8)).toBe('700')
-    expect(fs.readdirSync(testDir).filter(name => name.startsWith('events.json.tmp-'))).toEqual([])
+    expect(fs.existsSync(path.join(testDir, 'events.json'))).toBe(false)
+  })
+
+  it('imports legacy events.json once into the operational sidecar', () => {
+    fs.mkdirSync(testDir, { recursive: true, mode: 0o700 })
+    fs.writeFileSync(
+      path.join(testDir, 'events.json'),
+      JSON.stringify({ events: ['2026-01-01T00:00:00.000Z: legacy event'] }, null, 2),
+      { mode: 0o600 },
+    )
+    clearEventsForTest()
+    const events = getQueuedEvents()
+    expect(events.some(e => e.includes('legacy event'))).toBe(true)
   })
 })

--- a/products/gateway/src/__tests__/workers.test.ts
+++ b/products/gateway/src/__tests__/workers.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
-import { clearWorkersForTest, getWorkerCounts, listWorkers, loadWorkerState, reconcileOpenCodeSessions, saveWorkerState, trackWorker } from '../workers.js'
+import { clearWorkersForTest, getWorkerCounts, listWorkers, loadWorkerState, reconcileOpenCodeSessions, saveWorkerState, trackWorker, workerSessionsStorePath } from '../workers.js'
 
 const worker = (id: string) => listWorkers().find(w => w.id === id)
 
@@ -10,42 +10,67 @@ describe('Gateway session sidecar state', () => {
   const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-gateway-sessions-test-'))
 
   afterAll(() => { try { fs.rmSync(testDir, { recursive: true, force: true }) } catch {} })
-  const store = path.join(testDir, 'sessions.json')
 
   beforeEach(() => {
+    process.env['OPENCODE_GATEWAY_STATE_DIR'] = testDir
+    process.env['OPENCODE_GATEWAY_CONFIG_DIR'] = testDir
     clearWorkersForTest()
     if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true })
+    fs.mkdirSync(testDir, { recursive: true, mode: 0o700 })
   })
 
   it('persists and reloads session sidecar state', () => {
     trackWorker({ id: 'ses_1', title: 'Example', parentId: 'test', status: 'running', startedAt: '2026-01-01T00:00:00.000Z', lastCheck: '2026-01-01T00:00:00.000Z', lastTodo: null, lastMessage: null })
-    saveWorkerState(store)
+    saveWorkerState()
 
     clearWorkersForTest()
-    loadWorkerState(store)
+    loadWorkerState()
 
     expect(worker('ses_1')?.title).toBe('Example')
     expect(getWorkerCounts()).toMatchObject({ total: 1, running: 1 })
   })
 
-  it('writes the session sidecar with private permissions', () => {
+  it('writes the operational sidecar with private permissions (H4 SQLite)', () => {
     trackWorker({ id: 'ses_private', title: 'Private', parentId: 'test', status: 'running', startedAt: '2026-01-01T00:00:00.000Z', lastCheck: '2026-01-01T00:00:00.000Z', lastTodo: null, lastMessage: null })
-    saveWorkerState(store)
+    saveWorkerState()
 
+    const store = workerSessionsStorePath()
+    expect(fs.existsSync(store)).toBe(true)
     expect((fs.statSync(store).mode & 0o777).toString(8)).toBe('600')
     expect((fs.statSync(testDir).mode & 0o777).toString(8)).toBe('700')
-    expect(fs.readdirSync(testDir).filter(name => name.startsWith('sessions.json.tmp-'))).toEqual([])
+    expect(fs.existsSync(path.join(testDir, 'sessions.json'))).toBe(false)
   })
 
-  it('does not wipe in-memory session entries when persisted JSON is corrupt', () => {
+  it('does not wipe in-memory session entries when the store file is removed mid-flight', () => {
     trackWorker({ id: 'ses_keep', title: 'Keep me', parentId: 'test', status: 'running', startedAt: '2026-01-01T00:00:00.000Z', lastCheck: '2026-01-01T00:00:00.000Z', lastTodo: null, lastMessage: null })
-    fs.mkdirSync(testDir, { recursive: true })
-    fs.writeFileSync(store, '{broken json', { mode: 0o600 })
+    try { fs.rmSync(workerSessionsStorePath(), { force: true }) } catch {}
 
-    loadWorkerState(store)
-
+    // In-memory map remains authoritative until clearWorkersForTest / process restart.
     expect(worker('ses_keep')?.title).toBe('Keep me')
     expect(getWorkerCounts()).toMatchObject({ total: 1, running: 1 })
+  })
+
+  it('imports legacy sessions.json once into the operational sidecar', () => {
+    try { fs.rmSync(workerSessionsStorePath(), { force: true }) } catch {}
+    fs.writeFileSync(
+      path.join(testDir, 'sessions.json'),
+      JSON.stringify({
+        sessions: [{
+          id: 'ses_legacy',
+          title: 'Legacy',
+          parentId: 'test',
+          status: 'running',
+          startedAt: '2026-01-01T00:00:00.000Z',
+          lastCheck: '2026-01-01T00:00:00.000Z',
+          lastTodo: null,
+          lastMessage: null,
+        }],
+      }),
+      { mode: 0o600 },
+    )
+    clearWorkersForTest()
+    loadWorkerState()
+    expect(worker('ses_legacy')?.title).toBe('Legacy')
   })
 
   it('reconciles active and completed GW sessions', () => {

--- a/products/gateway/src/channels/telegram.ts
+++ b/products/gateway/src/channels/telegram.ts
@@ -10,13 +10,17 @@
  * Responses from OpenCode sessions are sent back to the user.
  */
 
-import * as fs from 'node:fs'
-import * as path from 'node:path'
 import { createHash } from 'node:crypto'
 import type { ChannelAdapter, ChannelMessage } from './provider.js'
 import { createStructuredMessage, planNativeActionDelivery, renderStructuredMessage, type ChannelCapabilities, type MessageAction, type NativeActionDeliveryItem, type RichMessageBlock, type StructuredGatewayMessage } from './renderer.js'
 import { telegramAdapterCapabilities } from './capabilities.js'
-import { getConfig, getConfigDir } from '../config.js'
+import { getConfig } from '../config.js'
+import {
+  clearChannelPollCursor,
+  loadChannelPollCursor,
+  operationalSidecarPath,
+  saveChannelPollCursor,
+} from '../operational-sidecar-store.js'
 import { queueEvent } from '../wakeup.js'
 import { appendWorkEvent, listRecentWorkEvents } from '../work-store.js'
 import { appendChannelInboundDenialAudit } from '../channel-audit.js'
@@ -616,9 +620,9 @@ function isTelegramTargetFailureDetail(detail: string): boolean {
   return /\b(chat not found|bot was blocked|user is deactivated|message thread not found|not enough rights)\b/i.test(detail)
 }
 
-function telegramUpdateCursorPath(): string {
-  return path.join(process.env['OPENCODE_GATEWAY_STATE_DIR'] || getConfigDir(), 'telegram-polling.json')
-}
+// JOE-996 / H8: Telegram long-poll cursor lives in operational-sidecar.sqlite
+// (channel_poll_cursors). Legacy telegram-polling.json is imported once.
+const TELEGRAM_POLL_PROVIDER = 'telegram'
 
 function normalizeUpdateId(value: unknown): number {
   const id = typeof value === 'number' ? value : Number(value)
@@ -627,11 +631,9 @@ function normalizeUpdateId(value: unknown): number {
 
 function loadTelegramUpdateCursor(): number {
   try {
-    const raw = fs.readFileSync(telegramUpdateCursorPath(), 'utf-8')
-    const parsed = JSON.parse(raw) as { lastUpdateId?: unknown }
-    return normalizeUpdateId(parsed.lastUpdateId)
+    return loadChannelPollCursor(TELEGRAM_POLL_PROVIDER)
   } catch (err: any) {
-    if (err?.code !== 'ENOENT') queueEvent(`Telegram polling cursor ignored: ${cleanText(err?.message || String(err), 240)}`)
+    queueEvent(`Telegram polling cursor ignored: ${cleanText(err?.message || String(err), 240)}`)
     return 0
   }
 }
@@ -639,13 +641,8 @@ function loadTelegramUpdateCursor(): number {
 function saveTelegramUpdateCursor(updateId: number): void {
   const normalized = normalizeUpdateId(updateId)
   if (!normalized) return
-  const file = telegramUpdateCursorPath()
-  const dir = path.dirname(file)
   try {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
-    const tmp = `${file}.tmp`
-    fs.writeFileSync(tmp, JSON.stringify({ lastUpdateId: normalized, updatedAt: new Date().toISOString() }, null, 2) + '\n', { mode: 0o600 })
-    fs.renameSync(tmp, file)
+    saveChannelPollCursor(TELEGRAM_POLL_PROVIDER, normalized)
   } catch (err: any) {
     queueEvent(`Telegram polling cursor write failed: ${cleanText(err?.message || String(err), 240)}`)
   }
@@ -658,7 +655,7 @@ export const __telegramTest = {
   },
   resetPollingCursorForTest() {
     lastUpdateId = 0
-    try { fs.rmSync(telegramUpdateCursorPath(), { force: true }) } catch {}
+    try { clearChannelPollCursor(TELEGRAM_POLL_PROVIDER) } catch {}
   },
   resetInMemoryPollingCursorForTest() {
     lastUpdateId = 0
@@ -666,7 +663,9 @@ export const __telegramTest = {
   setTransientRetryBackoffForTest(ms = TRANSIENT_RETRY_BACKOFF_MS) {
     transientRetryBackoffMs = ms
   },
-  pollingCursorPath: telegramUpdateCursorPath,
+  /** Durable operational sidecar path (cursor is a row, not a JSON file). */
+  pollingCursorPath: operationalSidecarPath,
+  getPollingCursor: loadTelegramUpdateCursor,
 }
 
 function sleep(ms: number): Promise<void> {

--- a/products/gateway/src/daemon-routes/system.ts
+++ b/products/gateway/src/daemon-routes/system.ts
@@ -564,6 +564,7 @@ function gatewayFileStatus(): Record<string, unknown> {
     path.join(dir, 'gateway.db'),
     path.join(dir, 'channel-sync.json'),
     path.join(dir, 'channel-sync.json.sqlite'),
+    path.join(dir, 'operational-sidecar.sqlite'),
     path.join(dir, 'events.json'),
     path.join(dir, 'sessions.json'),
   ]

--- a/products/gateway/src/operational-sidecar-store.ts
+++ b/products/gateway/src/operational-sidecar-store.ts
@@ -268,7 +268,16 @@ export function loadWorkerSessions(filePath = operationalSidecarPath()): WorkerS
     const rows = db.prepare(`
       SELECT id, title, parent_id, status, started_at, last_check, last_todo, last_message
       FROM worker_sessions
-    `).all() as Array<Record<string, unknown>>
+    `).all() as Array<{
+      id: unknown
+      title: unknown
+      parent_id: unknown
+      status: unknown
+      started_at: unknown
+      last_check: unknown
+      last_todo: unknown
+      last_message: unknown
+    }>
     return rows.map((row) => ({
       id: String(row.id),
       title: String(row.title),

--- a/products/gateway/src/operational-sidecar-store.ts
+++ b/products/gateway/src/operational-sidecar-store.ts
@@ -1,0 +1,392 @@
+/**
+ * JOE-996 progressive slice: durable SQLite store for operational multi-writer
+ * hazards that previously lived in JSON sidecars.
+ *
+ * Migrates:
+ *   H3 events.json        → operational_events
+ *   H4 sessions.json      → worker_sessions
+ *   H8 telegram-polling.json → channel_poll_cursors
+ *
+ * Still open (not this module): H1 channel-sync.json coordination, H13 notify
+ * in-flight leases. Registry remains status=partial until those close.
+ *
+ * SQLite + BEGIN IMMEDIATE avoids JSON rewrite corruption under concurrent
+ * writers on a shared volume. Production shape remains single-daemon until
+ * open migrate hazards are empty and proving status=ready.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { getConfigDir } from './config.js'
+import { recoverInterruptedStorageRestore, restrictSqliteDbPermissions } from './work-store.js'
+
+export const OPERATIONAL_SIDECAR_FILE = 'operational-sidecar.sqlite'
+export const LEGACY_EVENTS_JSON = 'events.json'
+export const LEGACY_SESSIONS_JSON = 'sessions.json'
+export const LEGACY_TELEGRAM_POLLING_JSON = 'telegram-polling.json'
+
+const MAX_OPERATIONAL_EVENTS = 100
+const MAX_WORKER_SESSIONS = 200
+
+export type WorkerSessionRow = {
+  id: string
+  title: string
+  parentId: string
+  status: 'running' | 'idle' | 'completed' | 'errored' | 'unknown'
+  startedAt: string
+  lastCheck: string
+  lastTodo: string | null
+  lastMessage: string | null
+}
+
+export function operationalSidecarPath(stateDir?: string): string {
+  const root = stateDir || process.env['OPENCODE_GATEWAY_STATE_DIR'] || getConfigDir()
+  return path.join(root, OPERATIONAL_SIDECAR_FILE)
+}
+
+function stateDirFromDbPath(dbPath: string): string {
+  return path.dirname(path.resolve(dbPath))
+}
+
+function openSidecarDb(filePath = operationalSidecarPath()): DatabaseSync {
+  const dbPath = path.resolve(filePath)
+  const dir = path.dirname(dbPath)
+  recoverInterruptedStorageRestore(dir)
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+  try { fs.chmodSync(dir, 0o700) } catch {}
+  const db = new DatabaseSync(dbPath)
+  try {
+    db.exec('PRAGMA journal_mode = WAL')
+    db.exec('PRAGMA synchronous = NORMAL')
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS operational_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        line TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS worker_sessions (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        parent_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        started_at TEXT NOT NULL,
+        last_check TEXT NOT NULL,
+        last_todo TEXT,
+        last_message TEXT
+      );
+      CREATE TABLE IF NOT EXISTS channel_poll_cursors (
+        provider TEXT PRIMARY KEY,
+        cursor INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `)
+    restrictSqliteDbPermissions(dbPath)
+    migrateLegacyJsonIfNeeded(db, dir)
+  } catch (err) {
+    try { db.close() } catch {}
+    throw err
+  }
+  return db
+}
+
+function withSidecarDb<T>(fn: (db: DatabaseSync) => T, filePath = operationalSidecarPath()): T {
+  const db = openSidecarDb(filePath)
+  try {
+    return fn(db)
+  } finally {
+    try { db.close() } catch {}
+  }
+}
+
+function migrateLegacyJsonIfNeeded(db: DatabaseSync, stateDir: string): void {
+  const eventCount = Number((db.prepare('SELECT COUNT(*) AS c FROM operational_events').get() as { c?: number } | undefined)?.c || 0)
+  if (eventCount === 0) {
+    const legacy = path.join(stateDir, LEGACY_EVENTS_JSON)
+    if (fs.existsSync(legacy)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(legacy, 'utf-8'))
+        const events = Array.isArray(parsed?.events)
+          ? parsed.events.filter((e: unknown) => typeof e === 'string').slice(-MAX_OPERATIONAL_EVENTS)
+          : []
+        if (events.length) {
+          const insert = db.prepare('INSERT INTO operational_events (line, created_at) VALUES (?, ?)')
+          const now = new Date().toISOString()
+          db.exec('BEGIN IMMEDIATE')
+          try {
+            for (const line of events) insert.run(line, now)
+            db.exec('COMMIT')
+          } catch (err) {
+            try { db.exec('ROLLBACK') } catch {}
+            throw err
+          }
+        }
+      } catch {
+        // Corrupt legacy JSON: leave empty SQLite table (same as previous fail-open load).
+      }
+    }
+  }
+
+  const sessionCount = Number((db.prepare('SELECT COUNT(*) AS c FROM worker_sessions').get() as { c?: number } | undefined)?.c || 0)
+  if (sessionCount === 0) {
+    const legacy = path.join(stateDir, LEGACY_SESSIONS_JSON)
+    if (fs.existsSync(legacy)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(legacy, 'utf-8'))
+        const rows = Array.isArray(parsed?.sessions) ? parsed.sessions : []
+        const insert = db.prepare(`
+          INSERT OR REPLACE INTO worker_sessions
+            (id, title, parent_id, status, started_at, last_check, last_todo, last_message)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `)
+        db.exec('BEGIN IMMEDIATE')
+        try {
+          for (const row of rows) {
+            if (!isWorkerSessionRow(row)) continue
+            insert.run(
+              row.id,
+              row.title,
+              row.parentId,
+              row.status,
+              row.startedAt,
+              row.lastCheck,
+              row.lastTodo,
+              row.lastMessage,
+            )
+          }
+          db.exec('COMMIT')
+        } catch (err) {
+          try { db.exec('ROLLBACK') } catch {}
+          throw err
+        }
+      } catch {
+        // Corrupt legacy JSON: leave empty table.
+      }
+    }
+  }
+
+  const telegram = db.prepare("SELECT cursor FROM channel_poll_cursors WHERE provider = 'telegram'").get() as { cursor?: number } | undefined
+  if (!telegram) {
+    const legacy = path.join(stateDir, LEGACY_TELEGRAM_POLLING_JSON)
+    if (fs.existsSync(legacy)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(legacy, 'utf-8')) as { lastUpdateId?: unknown }
+        const cursor = normalizeCursor(parsed.lastUpdateId)
+        if (cursor > 0) {
+          db.prepare(`
+            INSERT OR REPLACE INTO channel_poll_cursors (provider, cursor, updated_at)
+            VALUES ('telegram', ?, ?)
+          `).run(cursor, new Date().toISOString())
+        }
+      } catch {
+        // ignore corrupt legacy
+      }
+    }
+  }
+}
+
+function isWorkerSessionRow(row: any): row is WorkerSessionRow {
+  return Boolean(
+    row
+    && typeof row.id === 'string'
+    && typeof row.title === 'string'
+    && typeof row.parentId === 'string'
+    && ['running', 'idle', 'completed', 'errored', 'unknown'].includes(row.status)
+    && typeof row.startedAt === 'string'
+    && typeof row.lastCheck === 'string',
+  )
+}
+
+function normalizeCursor(value: unknown): number {
+  const id = typeof value === 'number' ? value : Number(value)
+  return Number.isSafeInteger(id) && id > 0 ? id : 0
+}
+
+export function loadOperationalEvents(filePath = operationalSidecarPath()): string[] {
+  return withSidecarDb((db) => {
+    const rows = db.prepare('SELECT line FROM operational_events ORDER BY id ASC').all() as Array<{ line: string }>
+    return rows.map((r) => String(r.line)).slice(-MAX_OPERATIONAL_EVENTS)
+  }, filePath)
+}
+
+export function replaceOperationalEvents(events: string[], filePath = operationalSidecarPath()): void {
+  const bounded = events.slice(-MAX_OPERATIONAL_EVENTS)
+  withSidecarDb((db) => {
+    const insert = db.prepare('INSERT INTO operational_events (line, created_at) VALUES (?, ?)')
+    const now = new Date().toISOString()
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM operational_events').run()
+      for (const line of bounded) insert.run(line, now)
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function appendOperationalEvent(line: string, filePath = operationalSidecarPath()): string[] {
+  return withSidecarDb((db) => {
+    const now = new Date().toISOString()
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('INSERT INTO operational_events (line, created_at) VALUES (?, ?)').run(line, now)
+      const count = Number((db.prepare('SELECT COUNT(*) AS c FROM operational_events').get() as { c?: number }).c || 0)
+      if (count > MAX_OPERATIONAL_EVENTS) {
+        db.prepare(`
+          DELETE FROM operational_events
+          WHERE id NOT IN (
+            SELECT id FROM operational_events ORDER BY id DESC LIMIT ?
+          )
+        `).run(MAX_OPERATIONAL_EVENTS)
+      }
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+    const rows = db.prepare('SELECT line FROM operational_events ORDER BY id ASC').all() as Array<{ line: string }>
+    return rows.map((r) => String(r.line))
+  }, filePath)
+}
+
+export function clearOperationalEvents(filePath = operationalSidecarPath()): void {
+  withSidecarDb((db) => {
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM operational_events').run()
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function loadWorkerSessions(filePath = operationalSidecarPath()): WorkerSessionRow[] {
+  return withSidecarDb((db) => {
+    const rows = db.prepare(`
+      SELECT id, title, parent_id, status, started_at, last_check, last_todo, last_message
+      FROM worker_sessions
+    `).all() as Array<Record<string, unknown>>
+    return rows.map((row) => ({
+      id: String(row.id),
+      title: String(row.title),
+      parentId: String(row.parent_id),
+      status: row.status as WorkerSessionRow['status'],
+      startedAt: String(row.started_at),
+      lastCheck: String(row.last_check),
+      lastTodo: row.last_todo == null ? null : String(row.last_todo),
+      lastMessage: row.last_message == null ? null : String(row.last_message),
+    })).filter(isWorkerSessionRow)
+  }, filePath)
+}
+
+export function replaceWorkerSessions(sessions: WorkerSessionRow[], filePath = operationalSidecarPath()): void {
+  const bounded = [...sessions]
+    .sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt))
+    .slice(0, MAX_WORKER_SESSIONS)
+  withSidecarDb((db) => {
+    const insert = db.prepare(`
+      INSERT INTO worker_sessions
+        (id, title, parent_id, status, started_at, last_check, last_todo, last_message)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM worker_sessions').run()
+      for (const row of bounded) {
+        insert.run(
+          row.id,
+          row.title,
+          row.parentId,
+          row.status,
+          row.startedAt,
+          row.lastCheck,
+          row.lastTodo,
+          row.lastMessage,
+        )
+      }
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function clearWorkerSessions(filePath = operationalSidecarPath()): void {
+  withSidecarDb((db) => {
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM worker_sessions').run()
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function loadChannelPollCursor(provider: string, filePath = operationalSidecarPath()): number {
+  return withSidecarDb((db) => {
+    const row = db.prepare('SELECT cursor FROM channel_poll_cursors WHERE provider = ?').get(provider) as { cursor?: number } | undefined
+    return normalizeCursor(row?.cursor)
+  }, filePath)
+}
+
+export function saveChannelPollCursor(provider: string, cursor: number, filePath = operationalSidecarPath()): void {
+  const normalized = normalizeCursor(cursor)
+  if (!normalized) return
+  withSidecarDb((db) => {
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare(`
+        INSERT INTO channel_poll_cursors (provider, cursor, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(provider) DO UPDATE SET
+          cursor = excluded.cursor,
+          updated_at = excluded.updated_at
+      `).run(provider, normalized, new Date().toISOString())
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function clearChannelPollCursor(provider: string, filePath = operationalSidecarPath()): void {
+  withSidecarDb((db) => {
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM channel_poll_cursors WHERE provider = ?').run(provider)
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+/** Test helper: wipe all operational sidecar tables for the current state dir. */
+export function clearOperationalSidecarForTest(filePath = operationalSidecarPath()): void {
+  const dbPath = path.resolve(filePath)
+  if (!fs.existsSync(dbPath)) return
+  withSidecarDb((db) => {
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.prepare('DELETE FROM operational_events').run()
+      db.prepare('DELETE FROM worker_sessions').run()
+      db.prepare('DELETE FROM channel_poll_cursors').run()
+      db.exec('COMMIT')
+    } catch (err) {
+      try { db.exec('ROLLBACK') } catch {}
+      throw err
+    }
+  }, filePath)
+}
+
+export function operationalSidecarStateDir(filePath = operationalSidecarPath()): string {
+  return stateDirFromDbPath(filePath)
+}

--- a/products/gateway/src/operational-sidecar-store.ts
+++ b/products/gateway/src/operational-sidecar-store.ts
@@ -44,10 +44,6 @@ export function operationalSidecarPath(stateDir?: string): string {
   return path.join(root, OPERATIONAL_SIDECAR_FILE)
 }
 
-function stateDirFromDbPath(dbPath: string): string {
-  return path.dirname(path.resolve(dbPath))
-}
-
 function openSidecarDb(filePath = operationalSidecarPath()): DatabaseSync {
   const dbPath = path.resolve(filePath)
   const dir = path.dirname(dbPath)
@@ -225,44 +221,6 @@ export function replaceOperationalEvents(events: string[], filePath = operationa
   }, filePath)
 }
 
-export function appendOperationalEvent(line: string, filePath = operationalSidecarPath()): string[] {
-  return withSidecarDb((db) => {
-    const now = new Date().toISOString()
-    db.exec('BEGIN IMMEDIATE')
-    try {
-      db.prepare('INSERT INTO operational_events (line, created_at) VALUES (?, ?)').run(line, now)
-      const count = Number((db.prepare('SELECT COUNT(*) AS c FROM operational_events').get() as { c?: number }).c || 0)
-      if (count > MAX_OPERATIONAL_EVENTS) {
-        db.prepare(`
-          DELETE FROM operational_events
-          WHERE id NOT IN (
-            SELECT id FROM operational_events ORDER BY id DESC LIMIT ?
-          )
-        `).run(MAX_OPERATIONAL_EVENTS)
-      }
-      db.exec('COMMIT')
-    } catch (err) {
-      try { db.exec('ROLLBACK') } catch {}
-      throw err
-    }
-    const rows = db.prepare('SELECT line FROM operational_events ORDER BY id ASC').all() as Array<{ line: string }>
-    return rows.map((r) => String(r.line))
-  }, filePath)
-}
-
-export function clearOperationalEvents(filePath = operationalSidecarPath()): void {
-  withSidecarDb((db) => {
-    db.exec('BEGIN IMMEDIATE')
-    try {
-      db.prepare('DELETE FROM operational_events').run()
-      db.exec('COMMIT')
-    } catch (err) {
-      try { db.exec('ROLLBACK') } catch {}
-      throw err
-    }
-  }, filePath)
-}
-
 export function loadWorkerSessions(filePath = operationalSidecarPath()): WorkerSessionRow[] {
   return withSidecarDb((db) => {
     const rows = db.prepare(`
@@ -324,19 +282,6 @@ export function replaceWorkerSessions(sessions: WorkerSessionRow[], filePath = o
   }, filePath)
 }
 
-export function clearWorkerSessions(filePath = operationalSidecarPath()): void {
-  withSidecarDb((db) => {
-    db.exec('BEGIN IMMEDIATE')
-    try {
-      db.prepare('DELETE FROM worker_sessions').run()
-      db.exec('COMMIT')
-    } catch (err) {
-      try { db.exec('ROLLBACK') } catch {}
-      throw err
-    }
-  }, filePath)
-}
-
 export function loadChannelPollCursor(provider: string, filePath = operationalSidecarPath()): number {
   return withSidecarDb((db) => {
     const row = db.prepare('SELECT cursor FROM channel_poll_cursors WHERE provider = ?').get(provider) as { cursor?: number } | undefined
@@ -378,24 +323,3 @@ export function clearChannelPollCursor(provider: string, filePath = operationalS
   }, filePath)
 }
 
-/** Test helper: wipe all operational sidecar tables for the current state dir. */
-export function clearOperationalSidecarForTest(filePath = operationalSidecarPath()): void {
-  const dbPath = path.resolve(filePath)
-  if (!fs.existsSync(dbPath)) return
-  withSidecarDb((db) => {
-    db.exec('BEGIN IMMEDIATE')
-    try {
-      db.prepare('DELETE FROM operational_events').run()
-      db.prepare('DELETE FROM worker_sessions').run()
-      db.prepare('DELETE FROM channel_poll_cursors').run()
-      db.exec('COMMIT')
-    } catch (err) {
-      try { db.exec('ROLLBACK') } catch {}
-      throw err
-    }
-  }, filePath)
-}
-
-export function operationalSidecarStateDir(filePath = operationalSidecarPath()): string {
-  return stateDirFromDbPath(filePath)
-}

--- a/products/gateway/src/storage/internal.ts
+++ b/products/gateway/src/storage/internal.ts
@@ -17,8 +17,15 @@ import type {
 export const CURRENT_BACKUP_VERSION = 1
 export const DEFAULT_BACKUP_RETENTION = 20
 export const CHANNEL_SYNC_OUTBOX_FILE = 'channel-sync.json.sqlite'
+export const OPERATIONAL_SIDECAR_FILE = 'operational-sidecar.sqlite'
+/** Legacy JSON sidecars (still backed up for restore of older states). */
 export const SIDECAR_FILES = ['channel-sync.json', 'events.json', 'sessions.json']
-export const BACKUP_FILE_NAMES = new Set(['gateway.db', CHANNEL_SYNC_OUTBOX_FILE, ...SIDECAR_FILES])
+export const BACKUP_FILE_NAMES = new Set([
+  'gateway.db',
+  CHANNEL_SYNC_OUTBOX_FILE,
+  OPERATIONAL_SIDECAR_FILE,
+  ...SIDECAR_FILES,
+])
 export const RECOVERY_DRILL_RETENTION = 20
 export const BACKUP_COUNT_KEYS = ['roadmaps', 'supervisors', 'projectBindings', 'completionProposals', 'tasks', 'runs', 'channelBindings', 'events'] as const
 export function storageStateDir(): string {
@@ -35,6 +42,21 @@ export function listStorageSources(options: { stateDir?: string } = {}): Storage
   return storageSourceSpecs(stateDir).map(spec => sourceRecord(spec, stateDir))
 }
 export function readSessionSidecarIds(stateDir: string): Set<string> | undefined {
+  // JOE-996 / H4: prefer operational-sidecar.sqlite worker_sessions; fall back to legacy sessions.json.
+  const sqlitePath = path.join(stateDir, OPERATIONAL_SIDECAR_FILE)
+  if (fs.existsSync(sqlitePath)) {
+    try {
+      const db = new DatabaseSync(sqlitePath, { readOnly: true })
+      try {
+        const rows = db.prepare('SELECT id FROM worker_sessions').all() as Array<{ id?: unknown }>
+        return new Set(rows.map((row) => String(row?.id || '').trim()).filter(Boolean))
+      } finally {
+        try { db.close() } catch {}
+      }
+    } catch {
+      // fall through to legacy JSON
+    }
+  }
   const sessionPath = path.join(stateDir, 'sessions.json')
   if (!fs.existsSync(sessionPath)) return undefined
   const parsed = readJsonArtifact(sessionPath)
@@ -67,7 +89,12 @@ export function uniqueStrings(values: unknown[]): string[] {
 }
 export function backupSourceFiles(stateDir = storageStateDir()): string[] {
   const resolved = path.resolve(stateDir)
-  return [workStatePathForStateDir(resolved), channelSyncOutboxPath(resolved), ...SIDECAR_FILES.map(name => path.join(resolved, name))]
+  return [
+    workStatePathForStateDir(resolved),
+    channelSyncOutboxPath(resolved),
+    path.join(resolved, OPERATIONAL_SIDECAR_FILE),
+    ...SIDECAR_FILES.map(name => path.join(resolved, name)),
+  ]
 }
 export function storageSourceSpecs(stateDir: string): StorageSourceSpec[] {
   const resolved = path.resolve(stateDir)
@@ -122,8 +149,20 @@ export function storageSourceSpecs(stateDir: string): StorageSourceSpec[] {
       remediation: 'Restore channel-sync.json from backup or rebuild it intentionally during a quiet maintenance window.',
     },
     {
+      id: 'operational_sidecar',
+      label: 'Operational sidecar store',
+      kind: 'transactional_sqlite',
+      rawPath: path.join(resolved, OPERATIONAL_SIDECAR_FILE),
+      fileName: OPERATIONAL_SIDECAR_FILE,
+      required: false,
+      backedUp: true,
+      owner: 'operational-sidecar',
+      description: 'SQLite store for operational events, worker session projection, and channel poll cursors (JOE-996 H3/H4/H8).',
+      remediation: 'Restore operational-sidecar.sqlite from backup or let Gateway recreate it after confirming local tooling no longer needs prior telemetry/cursors.',
+    },
+    {
       id: 'events_sidecar',
-      label: 'Events sidecar',
+      label: 'Events sidecar (legacy JSON)',
       kind: 'append_only_evidence',
       rawPath: path.join(resolved, 'events.json'),
       fileName: 'events.json',
@@ -131,12 +170,12 @@ export function storageSourceSpecs(stateDir: string): StorageSourceSpec[] {
       required: false,
       backedUp: true,
       owner: 'wakeup',
-      description: 'Append-only bounded operational telemetry written live by wakeup event capture.',
-      remediation: 'Restore from backup if still used by local tooling; otherwise it can be absent.',
+      description: 'Legacy bounded operational telemetry JSON. Migrated into operational-sidecar.sqlite on first open (H3).',
+      remediation: 'Prefer operational-sidecar.sqlite; restore legacy events.json only for older backups.',
     },
     {
       id: 'sessions_sidecar',
-      label: 'Sessions sidecar',
+      label: 'Sessions sidecar (legacy JSON)',
       kind: 'derived_cache',
       rawPath: path.join(resolved, 'sessions.json'),
       fileName: 'sessions.json',
@@ -144,8 +183,8 @@ export function storageSourceSpecs(stateDir: string): StorageSourceSpec[] {
       required: false,
       backedUp: true,
       owner: 'workers',
-      description: 'Live worker registry state written by the worker supervisor to track running sessions.',
-      remediation: 'Restore from backup if still used by local tooling; otherwise it can be absent.',
+      description: 'Legacy worker registry JSON. Migrated into operational-sidecar.sqlite on first open (H4).',
+      remediation: 'Prefer operational-sidecar.sqlite; restore legacy sessions.json only for older backups.',
     },
     {
       id: 'backups',

--- a/products/gateway/src/storage/restore.ts
+++ b/products/gateway/src/storage/restore.ts
@@ -16,6 +16,7 @@ import {
 import { assertSupportedWorkStoreSchemaVersion, workStoreSchemaVersion } from '../work-store/schema.js'
 import {
   CHANNEL_SYNC_OUTBOX_FILE,
+  OPERATIONAL_SIDECAR_FILE,
   SIDECAR_FILES,
   DEFAULT_BACKUP_RETENTION,
   storageStateDir,
@@ -119,8 +120,8 @@ export function recoverStorageRestoreToStateDir(targetStateDir: string): Storage
 }
 
 function restoreManagedFileNames(): string[] {
-  const names = new Set(['gateway.db', CHANNEL_SYNC_OUTBOX_FILE, ...SIDECAR_FILES])
-  for (const sqlite of ['gateway.db', CHANNEL_SYNC_OUTBOX_FILE]) {
+  const names = new Set(['gateway.db', CHANNEL_SYNC_OUTBOX_FILE, OPERATIONAL_SIDECAR_FILE, ...SIDECAR_FILES])
+  for (const sqlite of ['gateway.db', CHANNEL_SYNC_OUTBOX_FILE, OPERATIONAL_SIDECAR_FILE]) {
     names.add(`${sqlite}-wal`)
     names.add(`${sqlite}-shm`)
   }

--- a/products/gateway/src/wakeup.ts
+++ b/products/gateway/src/wakeup.ts
@@ -8,7 +8,6 @@ import { getConfig } from './config.js'
 import { redactSensitiveText } from './security.js'
 import {
   loadOperationalEvents,
-  operationalSidecarPath,
   replaceOperationalEvents,
 } from './operational-sidecar-store.js'
 
@@ -70,13 +69,3 @@ export function clearEventsForTest(): void {
   lastSaveMs = 0
 }
 
-/** Path of the durable operational sidecar (tests / diagnostics). */
-export function operationalEventsStorePath(): string {
-  return operationalSidecarPath()
-}
-
-export function flushQueuedEventsForTest(): void {
-  ensureLoaded()
-  lastSaveMs = 0
-  saveEvents()
-}

--- a/products/gateway/src/wakeup.ts
+++ b/products/gateway/src/wakeup.ts
@@ -1,49 +1,42 @@
 /**
  * Event queue for heartbeat logging and dashboard replay.
+ *
+ * JOE-996 / H3: authoritative persistence is operational-sidecar.sqlite
+ * (not events.json). Legacy events.json is imported once on first open.
  */
-import * as fs from 'node:fs'
-import * as path from 'node:path'
-import { getConfig, getConfigDir } from './config.js'
+import { getConfig } from './config.js'
 import { redactSensitiveText } from './security.js'
+import {
+  loadOperationalEvents,
+  operationalSidecarPath,
+  replaceOperationalEvents,
+} from './operational-sidecar-store.js'
 
 let queuedEvents: string[] = []
 let loaded = false
-// events.json is a bounded operational-telemetry sidecar. Rewriting the whole
-// file on every queued line makes a busy channel session issue hundreds of
-// synchronous filesystem writes per minute, so persistence is throttled: the
-// in-memory queue stays authoritative and the file is rewritten at most once
-// per interval, with skipped lines flushed by the next write. A hard crash can
-// lose at most the last interval of telemetry lines, which is acceptable for
-// this sidecar (durable workflow events live in SQLite).
+// operational_events is bounded telemetry. Rewriting SQLite on every queued
+// line under a busy channel would thrash the DB, so persistence is throttled:
+// the in-memory queue stays authoritative and the store is flushed at most once
+// per interval. A hard crash can lose at most the last interval of telemetry
+// lines, which is acceptable (durable workflow events live in gateway.db).
 const SAVE_MIN_INTERVAL_MS = 1000
 let lastSaveMs = 0
-
-function eventStorePath(): string {
-  return path.join(process.env['OPENCODE_GATEWAY_STATE_DIR'] || getConfigDir(), 'events.json')
-}
 
 function ensureLoaded(): void {
   if (loaded) return
   loaded = true
   try {
-    const parsed = JSON.parse(fs.readFileSync(eventStorePath(), 'utf-8'))
-    queuedEvents = Array.isArray(parsed?.events) ? parsed.events.filter((e: any) => typeof e === 'string').slice(-100) : []
-  } catch {}
+    queuedEvents = loadOperationalEvents()
+  } catch {
+    queuedEvents = []
+  }
 }
 
 function saveEvents(): void {
-  let tmp = ''
   try {
-    const file = eventStorePath()
-    const dir = path.dirname(file)
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
-    try { fs.chmodSync(dir, 0o700) } catch {}
-    tmp = `${file}.tmp-${process.pid}-${Date.now()}`
-    fs.writeFileSync(tmp, JSON.stringify({ savedAt: new Date().toISOString(), events: queuedEvents }, null, 2), { mode: 0o600 })
-    fs.renameSync(tmp, file)
-    try { fs.chmodSync(file, 0o600) } catch {}
+    replaceOperationalEvents(queuedEvents)
   } catch {
-    if (tmp) try { fs.rmSync(tmp, { force: true }) } catch {}
+    // Best-effort operational telemetry — do not take down the daemon.
   }
 }
 
@@ -71,7 +64,19 @@ export function getQueuedEvents(): string[] {
 }
 
 export function clearEventsForTest(): void {
+  // Memory only — persist/reload tests call getQueuedEvents after clear.
   loaded = false
   queuedEvents = []
   lastSaveMs = 0
+}
+
+/** Path of the durable operational sidecar (tests / diagnostics). */
+export function operationalEventsStorePath(): string {
+  return operationalSidecarPath()
+}
+
+export function flushQueuedEventsForTest(): void {
+  ensureLoaded()
+  lastSaveMs = 0
+  saveEvents()
 }

--- a/products/gateway/src/workers.ts
+++ b/products/gateway/src/workers.ts
@@ -1,25 +1,21 @@
-import * as fs from 'node:fs'
-import * as path from 'node:path'
-import { getConfigDir } from './config.js'
+/**
+ * Worker / session projection for Mission Control.
+ *
+ * JOE-996 / H4: authoritative persistence is operational-sidecar.sqlite
+ * (not sessions.json). Legacy sessions.json is imported once on first open.
+ */
+import {
+  loadWorkerSessions,
+  operationalSidecarPath,
+  replaceWorkerSessions,
+  type WorkerSessionRow,
+} from './operational-sidecar-store.js'
 import { openCodeFetch } from './opencode-client.js'
 
-export interface WorkerState {
-  id: string
-  title: string
-  parentId: string
-  status: 'running' | 'idle' | 'completed' | 'errored' | 'unknown'
-  startedAt: string
-  lastCheck: string
-  lastTodo: string | null
-  lastMessage: string | null
-}
+export type WorkerState = WorkerSessionRow
 
 const workers = new Map<string, WorkerState>()
 let loaded = false
-
-function workerStorePath(): string {
-  return path.join(process.env['OPENCODE_GATEWAY_STATE_DIR'] || getConfigDir(), 'sessions.json')
-}
 
 function ensureLoaded(): void {
   if (!loaded) loadWorkerState()
@@ -30,7 +26,6 @@ export function trackWorker(state: WorkerState): void {
   workers.set(state.id, state)
   saveWorkerState()
 }
-
 
 export function updateWorker(id: string, patch: Partial<Omit<WorkerState, 'id'>>): void {
   ensureLoaded()
@@ -46,7 +41,6 @@ export function listWorkers(): WorkerState[] {
     .sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt))
 }
 
-
 export function getWorkerCounts(): { total: number; running: number; idle: number; completed: number } {
   const all = listWorkers()
   return {
@@ -57,34 +51,23 @@ export function getWorkerCounts(): { total: number; running: number; idle: numbe
   }
 }
 
-export function loadWorkerState(filePath = workerStorePath()): WorkerState[] {
+export function loadWorkerState(_filePath?: string): WorkerState[] {
   loaded = true
   try {
-    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
-    const rows = Array.isArray(parsed?.sessions) ? parsed.sessions : []
+    const rows = loadWorkerSessions()
     workers.clear()
-    for (const row of rows) {
-      if (isWorkerState(row)) workers.set(row.id, row)
-    }
-  } catch {}
+    for (const row of rows) workers.set(row.id, row)
+  } catch {
+    // Fail closed to empty map on corrupt/missing store (same as prior JSON).
+  }
   return Array.from(workers.values())
 }
 
-export function saveWorkerState(filePath = workerStorePath()): void {
-  let tmp = ''
+export function saveWorkerState(_filePath?: string): void {
   try {
-    const dir = path.dirname(filePath)
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
-    try { fs.chmodSync(dir, 0o700) } catch {}
-    const rows = Array.from(workers.values())
-      .sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt))
-      .slice(0, 200)
-    tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`
-    fs.writeFileSync(tmp, JSON.stringify({ savedAt: new Date().toISOString(), sessions: rows }, null, 2), { mode: 0o600 })
-    fs.renameSync(tmp, filePath)
-    try { fs.chmodSync(filePath, 0o600) } catch {}
+    replaceWorkerSessions(Array.from(workers.values()))
   } catch {
-    if (tmp) try { fs.rmSync(tmp, { force: true }) } catch {}
+    // Best-effort projection — do not take down the daemon.
   }
 }
 
@@ -144,23 +127,17 @@ function hasSessionActivity(session: any): boolean {
     tokens.output > 0 ||
     tokens.reasoning > 0 ||
     tokens.cache?.read > 0 ||
-    tokens.cache?.write > 0
-  )
-}
-
-function isWorkerState(row: any): row is WorkerState {
-  return Boolean(
-    row &&
-    typeof row.id === 'string' &&
-    typeof row.title === 'string' &&
-    typeof row.parentId === 'string' &&
-    ['running', 'idle', 'completed', 'errored', 'unknown'].includes(row.status) &&
-    typeof row.startedAt === 'string' &&
-    typeof row.lastCheck === 'string'
+    tokens.cache?.write > 0,
   )
 }
 
 export function clearWorkersForTest(): void {
+  // Memory only — persist/reload tests call loadWorkerState after clear.
   loaded = true
   workers.clear()
+}
+
+/** Path of the durable operational sidecar (tests / diagnostics). */
+export function workerSessionsStorePath(): string {
+  return operationalSidecarPath()
 }


### PR DESCRIPTION
## Summary

Progressive slice of **JOE-996** (HA open migrate hazards). Does **not** claim multi-AZ HA or proving `status=ready`.

| Hazard | Change |
| --- | --- |
| **H3** | `events.json` → `operational-sidecar.sqlite` (`operational_events`) |
| **H4** | `sessions.json` → `worker_sessions` |
| **H8** | `telegram-polling.json` → `channel_poll_cursors` |
| **H1 / H13** | Still open — registry remains `status=partial`, `openMigrateHazards: ["H1","H13"]` |

- One-shot import of legacy JSON on first open
- Backup/restore/doctor list the new SQLite file
- Claims language stays fail-closed for multi-AZ HA marketing

## Validation

- [x] `pnpm --filter cowork-gateway exec vitest run` (wakeup, workers, telegram, storage, durable-storage, service-health, module-boundaries, proving)
- [x] `node scripts/check-distributed-ownership-claims.mjs`
- [ ] full CI

## Dual-channel security checklist

- [x] Reviewed **Durable Gateway channels** (`products/gateway/src/channels/*` and related security)
- [x] Both stacks fixed **or** explicit single-stack ownership noted in Notes with follow-up

## User-visible impact

- [x] Runtime behavior change (state files: new `operational-sidecar.sqlite`; legacy JSON read once if present)
- [x] Docs change

## Notes

- single-stack ownership: Durable H8 poll cursor only; monorepo providers N/A
- Not multi-AZ HA. Remaining work on JOE-996: H1 channel-sync JSON coordination + H13 durable send leases.

Linear: JOE-996 (partial)