### PR TITLE
feat(joe-994): Phase 2 Telegram monorepo protocol façade

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'products/gateway/**'
       - 'packages/shared/**'
+      - 'packages/gateway-channel/**'
+      - 'packages/gateway-provider-telegram/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-gateway.yml'
       - 'scripts/check-product-boundaries.mjs'
@@ -13,6 +15,8 @@ on:
     paths:
       - 'products/gateway/**'
       - 'packages/shared/**'
+      - 'packages/gateway-channel/**'
+      - 'packages/gateway-provider-telegram/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-gateway.yml'
 
@@ -42,9 +46,9 @@ jobs:
       - name: Product boundaries
         run: pnpm boundaries:check
 
-      # products/gateway depends on @open-cowork/shared (dist-only package exports).
-      - name: Build shared workspace package
-        run: pnpm --filter @open-cowork/shared build
+      # products/gateway depends on dist-only workspace packages (shared + Telegram stack).
+      - name: Build workspace channel packages
+        run: pnpm --filter @open-cowork/gateway-provider-telegram build
 
       - name: Build Gateway
         run: pnpm --filter cowork-gateway build

--- a/.github/workflows/release-gateway.yml
+++ b/.github/workflows/release-gateway.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Product boundaries
         run: pnpm boundaries:check
 
-      - name: Build shared workspace package
-        run: pnpm --filter @open-cowork/shared build
+      - name: Build workspace channel packages
+        run: pnpm --filter @open-cowork/gateway-provider-telegram build
 
       - name: Build
         run: pnpm --filter cowork-gateway build

--- a/.github/workflows/weekly-gateway.yml
+++ b/.github/workflows/weekly-gateway.yml
@@ -44,7 +44,7 @@ jobs:
 
       # products/gateway depends on @open-cowork/shared (dist-only package exports).
       - name: Build shared workspace package
-        run: pnpm --filter @open-cowork/shared build
+        run: pnpm --filter @open-cowork/gateway-provider-telegram build
 
       - name: Build Gateway
         run: pnpm --filter cowork-gateway build
@@ -82,7 +82,7 @@ jobs:
 
           Reproduce locally:
           \`\`\`
-          pnpm --filter @open-cowork/shared build
+          pnpm --filter @open-cowork/gateway-provider-telegram build
           pnpm test:gateway
           \`\`\`
           EOF

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `7970be81d72899c322d2af180700f203021051fa642eafcb25a3150693a39833`
+- pnpm lockfile SHA-256: `4a36f27fe4ff1a89b49b033e49cf332220e054a1d2b610a6cf6d6f1af47b2fa5`
 - Production package entries: 403
 - Bundled license directories: 388 (15 package entries have no standalone license file or are workspace links)
 

--- a/docs/product-channel-ownership.md
+++ b/docs/product-channel-ownership.md
@@ -9,7 +9,7 @@
 | Layer | Status | Meaning |
 | --- | --- | --- |
 | **Security body** (signature verify, Meta/Discord/Telegram/Slack kernels, rate-limit algorithm) | **Done** | Shared; dual-fix checklist still required for security PRs |
-| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Intentional residual freeze** | Not an incomplete P1; full protocol re-home is a future epic (capacity), not a missing security fix |
+| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Partial Phase 2 (Telegram opt-in)** | Telegram can compose monorepo provider behind `channels.telegram.protocolStack=monorepo` (default remains Durable legacy). **Intentional residual freeze** for WhatsApp/Discord. |
 
 ## Two stacks (intentional)
 
@@ -41,7 +41,20 @@ ready — **do not re-open as incomplete dual-stack security P1**.
 ([JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)).
 Inventory guard: `node scripts/check-channel-protocol-inventory.mjs`.
 
-Until then, this freeze document is the source of truth for dual-stack ownership.
+### Telegram monorepo façade (JOE-994 Phase 2)
+
+| Setting | Effect |
+| --- | --- |
+| `channels.telegram.protocolStack: "durable"` (default) | Legacy Durable long-poll in `channels/telegram.ts` |
+| `channels.telegram.protocolStack: "monorepo"` | Thin façade over `@open-cowork/gateway-provider-telegram` |
+| `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK=durable\|monorepo` | Process env override (rollback / canary) |
+
+Durable product policy (trust allowlists, claims, denial probes) is shared via
+`channels/telegram-inbound-policy.ts` on both stacks. Security kernels remain
+in `@open-cowork/shared/node`.
+
+Until WhatsApp/Discord compose monorepo providers, this freeze document remains
+the source of truth for dual-stack ownership on those channels.
 
 ### Shared security kernel (2026-07-21)
 

--- a/docs/product-channel-protocol-unification.md
+++ b/docs/product-channel-protocol-unification.md
@@ -1,6 +1,6 @@
 # Dual-stack channel protocol unification (JOE-994)
 
-**Status:** Capacity epic — **protocol freeze retained**
+**Status:** Capacity epic — **Phase 2 Telegram opt-in façade shipped**; WhatsApp/Discord **protocol freeze retained**
 **Security body:** Done (shared kernels + dual-stack checklist / CI gate)
 **Linear:** [JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)
 **Freeze source of truth:** [`product-channel-ownership.md`](product-channel-ownership.md)
@@ -72,10 +72,19 @@ Until a phase below is explicitly scheduled:
 
 ### Phase 2 — Compose one Durable channel onto monorepo provider
 
-- [ ] Pick one provider (recommend Telegram or Discord)
-- [ ] Durable adapter becomes thin façade over `gateway-provider-*`
-- [ ] Dual-stack checklist + parity tests green
-- [ ] Feature-flag / config escape hatch for rollback
+- [x] Pick one provider: **Telegram**
+- [x] Durable adapter becomes thin façade over `gateway-provider-telegram`
+  (`products/gateway/src/channels/telegram-monorepo-adapter.ts` + shared
+  inbound policy in `telegram-inbound-policy.ts`)
+- [x] Dual-stack checklist + parity tests green
+  (`products/gateway/src/__tests__/telegram-monorepo-facade.test.ts`)
+- [x] Feature-flag / config escape hatch for rollback
+  (`channels.telegram.protocolStack: durable|monorepo`, default **durable**;
+  env `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK` overrides)
+
+**Residuals on monorepo stack (flag-on only):** grammy poll offset is not the
+HA operational-sidecar cursor; rich HTML `sendRichMessage` falls back to text;
+native `setMyCommands` registration is not mirrored. Default path unchanged.
 
 ### Phase 3 — Remaining channels + decommission
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,6 +706,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(zod@4.4.3)
+      '@open-cowork/gateway-channel':
+        specifier: workspace:*
+        version: link:../../packages/gateway-channel
+      '@open-cowork/gateway-provider-telegram':
+        specifier: workspace:*
+        version: link:../../packages/gateway-provider-telegram
       '@open-cowork/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/products/gateway/package.json
+++ b/products/gateway/package.json
@@ -53,6 +53,8 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@open-cowork/gateway-channel": "workspace:*",
+    "@open-cowork/gateway-provider-telegram": "workspace:*",
     "@open-cowork/shared": "workspace:*",
     "@opencode-ai/sdk": "1.18.1",
     "zod": "^4.4.3"

--- a/products/gateway/scripts/pack-standalone.mjs
+++ b/products/gateway/scripts/pack-standalone.mjs
@@ -2,9 +2,10 @@
 /**
  * Build a standalone-installable cowork-gateway tarball from the monorepo.
  *
- * Workspace deps such as `@open-cowork/shared` are vendored under
- * `vendor/` and rewritten to `file:` dependencies so `npm install` of the
- * packed tarball works outside the pnpm workspace (JOE-914 smoke / release pack).
+ * Workspace deps such as `@open-cowork/shared` (and JOE-994 Telegram stack
+ * packages) are vendored under `vendor/` and rewritten to `file:` dependencies
+ * so `npm install` of the packed tarball works outside the pnpm workspace
+ * (JOE-914 smoke / release pack).
  *
  * Usage:
  *   node products/gateway/scripts/pack-standalone.mjs [pack-destination-dir]
@@ -19,8 +20,15 @@ import { fileURLToPath } from 'node:url'
 
 const productRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const monorepoRoot = path.resolve(productRoot, '../..')
-const sharedRoot = path.join(monorepoRoot, 'packages/shared')
+const packagesRoot = path.join(monorepoRoot, 'packages')
 const packDestination = path.resolve(process.argv[2] || path.join(productRoot, 'artifacts/pack'))
+
+/** Private workspace packages Durable Gateway may compose (JOE-994 Phase 2+). */
+const WORKSPACE_VENDOR_PACKAGES = [
+  { name: '@open-cowork/shared', dir: 'shared' },
+  { name: '@open-cowork/gateway-channel', dir: 'gateway-channel' },
+  { name: '@open-cowork/gateway-provider-telegram', dir: 'gateway-provider-telegram' },
+]
 
 function fail(message) {
   console.error(`[gateway-pack-standalone] ${message}`)
@@ -48,14 +56,16 @@ function copyDir(src, dest) {
 }
 
 const pkg = JSON.parse(fs.readFileSync(path.join(productRoot, 'package.json'), 'utf8'))
-const sharedPkg = JSON.parse(fs.readFileSync(path.join(sharedRoot, 'package.json'), 'utf8'))
 
-// Ensure shared + gateway dist exist.
-run('pnpm', ['--filter', '@open-cowork/shared', 'build'], { cwd: monorepoRoot })
+// Build monorepo channel stack then Durable Gateway dist.
+run('pnpm', ['--filter', '@open-cowork/gateway-provider-telegram', 'build'], { cwd: monorepoRoot })
 run('pnpm', ['--filter', 'cowork-gateway', 'build'], { cwd: monorepoRoot })
 
-if (!fs.existsSync(path.join(sharedRoot, 'dist/index.js'))) {
-  fail('packages/shared dist/index.js missing after build')
+for (const entry of WORKSPACE_VENDOR_PACKAGES) {
+  const distIndex = path.join(packagesRoot, entry.dir, 'dist/index.js')
+  if (!fs.existsSync(distIndex)) {
+    fail(`packages/${entry.dir} dist/index.js missing after build`)
+  }
 }
 if (!fs.existsSync(path.join(productRoot, 'dist/cli.js'))) {
   fail('products/gateway dist/cli.js missing after build')
@@ -84,26 +94,39 @@ try {
   // Vendor private workspace packages declared as workspace:*.
   const stagedPkg = JSON.parse(fs.readFileSync(path.join(stageRoot, 'package.json'), 'utf8'))
   const deps = { ...(stagedPkg.dependencies || {}) }
-  const vendorRel = 'vendor/@open-cowork/shared'
-  if (deps['@open-cowork/shared']) {
+
+  for (const entry of WORKSPACE_VENDOR_PACKAGES) {
+    if (!deps[entry.name]) continue
+    const packageRoot = path.join(packagesRoot, entry.dir)
+    const sourcePkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'))
+    const vendorRel = `vendor/${entry.name}`
     const vendorAbs = path.join(stageRoot, vendorRel)
     fs.mkdirSync(vendorAbs, { recursive: true })
-    copyDir(path.join(sharedRoot, 'dist'), path.join(vendorAbs, 'dist'))
-    // Minimal package manifest for the vendored shared package.
+    copyDir(path.join(packageRoot, 'dist'), path.join(vendorAbs, 'dist'))
+
+    // Nested workspace deps inside the vendored package also point at sibling vendors.
+    const nestedDeps = { ...(sourcePkg.dependencies || {}) }
+    for (const nested of WORKSPACE_VENDOR_PACKAGES) {
+      if (nestedDeps[nested.name]) {
+        nestedDeps[nested.name] = `file:../${nested.name}`
+      }
+    }
+
     const vendorManifest = {
-      name: sharedPkg.name,
-      version: sharedPkg.version,
+      name: sourcePkg.name,
+      version: sourcePkg.version,
       private: true,
-      type: sharedPkg.type || 'module',
-      main: sharedPkg.main,
-      types: sharedPkg.types,
-      exports: sharedPkg.exports,
+      type: sourcePkg.type || 'module',
+      main: sourcePkg.main,
+      types: sourcePkg.types,
+      exports: sourcePkg.exports,
       files: ['dist'],
-      license: sharedPkg.license || 'MIT',
-      sideEffects: false,
+      license: sourcePkg.license || 'MIT',
+      sideEffects: sourcePkg.sideEffects ?? false,
+      dependencies: nestedDeps,
     }
     fs.writeFileSync(path.join(vendorAbs, 'package.json'), `${JSON.stringify(vendorManifest, null, 2)}\n`)
-    deps['@open-cowork/shared'] = `file:./${vendorRel}`
+    deps[entry.name] = `file:./${vendorRel}`
   }
 
   // Drop monorepo-only scripts that would re-run tsc without workspace context.

--- a/products/gateway/src/__tests__/telegram-monorepo-facade.test.ts
+++ b/products/gateway/src/__tests__/telegram-monorepo-facade.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { clearConfigCacheForTest, updateConfig } from '../config.js'
+import { createChannelClaimCode } from '../channel-claims.js'
+import { clearEventsForTest, getQueuedEvents } from '../wakeup.js'
+import { processDurableTelegramInbound } from '../channels/telegram-inbound-policy.js'
+import {
+  getTelegramChannel,
+  peekTelegramProtocolStack,
+  resetTelegramChannelForTest,
+  resolveTelegramProtocolStack,
+} from '../channels/telegram-protocol-stack.js'
+import { __telegramMonorepoTest } from '../channels/telegram-monorepo-adapter.js'
+import { telegramChannel } from '../channels/telegram.js'
+import type { ChannelMessage } from '../channels/provider.js'
+import type { IncomingChannelMessage } from '@open-cowork/gateway-channel'
+
+describe('JOE-994 Phase 2 telegram monorepo façade', () => {
+  const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-gateway-telegram-facade-'))
+
+  beforeEach(() => {
+    process.env['OPENCODE_GATEWAY_CONFIG_DIR'] = testDir
+    process.env['OPENCODE_GATEWAY_STATE_DIR'] = testDir
+    delete process.env['OPEN_COWORK_TELEGRAM_PROTOCOL_STACK']
+    delete process.env['TELEGRAM_PROTOCOL_STACK']
+    if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true })
+    fs.mkdirSync(testDir, { recursive: true })
+    clearConfigCacheForTest()
+    clearEventsForTest()
+    resetTelegramChannelForTest()
+  })
+
+  afterEach(() => {
+    delete process.env['OPENCODE_GATEWAY_CONFIG_DIR']
+    delete process.env['OPENCODE_GATEWAY_STATE_DIR']
+    delete process.env['OPEN_COWORK_TELEGRAM_PROTOCOL_STACK']
+    delete process.env['TELEGRAM_PROTOCOL_STACK']
+    clearConfigCacheForTest()
+    clearEventsForTest()
+    resetTelegramChannelForTest()
+  })
+
+  it('defaults protocol stack to durable for rollback safety', () => {
+    expect(resolveTelegramProtocolStack({}, undefined)).toBe('durable')
+    expect(peekTelegramProtocolStack()).toBe('durable')
+    expect(getTelegramChannel()).toBe(telegramChannel)
+  })
+
+  it('selects monorepo stack from env override', () => {
+    process.env['OPEN_COWORK_TELEGRAM_PROTOCOL_STACK'] = 'monorepo'
+    resetTelegramChannelForTest()
+    expect(resolveTelegramProtocolStack(process.env)).toBe('monorepo')
+    const adapter = getTelegramChannel()
+    expect(adapter).not.toBe(telegramChannel)
+    expect(adapter.name).toBe('telegram')
+    expect(adapter.capabilities.provider).toBe('telegram')
+  })
+
+  it('selects monorepo stack from config when env unset', () => {
+    updateConfig({ channels: { telegram: { protocolStack: 'monorepo' } } } as any)
+    resetTelegramChannelForTest()
+    expect(peekTelegramProtocolStack()).toBe('monorepo')
+    expect(getTelegramChannel()).not.toBe(telegramChannel)
+  })
+
+  it('env durable forces legacy even when config says monorepo', () => {
+    updateConfig({ channels: { telegram: { protocolStack: 'monorepo' } } } as any)
+    process.env['OPEN_COWORK_TELEGRAM_PROTOCOL_STACK'] = 'durable'
+    resetTelegramChannelForTest()
+    expect(peekTelegramProtocolStack()).toBe('durable')
+    expect(getTelegramChannel()).toBe(telegramChannel)
+  })
+
+  it('maps monorepo IncomingChannelMessage onto Durable ChannelMessage', () => {
+    const incoming: IncomingChannelMessage = {
+      id: 'in-1',
+      providerEventId: 'upd-9',
+      providerMessageId: '42',
+      provider: 'telegram',
+      target: { provider: 'telegram', chatId: 'chat-7', threadId: 'topic-1', userId: null, messageId: null },
+      sender: { providerUserId: 'user-3', username: 'alice' },
+      text: '/status',
+      rawText: '/status',
+      isCommand: true,
+      command: 'status',
+      commandArgs: '',
+      attachments: [{ filename: 'note.txt', mimeType: 'text/plain', providerFileId: 'file-1' }],
+      receivedAt: new Date('2026-07-24T00:00:00.000Z'),
+      raw: {},
+    }
+    const mapped = __telegramMonorepoTest.mapIncomingToDurableMessage(incoming)
+    expect(mapped).toEqual({
+      provider: 'telegram',
+      chatId: 'chat-7',
+      threadId: 'topic-1',
+      messageId: '42',
+      userId: 'user-3',
+      text: '/status',
+      attachments: [{ name: 'note.txt', url: '', mimeType: 'text/plain' }],
+      timestamp: '2026-07-24T00:00:00.000Z',
+    })
+  })
+
+  it('shared inbound policy rejects untrusted free text and accepts claim codes', async () => {
+    const handled: ChannelMessage[] = []
+    const untrusted: ChannelMessage = {
+      provider: 'telegram',
+      chatId: 'untrusted-chat',
+      userId: 'u1',
+      text: 'hello free text',
+      timestamp: new Date().toISOString(),
+    }
+    await processDurableTelegramInbound(untrusted, {
+      deliver: async (msg) => { handled.push(msg) },
+    })
+    expect(handled).toEqual([])
+    expect(getQueuedEvents().join('\n')).toMatch(/rejected untrusted inbound/i)
+
+    clearEventsForTest()
+    const claim = createChannelClaimCode({ provider: 'telegram', ttlMs: 60_000 })
+    const claimMsg: ChannelMessage = {
+      provider: 'telegram',
+      chatId: 'claim-chat',
+      userId: 'u2',
+      text: claim.code,
+      timestamp: new Date().toISOString(),
+    }
+    await processDurableTelegramInbound(claimMsg, {
+      deliver: async (msg) => { handled.push(msg) },
+    })
+    expect(handled).toEqual([])
+    expect(getQueuedEvents().join('\n')).toMatch(/claim accepted/i)
+  })
+})

--- a/products/gateway/src/channels/telegram-inbound-policy.ts
+++ b/products/gateway/src/channels/telegram-inbound-policy.ts
@@ -1,0 +1,75 @@
+/**
+ * Durable product policy for Telegram inbound (trust, claims, denial probes).
+ * Shared by the legacy Durable poll loop and the monorepo-provider façade
+ * (JOE-994 Phase 2) so protocol transport can change without forking policy.
+ */
+import type { ChannelMessage } from './provider.js'
+import { getConfig } from '../config.js'
+import { queueEvent } from '../wakeup.js'
+import { appendChannelInboundDenialAudit } from '../channel-audit.js'
+import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
+import { isPreTrustChannelCommandText } from '../channel-commands.js'
+import { isTrustedChannelTarget, redactedChannelTargetLabel } from '../security.js'
+
+export type TelegramInboundDelivery = {
+  /** Final delivery into the gateway session pipeline (after policy accepts). */
+  deliver: (msg: ChannelMessage) => Promise<void>
+  /**
+   * Optional typing wrapper (legacy uses sendChatAction heartbeat; monorepo
+   * path can use TelegramProvider.setTyping).
+   */
+  withTyping?: (msg: ChannelMessage, task: () => Promise<void>) => Promise<void>
+}
+
+/**
+ * Apply Durable Telegram inbound policy, then deliver accepted messages.
+ * Returns without calling deliver when the message is a claim/probe/denial.
+ */
+export async function processDurableTelegramInbound(
+  msg: ChannelMessage,
+  delivery: TelegramInboundDelivery,
+): Promise<void> {
+  const chatId = msg.chatId
+  const threadId = msg.threadId
+  const denialProbe = acceptChannelDenialProbeFromMessage(msg)
+  if (denialProbe.status === 'accepted') {
+    queueEvent(`Telegram denial probe accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
+    return
+  }
+  if (denialProbe.status === 'denied') return
+  if (!isTrustedChannelTarget('telegram', chatId, threadId, getConfig())) {
+    const claim = acceptChannelClaimFromMessage(msg)
+    if (claim.status === 'accepted') {
+      queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
+      return
+    }
+    if (claim.status === 'denied') return
+    if (isPreTrustChannelCommandText(msg.text)) {
+      await delivery.deliver(msg)
+      return
+    }
+    const target = redactedChannelTargetLabel('telegram', chatId, threadId)
+    queueEvent(`Telegram rejected untrusted inbound: ${target}`)
+    safeAuditInboundDenial('telegram', chatId, threadId)
+    return
+  }
+  // A valid claim code from an already-trusted target heals allowlist rules
+  // created before per-sender actor policies existed by merging the claimant
+  // into the rule's userIds (see addTrustedTarget in channel-claims).
+  const trustedClaim = acceptChannelClaimFromMessage(msg)
+  if (trustedClaim.status === 'accepted') {
+    queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
+    return
+  }
+  if (trustedClaim.status === 'denied') return
+
+  if (delivery.withTyping) {
+    await delivery.withTyping(msg, () => delivery.deliver(msg))
+    return
+  }
+  await delivery.deliver(msg)
+}
+
+function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
+  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
+}

--- a/products/gateway/src/channels/telegram-monorepo-adapter.ts
+++ b/products/gateway/src/channels/telegram-monorepo-adapter.ts
@@ -1,0 +1,240 @@
+/**
+ * JOE-994 Phase 2: Durable ChannelAdapter façade over monorepo
+ * `@open-cowork/gateway-provider-telegram`.
+ *
+ * Transport/protocol lives in the monorepo provider; Durable product policy
+ * (trust, claims, denial probes) stays in `telegram-inbound-policy.ts`.
+ *
+ * Default path remains the legacy Durable adapter (`telegram.ts`). Enable this
+ * façade via `channels.telegram.protocolStack: "monorepo"` or
+ * `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK=monorepo`.
+ *
+ * Residuals (documented, not regressions of the default path):
+ * - Poll offset is grammy/process-local (not HA operational-sidecar cursor).
+ * - Rich/structured Telegram HTML payload falls back to plain/markdown text.
+ * - Native setMyCommands registration is not mirrored (slash text still works).
+ */
+import { TelegramProvider } from '@open-cowork/gateway-provider-telegram'
+import type { IncomingChannelMessage } from '@open-cowork/gateway-channel'
+import type { ChannelAdapter, ChannelMessage } from './provider.js'
+import {
+  createStructuredMessage,
+  renderStructuredMessage,
+  type ChannelCapabilities,
+} from './renderer.js'
+import { telegramAdapterCapabilities } from './capabilities.js'
+import { getConfig } from '../config.js'
+import { queueEvent } from '../wakeup.js'
+import { processDurableTelegramInbound } from './telegram-inbound-policy.js'
+import { CHANNEL_ACTION_TYPING_HEARTBEAT_MS, CHANNEL_ACTION_TYPING_TIMEOUT_MS } from '../channel-actions.js'
+
+function getToken(): string {
+  return process.env['TELEGRAM_BOT_TOKEN'] || getConfig().channels.telegram.botToken || ''
+}
+
+function telegramCapabilities(): ChannelCapabilities {
+  const config = getConfig()
+  const richEnabled = config.channels.richMessages.enabled !== false && config.channels.telegram.richMessages?.enabled !== false
+  return telegramAdapterCapabilities({ richMessagesEnabled: richEnabled })
+}
+
+function mapIncomingToDurableMessage(incoming: IncomingChannelMessage): ChannelMessage {
+  const attachments = (incoming.attachments || []).map((a) => ({
+    name: a.filename || a.providerFileId || 'attachment',
+    url: a.downloadUrl || '',
+    mimeType: a.mimeType || 'application/octet-stream',
+  }))
+  return {
+    provider: 'telegram',
+    chatId: incoming.target.chatId,
+    threadId: incoming.target.threadId ?? undefined,
+    messageId: incoming.providerMessageId || incoming.providerEventId || incoming.id,
+    userId: incoming.sender.providerUserId,
+    text: incoming.text || incoming.rawText || '',
+    attachments,
+    timestamp: (incoming.receivedAt instanceof Date ? incoming.receivedAt : new Date()).toISOString(),
+  }
+}
+
+function chunkText(text: string, size: number): string[] {
+  const chunks: string[] = []
+  for (let i = 0; i < text.length; i += size) {
+    chunks.push(text.substring(i, size + i))
+  }
+  return chunks.length ? chunks : ['']
+}
+
+export function createTelegramMonorepoChannelAdapter(): ChannelAdapter {
+  let handler: ((msg: ChannelMessage) => Promise<void>) | null = null
+  let provider: TelegramProvider | null = null
+  let lastTypingFailureEventAt = 0
+
+  const adapter: ChannelAdapter = {
+    name: 'telegram',
+    get capabilities() {
+      return telegramCapabilities()
+    },
+
+    async start() {
+      const token = getToken()
+      if (!token) {
+        console.error('[telegram] bot token not set — monorepo façade disabled')
+        return
+      }
+      if (provider) return
+
+      queueEvent('Telegram monorepo protocol stack enabled (JOE-994 Phase 2 façade)')
+      const next = new TelegramProvider({
+        botToken: token,
+        mode: 'polling',
+        // Durable policy is the trust gate; monorepo must not pre-filter group traffic.
+        respondInGroups: 'all',
+        observeUnmentionedGroupMessages: true,
+      })
+      provider = next
+
+      try {
+        await next.start(async (incoming) => {
+          if (!handler) return
+          const msg = mapIncomingToDurableMessage(incoming)
+          await processDurableTelegramInbound(msg, {
+            deliver: (accepted) => handler!(accepted),
+            withTyping: async (accepted, task) => {
+              await withMonorepoTyping(next, accepted, task, () => {
+                const now = Date.now()
+                if (now - lastTypingFailureEventAt < 60_000) return
+                lastTypingFailureEventAt = now
+              })
+            },
+          })
+        })
+        const health = next.health?.()
+        if (health && health.ok === false) {
+          queueEvent(`Telegram monorepo provider degraded: ${health.error || 'unknown'}`)
+        } else {
+          queueEvent('Telegram channel ready via monorepo provider (polling)')
+        }
+      } catch (err: unknown) {
+        provider = null
+        const detail = err instanceof Error ? err.message : String(err)
+        console.error(`[telegram] monorepo façade startup failed: ${detail}`)
+        queueEvent(`Telegram monorepo façade startup failed: ${detail}`)
+      }
+    },
+
+    async stop() {
+      const current = provider
+      provider = null
+      if (current) {
+        try {
+          await current.stop()
+        } catch (err: unknown) {
+          const detail = err instanceof Error ? err.message : String(err)
+          queueEvent(`Telegram monorepo façade stop failed: ${detail}`)
+        }
+      }
+    },
+
+    async sendMessage(chatId, text, options) {
+      const active = requireProvider(provider)
+      const limit = Math.max(1, Math.min(active.capabilities.maxTextLength || 4096, 4000))
+      for (const part of chunkText(text, limit)) {
+        await active.sendText(
+          {
+            provider: 'telegram',
+            chatId,
+            threadId: options?.threadId ?? null,
+            userId: null,
+            messageId: null,
+          },
+          part,
+          options?.idempotencyKey ? { deliveryId: options.idempotencyKey } : undefined,
+        )
+      }
+    },
+
+    async sendStructuredMessage(chatId, message, options) {
+      const capabilities = telegramCapabilities()
+      const rendered = renderStructuredMessage(message, capabilities)
+      const text = rendered.markdown || rendered.plainText || rendered.text || message.summary || message.title || ''
+      await adapter.sendMessage(chatId, text, options)
+    },
+
+    async sendCommandMenu(chatId, text, actions, options) {
+      const message = createStructuredMessage({
+        kind: 'status',
+        title: 'Gateway Commands',
+        summary: text,
+        blocks: [
+          { type: 'heading', text: 'Gateway Commands', level: 2 },
+          { type: 'text', text },
+          {
+            type: 'facts',
+            facts: actions.slice(0, 12).map((action) => ({
+              label: action.label,
+              value: action.description || action.command,
+            })),
+          },
+        ],
+        actions: actions.map((action) => ({ label: action.label, command: action.command })),
+      })
+      await adapter.sendStructuredMessage?.(chatId, message, options)
+    },
+
+    onMessage(h) {
+      handler = h
+    },
+  }
+
+  return adapter
+}
+
+function requireProvider(provider: TelegramProvider | null): TelegramProvider {
+  if (!provider) {
+    throw new Error('Telegram monorepo provider is not started')
+  }
+  return provider
+}
+
+async function withMonorepoTyping(
+  provider: TelegramProvider,
+  msg: ChannelMessage,
+  task: () => Promise<void>,
+  onFailureThrottle: () => void,
+): Promise<void> {
+  let active = true
+  const startedAt = Date.now()
+  const target = {
+    provider: 'telegram' as const,
+    chatId: msg.chatId,
+    threadId: msg.threadId ?? null,
+    userId: null,
+    messageId: null,
+  }
+  const send = () =>
+    provider.setTyping?.(target).catch((err: unknown) => {
+      onFailureThrottle()
+      const detail = err instanceof Error ? err.message : String(err)
+      queueEvent(`Telegram typing feedback degraded: ${detail}`)
+    })
+  await send()
+  const timer = setInterval(() => {
+    if (!active) return
+    if (Date.now() - startedAt >= CHANNEL_ACTION_TYPING_TIMEOUT_MS) {
+      clearInterval(timer)
+      return
+    }
+    void send()
+  }, CHANNEL_ACTION_TYPING_HEARTBEAT_MS)
+  try {
+    await task()
+  } finally {
+    active = false
+    clearInterval(timer)
+  }
+}
+
+/** Test helper: pure inbound mapping without starting grammy. */
+export const __telegramMonorepoTest = {
+  mapIncomingToDurableMessage,
+}

--- a/products/gateway/src/channels/telegram-protocol-stack.ts
+++ b/products/gateway/src/channels/telegram-protocol-stack.ts
@@ -1,0 +1,55 @@
+/**
+ * JOE-994 Phase 2: select Telegram protocol implementation.
+ *
+ * - `durable` (default): legacy products/gateway long-poll adapter
+ * - `monorepo`: thin façade over @open-cowork/gateway-provider-telegram
+ *
+ * Env overrides config for emergency rollback:
+ *   OPEN_COWORK_TELEGRAM_PROTOCOL_STACK=durable|monorepo
+ */
+import type { ChannelAdapter } from './provider.js'
+import { telegramChannel } from './telegram.js'
+import { createTelegramMonorepoChannelAdapter } from './telegram-monorepo-adapter.js'
+import { getConfig } from '../config.js'
+
+export type TelegramProtocolStack = 'durable' | 'monorepo'
+
+let cachedAdapter: ChannelAdapter | null = null
+let cachedStack: TelegramProtocolStack | null = null
+
+export function resolveTelegramProtocolStack(
+  env: NodeJS.ProcessEnv = process.env,
+  configStack?: string | undefined,
+): TelegramProtocolStack {
+  const rawEnv = (env['OPEN_COWORK_TELEGRAM_PROTOCOL_STACK'] || env['TELEGRAM_PROTOCOL_STACK'] || '').trim().toLowerCase()
+  if (rawEnv === 'monorepo' || rawEnv === 'shared' || rawEnv === 'gateway-provider' || rawEnv === 'provider') {
+    return 'monorepo'
+  }
+  if (rawEnv === 'durable' || rawEnv === 'legacy' || rawEnv === 'classic') {
+    return 'durable'
+  }
+  const fromConfig = (configStack || '').trim().toLowerCase()
+  if (fromConfig === 'monorepo') return 'monorepo'
+  return 'durable'
+}
+
+/**
+ * Resolve the Telegram ChannelAdapter for daemon wiring.
+ * Cached for process lifetime; call resetTelegramChannelForTest in tests.
+ */
+export function getTelegramChannel(): ChannelAdapter {
+  const stack = resolveTelegramProtocolStack(process.env, getConfig().channels.telegram.protocolStack)
+  if (cachedAdapter && cachedStack === stack) return cachedAdapter
+  cachedStack = stack
+  cachedAdapter = stack === 'monorepo' ? createTelegramMonorepoChannelAdapter() : telegramChannel
+  return cachedAdapter
+}
+
+export function peekTelegramProtocolStack(): TelegramProtocolStack {
+  return resolveTelegramProtocolStack(process.env, getConfig().channels.telegram.protocolStack)
+}
+
+export function resetTelegramChannelForTest(): void {
+  cachedAdapter = null
+  cachedStack = null
+}

--- a/products/gateway/src/channels/telegram.ts
+++ b/products/gateway/src/channels/telegram.ts
@@ -23,12 +23,10 @@ import {
 } from '../operational-sidecar-store.js'
 import { queueEvent } from '../wakeup.js'
 import { appendWorkEvent, listRecentWorkEvents } from '../work-store.js'
-import { appendChannelInboundDenialAudit } from '../channel-audit.js'
-import { isTransientInboundError, isTrustedChannelTarget, redactedChannelTargetLabel, redactSensitiveText } from '../security.js'
-import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
-import { isPreTrustChannelCommandText } from '../channel-commands.js'
+import { isTransientInboundError, redactSensitiveText } from '../security.js'
 import { CHANNEL_ACTION_TYPING_HEARTBEAT_MS, CHANNEL_ACTION_TYPING_TIMEOUT_MS, telegramNativeSlashCommandManifest } from '../channel-actions.js'
 import { fetchWithTimeout } from '../deadlines.js'
+import { processDurableTelegramInbound } from './telegram-inbound-policy.js'
 
 let handler: ((msg: ChannelMessage) => Promise<void>) | null = null
 let polling = false
@@ -371,47 +369,17 @@ async function handleTelegramInboundMessage(update: any, rawMessage: any, text: 
     attachments: [],
     timestamp: new Date(timestampSeconds * 1000).toISOString(),
   }
-  const denialProbe = acceptChannelDenialProbeFromMessage(msg)
-  if (denialProbe.status === 'accepted') {
-    queueEvent(`Telegram denial probe accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-    return
-  }
-  if (denialProbe.status === 'denied') return
-  if (!isTrustedChannelTarget('telegram', chatId, threadId, getConfig())) {
-    const claim = acceptChannelClaimFromMessage(msg)
-    if (claim.status === 'accepted') {
-      queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-      return
-    }
-    if (claim.status === 'denied') return
-    if (isPreTrustChannelCommandText(msg.text)) {
-      await inboundHandler(msg)
-      return
-    }
-    const target = redactedChannelTargetLabel('telegram', chatId, threadId)
-    queueEvent(`Telegram rejected untrusted inbound: ${target}`)
-    safeAuditInboundDenial('telegram', chatId, threadId)
-    return
-  }
-  // A valid claim code from an already-trusted target heals allowlist rules
-  // created before per-sender actor policies existed by merging the claimant
-  // into the rule's userIds (see addTrustedTarget in channel-claims).
-  const trustedClaim = acceptChannelClaimFromMessage(msg)
-  if (trustedClaim.status === 'accepted') {
-    queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-    return
-  }
-  if (trustedClaim.status === 'denied') return
-  const token = getToken()
-  if (!token) {
-    await inboundHandler(msg)
-    return
-  }
-  await withTelegramTyping(getApi(token), chatId, threadId, () => inboundHandler(msg))
-}
-
-function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
-  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
+  await processDurableTelegramInbound(msg, {
+    deliver: (accepted) => inboundHandler(accepted),
+    withTyping: async (accepted, task) => {
+      const token = getToken()
+      if (!token) {
+        await task()
+        return
+      }
+      await withTelegramTyping(getApi(token), accepted.chatId, accepted.threadId, task)
+    },
+  })
 }
 
 async function registerTelegramCommands(api: string): Promise<void> {

--- a/products/gateway/src/config-schema.ts
+++ b/products/gateway/src/config-schema.ts
@@ -221,7 +221,12 @@ const zScheduler = z.object({
 
 const zChannels = z.object({
   richMessages: z.object({ enabled: zBoolean }),
-  telegram: z.object({ botToken: zString.optional(), richMessages: z.object({ enabled: zBoolean }).optional() }),
+  telegram: z.object({
+    botToken: zString.optional(),
+    richMessages: z.object({ enabled: zBoolean }).optional(),
+    /** JOE-994 Phase 2: durable (default) | monorepo provider façade. Env OPEN_COWORK_TELEGRAM_PROTOCOL_STACK overrides. */
+    protocolStack: z.enum(['durable', 'monorepo']).optional(),
+  }),
   whatsapp: zStringRecord(z.unknown()),
   discord: z.object({
     enabled: zBoolean,

--- a/products/gateway/src/config.ts
+++ b/products/gateway/src/config.ts
@@ -333,7 +333,12 @@ export interface GatewayConfig {
   }
   channels: {
     richMessages: { enabled: boolean }
-    telegram: { botToken?: string; richMessages?: { enabled: boolean } }
+    telegram: {
+      botToken?: string
+      richMessages?: { enabled: boolean }
+      /** JOE-994 Phase 2: `durable` (default) or monorepo `@open-cowork/gateway-provider-telegram` façade. */
+      protocolStack?: 'durable' | 'monorepo'
+    }
     whatsapp: {
       setupMode?: 'cloudApiDirect'
       accessToken?: string
@@ -901,6 +906,7 @@ function normalizeChannelsConfig(input: Partial<GatewayConfig['channels']> | und
     telegram: {
       botToken: normalizeOptionalText(input?.telegram?.botToken, 4096),
       richMessages: { enabled: input?.telegram?.richMessages?.enabled !== false },
+      protocolStack: normalizeTelegramProtocolStack(input?.telegram?.protocolStack),
     },
     whatsapp: {
       setupMode: normalizeWhatsAppSetupMode(input?.whatsapp?.setupMode, 'channels.whatsapp.setupMode'),
@@ -996,6 +1002,12 @@ function normalizeWhatsAppSetupMode(input: unknown, label: string): GatewayConfi
   if (input === undefined || input === null || input === '') return undefined
   if (input === 'cloudApiDirect') return input
   throw new Error(`${label} must be cloudApiDirect`)
+}
+
+function normalizeTelegramProtocolStack(input: unknown): GatewayConfig['channels']['telegram']['protocolStack'] {
+  if (input === undefined || input === null || input === '') return undefined
+  if (input === 'durable' || input === 'monorepo') return input
+  throw new Error('channels.telegram.protocolStack must be durable or monorepo')
 }
 
 function normalizeAgentTeams(input: Record<string, Partial<AgentTeamConfig>>, scheduler: GatewayConfig['scheduler'], profiles: Record<string, AgentProfile>): Record<string, AgentTeamConfig> {

--- a/products/gateway/src/daemon.ts
+++ b/products/gateway/src/daemon.ts
@@ -8,7 +8,7 @@ import { setDaemonClient } from './gateway-runtime.js'
 import { trackWorker, loadWorkerState, reconcileWorkersFromOpenCode } from './workers.js'
 import { renderDashboard } from './dashboard.js'
 import { subscribeToOpenCodeEvents, addLiveClient, closeAllLiveClients, removeLiveClient } from './live.js'
-import { telegramChannel } from './channels/telegram.js'
+import { getTelegramChannel } from './channels/telegram-protocol-stack.js'
 import { whatsappChannel } from './channels/whatsapp.js'
 import { discordChannel } from './channels/discord.js'
 import { claimInboundWebhookRateLimit, inboundWebhookRateKey, noteInboundWebhookAuthFailure } from './channels/webhook-rate-limit.js'
@@ -112,6 +112,8 @@ export async function serve() {
   // Start heartbeat for Gateway session monitoring
   startHeartbeat()
 
+  // JOE-994 Phase 2: Telegram may be legacy Durable or monorepo-provider façade.
+  const telegramChannel = getTelegramChannel()
   const channelByName = new Map([
     [telegramChannel.name, telegramChannel],
     [whatsappChannel.name, whatsappChannel],

--- a/scripts/check-channel-protocol-inventory.mjs
+++ b/scripts/check-channel-protocol-inventory.mjs
@@ -41,6 +41,17 @@ for (const name of ['telegram.ts', 'whatsapp.ts', 'discord.ts', 'provider.ts']) 
   mustExist(`products/gateway/src/channels/${name}`)
 }
 
+// JOE-994 Phase 2: Telegram monorepo façade + stack selector + shared policy
+for (const name of [
+  'telegram-monorepo-adapter.ts',
+  'telegram-protocol-stack.ts',
+  'telegram-inbound-policy.ts',
+]) {
+  mustExist(`products/gateway/src/channels/${name}`)
+}
+mustContain('docs/product-channel-protocol-unification.md', 'Phase 2')
+mustContain('docs/product-channel-ownership.md', 'Telegram monorepo façade')
+
 // Monorepo provider packages (at least the production set)
 const providerRoot = mustExist('packages')
 const providers = readdirSync(providerRoot)


### PR DESCRIPTION
## Summary

JOE-994 **Phase 2**: Durable Telegram can compose monorepo `@open-cowork/gateway-provider-telegram` as a thin ChannelAdapter façade.

- Shared inbound product policy: `telegram-inbound-policy.ts` (trust/claims/denial probes)
- Monorepo façade: `telegram-monorepo-adapter.ts` (grammy provider transport)
- Stack selector: `telegram-protocol-stack.ts` + daemon wiring via `getTelegramChannel()`
- **Default remains durable** (rollback-safe). Opt-in:
  - config `channels.telegram.protocolStack: "monorepo"`
  - env `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK=monorepo|durable`
- Docs + inventory guard updated for Phase 2 files

### Residuals (monorepo stack only)
- Poll offset is grammy/process-local (not HA operational-sidecar cursor)
- Rich HTML `sendRichMessage` falls back to plain/markdown text
- Native `setMyCommands` not mirrored (slash text still works)

WhatsApp/Discord protocol freeze retained. No multi-AZ HA marketing. Security kernels unchanged.

## Validation

- [x] `node scripts/check-channel-protocol-inventory.mjs`
- [x] `pnpm exec tsc --noEmit` (cowork-gateway)
- [x] vitest `telegram-monorepo-facade` + `telegram` + capabilities/renderer/boundaries
- [ ] full CI

## Dual-channel security checklist

- [ ] N/A — not a channel security/protocol change
- [x] Reviewed **monorepo providers** (`packages/gateway-provider-*`, `packages/gateway-channel`, `apps/channel-gateway`)
- [x] Reviewed **Durable Gateway channels** (`products/gateway/src/channels/*` and related security)
- [x] Shared primitives preferred (`@open-cowork/shared`, `gateway-channel`) over copy-paste
- [x] Both stacks fixed **or** explicit single-stack ownership noted in Notes with follow-up

## User-visible impact

- [x] No user-visible behavior change (default path)
- [ ] UI change
- [x] Runtime behavior change (only when monorepo stack enabled)
- [ ] Packaging / release change
- [x] Docs change

## Notes

- Dual-stack checklist: both stacks reviewed for Telegram composition; security verify kernels unchanged (still shared)
- Default path is legacy Durable adapter; monorepo is opt-in with env/config rollback
- Phase 3 still open for WhatsApp/Discord + residual gaps above

Linear: JOE-994