### PR TITLE
feat(joe-994): Phase 3 Discord/WhatsApp monorepo bridge façades

### DIFF
--- a/.github/workflows/ci-gateway.yml
+++ b/.github/workflows/ci-gateway.yml
@@ -7,6 +7,9 @@ on:
       - 'packages/shared/**'
       - 'packages/gateway-channel/**'
       - 'packages/gateway-provider-telegram/**'
+      - 'packages/gateway-provider-discord/**'
+      - 'packages/gateway-provider-whatsapp/**'
+      - 'packages/gateway-provider-webhook/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-gateway.yml'
       - 'scripts/check-product-boundaries.mjs'
@@ -17,6 +20,9 @@ on:
       - 'packages/shared/**'
       - 'packages/gateway-channel/**'
       - 'packages/gateway-provider-telegram/**'
+      - 'packages/gateway-provider-discord/**'
+      - 'packages/gateway-provider-whatsapp/**'
+      - 'packages/gateway-provider-webhook/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/ci-gateway.yml'
 
@@ -46,9 +52,12 @@ jobs:
       - name: Product boundaries
         run: pnpm boundaries:check
 
-      # products/gateway depends on dist-only workspace packages (shared + Telegram stack).
+      # products/gateway depends on dist-only workspace channel packages (JOE-994).
       - name: Build workspace channel packages
-        run: pnpm --filter @open-cowork/gateway-provider-telegram build
+        run: |
+          pnpm --filter @open-cowork/gateway-provider-telegram build
+          pnpm --filter @open-cowork/gateway-provider-discord build
+          pnpm --filter @open-cowork/gateway-provider-whatsapp build
 
       - name: Build Gateway
         run: pnpm --filter cowork-gateway build

--- a/.github/workflows/release-gateway.yml
+++ b/.github/workflows/release-gateway.yml
@@ -45,7 +45,10 @@ jobs:
         run: pnpm boundaries:check
 
       - name: Build workspace channel packages
-        run: pnpm --filter @open-cowork/gateway-provider-telegram build
+        run: |
+          pnpm --filter @open-cowork/gateway-provider-telegram build
+          pnpm --filter @open-cowork/gateway-provider-discord build
+          pnpm --filter @open-cowork/gateway-provider-whatsapp build
 
       - name: Build
         run: pnpm --filter cowork-gateway build

--- a/.github/workflows/weekly-gateway.yml
+++ b/.github/workflows/weekly-gateway.yml
@@ -44,7 +44,10 @@ jobs:
 
       # products/gateway depends on @open-cowork/shared (dist-only package exports).
       - name: Build shared workspace package
-        run: pnpm --filter @open-cowork/gateway-provider-telegram build
+        run: |
+          pnpm --filter @open-cowork/gateway-provider-telegram build
+          pnpm --filter @open-cowork/gateway-provider-discord build
+          pnpm --filter @open-cowork/gateway-provider-whatsapp build
 
       - name: Build Gateway
         run: pnpm --filter cowork-gateway build

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 Open Cowork includes third-party open source packages in its production dependency graph. This file is generated from `pnpm list --prod --recursive` and the installed package manifests.
 
 Generation provenance:
-- pnpm lockfile SHA-256: `4a36f27fe4ff1a89b49b033e49cf332220e054a1d2b610a6cf6d6f1af47b2fa5`
+- pnpm lockfile SHA-256: `e490caa69177d456639f841a8ce85683d70049fd399c843dba9f470ae67f0df1`
 - Production package entries: 403
 - Bundled license directories: 388 (15 package entries have no standalone license file or are workspace links)
 

--- a/docs/product-channel-ownership.md
+++ b/docs/product-channel-ownership.md
@@ -9,7 +9,7 @@
 | Layer | Status | Meaning |
 | --- | --- | --- |
 | **Security body** (signature verify, Meta/Discord/Telegram/Slack kernels, rate-limit algorithm) | **Done** | Shared; dual-fix checklist still required for security PRs |
-| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Partial Phase 2 (Telegram opt-in)** | Telegram can compose monorepo provider behind `channels.telegram.protocolStack=monorepo` (default remains Durable legacy). **Intentional residual freeze** for WhatsApp/Discord. |
+| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Phase 2–3 opt-in façades** | Telegram native monorepo provider; Discord/WhatsApp monorepo **bridge** façades. Defaults remain Durable native. **Intentional residual freeze** on decommissioning native adapters until monorepo is default. |
 
 ## Two stacks (intentional)
 
@@ -41,20 +41,23 @@ ready — **do not re-open as incomplete dual-stack security P1**.
 ([JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)).
 Inventory guard: `node scripts/check-channel-protocol-inventory.mjs`.
 
-### Telegram monorepo façade (JOE-994 Phase 2)
+### Protocol stack façades (JOE-994 Phase 2–3)
 
-| Setting | Effect |
-| --- | --- |
-| `channels.telegram.protocolStack: "durable"` (default) | Legacy Durable long-poll in `channels/telegram.ts` |
-| `channels.telegram.protocolStack: "monorepo"` | Thin façade over `@open-cowork/gateway-provider-telegram` |
-| `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK=durable\|monorepo` | Process env override (rollback / canary) |
+| Channel | Setting | Monorepo meaning |
+| --- | --- | --- |
+| Telegram | `channels.telegram.protocolStack` / `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK` | Native grammy provider (`gateway-provider-telegram`) |
+| Discord | `channels.discord.protocolStack` / `OPEN_COWORK_DISCORD_PROTOCOL_STACK` | Webhook **bridge** (`gateway-provider-discord`); needs `bridgeDeliveryUrl` + `bridgeSharedSecret` |
+| WhatsApp | `channels.whatsapp.protocolStack` / `OPEN_COWORK_WHATSAPP_PROTOCOL_STACK` | Webhook **bridge** (`gateway-provider-whatsapp`); needs bridge URL + secret |
+
+Defaults are **`durable`** (native Durable adapters). Env overrides config for
+rollback/canary.
 
 Durable product policy (trust allowlists, claims, denial probes) is shared via
-`channels/telegram-inbound-policy.ts` on both stacks. Security kernels remain
-in `@open-cowork/shared/node`.
+`channels/channel-inbound-policy.ts` on all stacks. Security kernels remain in
+`@open-cowork/shared/node`.
 
-Until WhatsApp/Discord compose monorepo providers, this freeze document remains
-the source of truth for dual-stack ownership on those channels.
+Native adapter decommission is still residual until monorepo (or bridge relays)
+are product-default.
 
 ### Shared security kernel (2026-07-21)
 

--- a/docs/product-channel-protocol-unification.md
+++ b/docs/product-channel-protocol-unification.md
@@ -1,6 +1,6 @@
 # Dual-stack channel protocol unification (JOE-994)
 
-**Status:** Capacity epic — **Phase 2 Telegram opt-in façade shipped**; WhatsApp/Discord **protocol freeze retained**
+**Status:** Capacity epic — **Phase 2–3 opt-in façades shipped** (Telegram native monorepo; Discord/WhatsApp bridge); native decommission residual; **protocol freeze retained** for default paths
 **Security body:** Done (shared kernels + dual-stack checklist / CI gate)
 **Linear:** [JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)
 **Freeze source of truth:** [`product-channel-ownership.md`](product-channel-ownership.md)
@@ -88,9 +88,20 @@ native `setMyCommands` registration is not mirrored. Default path unchanged.
 
 ### Phase 3 — Remaining channels + decommission
 
-- [ ] Migrate remaining Durable channels
-- [ ] Remove or archive duplicate protocol code
-- [ ] Update freeze doc to “unified” with residual notes
+- [x] Migrate remaining Durable channels (opt-in monorepo façades)
+  - Discord + WhatsApp bridge façades over `gateway-provider-discord` /
+    `gateway-provider-whatsapp` (WebhookProvider bridge mode)
+  - Shared inbound policy: `channel-inbound-policy.ts` (all three providers)
+  - Defaults remain **durable native**; monorepo requires bridge credentials
+- [x] Protocol stack selectors + daemon channel-map wiring for webhook routes
+- [ ] Remove or archive duplicate **native** protocol code (only after monorepo
+  becomes default / bridge relays are product-standard)
+- [x] Update freeze/ownership docs with residual notes (bridge ≠ native)
+
+**Residuals (monorepo Discord/WhatsApp only):** bridge-mode only (relay must
+verify native platform signatures); not a drop-in for Meta/Discord interaction
+URLs pointed at Gateway; structured rich payloads degrade to text on bridge
+outbound.
 
 ## Non-goals
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,9 +709,15 @@ importers:
       '@open-cowork/gateway-channel':
         specifier: workspace:*
         version: link:../../packages/gateway-channel
+      '@open-cowork/gateway-provider-discord':
+        specifier: workspace:*
+        version: link:../../packages/gateway-provider-discord
       '@open-cowork/gateway-provider-telegram':
         specifier: workspace:*
         version: link:../../packages/gateway-provider-telegram
+      '@open-cowork/gateway-provider-whatsapp':
+        specifier: workspace:*
+        version: link:../../packages/gateway-provider-whatsapp
       '@open-cowork/shared':
         specifier: workspace:*
         version: link:../../packages/shared

--- a/products/gateway/package.json
+++ b/products/gateway/package.json
@@ -54,7 +54,9 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@open-cowork/gateway-channel": "workspace:*",
+    "@open-cowork/gateway-provider-discord": "workspace:*",
     "@open-cowork/gateway-provider-telegram": "workspace:*",
+    "@open-cowork/gateway-provider-whatsapp": "workspace:*",
     "@open-cowork/shared": "workspace:*",
     "@opencode-ai/sdk": "1.18.1",
     "zod": "^4.4.3"

--- a/products/gateway/scripts/pack-standalone.mjs
+++ b/products/gateway/scripts/pack-standalone.mjs
@@ -27,7 +27,10 @@ const packDestination = path.resolve(process.argv[2] || path.join(productRoot, '
 const WORKSPACE_VENDOR_PACKAGES = [
   { name: '@open-cowork/shared', dir: 'shared' },
   { name: '@open-cowork/gateway-channel', dir: 'gateway-channel' },
+  { name: '@open-cowork/gateway-provider-webhook', dir: 'gateway-provider-webhook' },
   { name: '@open-cowork/gateway-provider-telegram', dir: 'gateway-provider-telegram' },
+  { name: '@open-cowork/gateway-provider-discord', dir: 'gateway-provider-discord' },
+  { name: '@open-cowork/gateway-provider-whatsapp', dir: 'gateway-provider-whatsapp' },
 ]
 
 function fail(message) {
@@ -59,6 +62,8 @@ const pkg = JSON.parse(fs.readFileSync(path.join(productRoot, 'package.json'), '
 
 // Build monorepo channel stack then Durable Gateway dist.
 run('pnpm', ['--filter', '@open-cowork/gateway-provider-telegram', 'build'], { cwd: monorepoRoot })
+run('pnpm', ['--filter', '@open-cowork/gateway-provider-discord', 'build'], { cwd: monorepoRoot })
+run('pnpm', ['--filter', '@open-cowork/gateway-provider-whatsapp', 'build'], { cwd: monorepoRoot })
 run('pnpm', ['--filter', 'cowork-gateway', 'build'], { cwd: monorepoRoot })
 
 for (const entry of WORKSPACE_VENDOR_PACKAGES) {

--- a/products/gateway/src/__tests__/channel-phase3-facades.test.ts
+++ b/products/gateway/src/__tests__/channel-phase3-facades.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { clearConfigCacheForTest, updateConfig } from '../config.js'
+import { clearEventsForTest, getQueuedEvents } from '../wakeup.js'
+import { processDurableChannelInbound } from '../channels/channel-inbound-policy.js'
+import {
+  getDiscordChannel,
+  peekDiscordProtocolStack,
+  resetDiscordChannelForTest,
+  resolveDiscordProtocolStack,
+} from '../channels/discord-protocol-stack.js'
+import {
+  getWhatsAppChannel,
+  peekWhatsAppProtocolStack,
+  resetWhatsAppChannelForTest,
+  resolveWhatsAppProtocolStack,
+} from '../channels/whatsapp-protocol-stack.js'
+import { discordChannel } from '../channels/discord.js'
+import { whatsappChannel } from '../channels/whatsapp.js'
+import type { ChannelMessage } from '../channels/provider.js'
+import { createChannelClaimCode } from '../channel-claims.js'
+
+describe('JOE-994 Phase 3 discord/whatsapp façades + shared inbound policy', () => {
+  const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-gateway-phase3-'))
+
+  beforeEach(() => {
+    process.env['OPENCODE_GATEWAY_CONFIG_DIR'] = testDir
+    process.env['OPENCODE_GATEWAY_STATE_DIR'] = testDir
+    delete process.env['OPEN_COWORK_DISCORD_PROTOCOL_STACK']
+    delete process.env['OPEN_COWORK_WHATSAPP_PROTOCOL_STACK']
+    if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true })
+    fs.mkdirSync(testDir, { recursive: true })
+    clearConfigCacheForTest()
+    clearEventsForTest()
+    resetDiscordChannelForTest()
+    resetWhatsAppChannelForTest()
+  })
+
+  afterEach(() => {
+    delete process.env['OPENCODE_GATEWAY_CONFIG_DIR']
+    delete process.env['OPENCODE_GATEWAY_STATE_DIR']
+    delete process.env['OPEN_COWORK_DISCORD_PROTOCOL_STACK']
+    delete process.env['OPEN_COWORK_WHATSAPP_PROTOCOL_STACK']
+    clearConfigCacheForTest()
+    clearEventsForTest()
+    resetDiscordChannelForTest()
+    resetWhatsAppChannelForTest()
+  })
+
+  it('defaults Discord and WhatsApp stacks to durable', () => {
+    expect(resolveDiscordProtocolStack({}, undefined)).toBe('durable')
+    expect(resolveWhatsAppProtocolStack({}, undefined)).toBe('durable')
+    expect(getDiscordChannel()).toBe(discordChannel)
+    expect(getWhatsAppChannel()).toBe(whatsappChannel)
+  })
+
+  it('selects monorepo Discord stack from env', () => {
+    process.env['OPEN_COWORK_DISCORD_PROTOCOL_STACK'] = 'monorepo'
+    resetDiscordChannelForTest()
+    expect(peekDiscordProtocolStack()).toBe('monorepo')
+    const adapter = getDiscordChannel()
+    expect(adapter).not.toBe(discordChannel)
+    expect(adapter.name).toBe('discord')
+  })
+
+  it('selects monorepo WhatsApp stack from config', () => {
+    updateConfig({ channels: { whatsapp: { protocolStack: 'monorepo' } } } as any)
+    resetWhatsAppChannelForTest()
+    expect(peekWhatsAppProtocolStack()).toBe('monorepo')
+    expect(getWhatsAppChannel()).not.toBe(whatsappChannel)
+  })
+
+  it('shared inbound policy works for discord and whatsapp labels', async () => {
+    const handled: ChannelMessage[] = []
+    await processDurableChannelInbound('discord', {
+      provider: 'discord',
+      chatId: 'untrusted',
+      userId: 'u1',
+      text: 'hello',
+      timestamp: new Date().toISOString(),
+    }, {
+      deliver: async (msg) => { handled.push(msg) },
+    })
+    expect(handled).toEqual([])
+    expect(getQueuedEvents().join('\n')).toMatch(/Discord rejected untrusted inbound/i)
+
+    clearEventsForTest()
+    const claim = createChannelClaimCode({ provider: 'whatsapp', ttlMs: 60_000 })
+    await processDurableChannelInbound('whatsapp', {
+      provider: 'whatsapp',
+      chatId: 'claim-chat',
+      userId: 'u2',
+      text: claim.code,
+      timestamp: new Date().toISOString(),
+    }, {
+      deliver: async (msg) => { handled.push(msg) },
+    })
+    expect(handled).toEqual([])
+    expect(getQueuedEvents().join('\n')).toMatch(/WhatsApp claim accepted/i)
+  })
+})

--- a/products/gateway/src/__tests__/daemon-http.test.ts
+++ b/products/gateway/src/__tests__/daemon-http.test.ts
@@ -7,6 +7,7 @@ import type { AddressInfo } from 'node:net'
 import { createHmac } from 'node:crypto'
 import { createDaemonHttpServer } from '../daemon.js'
 import { whatsappChannel } from '../channels/whatsapp.js'
+import { discordChannel } from '../channels/discord.js'
 import { TransientInboundError, resetExposedHttpGuardsForTest } from '../security.js'
 import { createJsonRoutes } from '../daemon-routes/index.js'
 import { clearConfigCacheForTest, updateConfig } from '../config.js'
@@ -35,7 +36,10 @@ describe.sequential('daemon HTTP server integration', () => {
   beforeAll(async () => {
     server = createDaemonHttpServer({
       client: fakeOpenCodeClient,
-      channels: new Map(),
+      channels: new Map<string, any>([
+        [whatsappChannel.name, whatsappChannel],
+        [discordChannel.name, discordChannel],
+      ]),
       routes: createJsonRoutes(),
       resolvePort: () => port,
     })

--- a/products/gateway/src/channels/bridge-protocol-stack.ts
+++ b/products/gateway/src/channels/bridge-protocol-stack.ts
@@ -1,0 +1,25 @@
+/**
+ * JOE-994 Phase 3: shared helpers for Durable → monorepo bridge protocol stacks
+ * (Discord / WhatsApp monorepo providers are WebhookProvider bridge-mode only).
+ */
+export type ChannelProtocolStack = 'durable' | 'monorepo'
+
+export function resolveChannelProtocolStack(
+  env: NodeJS.ProcessEnv,
+  envKeys: readonly string[],
+  configStack?: string | undefined,
+): ChannelProtocolStack {
+  for (const key of envKeys) {
+    const rawEnv = (env[key] || '').trim().toLowerCase()
+    if (rawEnv === 'monorepo' || rawEnv === 'shared' || rawEnv === 'gateway-provider' || rawEnv === 'provider' || rawEnv === 'bridge') {
+      return 'monorepo'
+    }
+    if (rawEnv === 'durable' || rawEnv === 'legacy' || rawEnv === 'classic' || rawEnv === 'native') {
+      return 'durable'
+    }
+  }
+  const fromConfig = (configStack || '').trim().toLowerCase()
+  if (fromConfig === 'monorepo' || fromConfig === 'bridge') return 'monorepo'
+  return 'durable'
+}
+

--- a/products/gateway/src/channels/channel-inbound-policy.ts
+++ b/products/gateway/src/channels/channel-inbound-policy.ts
@@ -1,0 +1,94 @@
+/**
+ * Durable product policy for channel inbound (trust, claims, denial probes).
+ * Shared across Telegram / Discord / WhatsApp stacks and monorepo façades
+ * (JOE-994 Phase 2–3) so protocol transport can change without forking policy.
+ */
+import type { ChannelMessage } from './provider.js'
+import { getConfig } from '../config.js'
+import { queueEvent } from '../wakeup.js'
+import { appendChannelInboundDenialAudit } from '../channel-audit.js'
+import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
+import { isPreTrustChannelCommandText } from '../channel-commands.js'
+import { isTrustedChannelTarget, redactedChannelTargetLabel } from '../security.js'
+
+export type DurableChannelProviderName = 'telegram' | 'discord' | 'whatsapp'
+
+export type ChannelInboundDelivery = {
+  /** Final delivery into the gateway session pipeline (after policy accepts). */
+  deliver: (msg: ChannelMessage) => Promise<void>
+  /** Optional typing / side-effect wrapper around accepted delivery. */
+  withTyping?: (msg: ChannelMessage, task: () => Promise<void>) => Promise<void>
+}
+
+export type ChannelInboundPolicyResult =
+  | { outcome: 'delivered' }
+  | { outcome: 'claim_accepted' }
+  | { outcome: 'denial_probe_accepted' }
+  | { outcome: 'denied' }
+  | { outcome: 'rejected_untrusted' }
+
+/**
+ * Apply Durable inbound policy, then deliver accepted messages.
+ * Returns a structured outcome so webhook handlers can count handled messages.
+ */
+export async function processDurableChannelInbound(
+  provider: DurableChannelProviderName,
+  msg: ChannelMessage,
+  delivery: ChannelInboundDelivery,
+): Promise<ChannelInboundPolicyResult> {
+  const label = providerLabel(provider)
+  const chatId = msg.chatId
+  const threadId = msg.threadId
+  const denialProbe = acceptChannelDenialProbeFromMessage(msg)
+  if (denialProbe.status === 'accepted') {
+    queueEvent(`${label} denial probe accepted: ${redactedChannelTargetLabel(provider, chatId, threadId)}`)
+    return { outcome: 'denial_probe_accepted' }
+  }
+  if (denialProbe.status === 'denied') return { outcome: 'denied' }
+  if (!isTrustedChannelTarget(provider, chatId, threadId, getConfig())) {
+    const claim = acceptChannelClaimFromMessage(msg)
+    if (claim.status === 'accepted') {
+      queueEvent(`${label} claim accepted: ${redactedChannelTargetLabel(provider, chatId, threadId)}`)
+      return { outcome: 'claim_accepted' }
+    }
+    if (claim.status === 'denied') return { outcome: 'denied' }
+    if (isPreTrustChannelCommandText(msg.text)) {
+      await runDelivery(msg, delivery)
+      return { outcome: 'delivered' }
+    }
+    const target = redactedChannelTargetLabel(provider, chatId, threadId)
+    queueEvent(`${label} rejected untrusted inbound: ${target}`)
+    safeAuditInboundDenial(provider, chatId, threadId)
+    return { outcome: 'rejected_untrusted' }
+  }
+  // A valid claim code from an already-trusted target heals allowlist rules
+  // created before per-sender actor policies existed by merging the claimant
+  // into the rule's userIds (see addTrustedTarget in channel-claims).
+  const trustedClaim = acceptChannelClaimFromMessage(msg)
+  if (trustedClaim.status === 'accepted') {
+    queueEvent(`${label} claim accepted: ${redactedChannelTargetLabel(provider, chatId, threadId)}`)
+    return { outcome: 'claim_accepted' }
+  }
+  if (trustedClaim.status === 'denied') return { outcome: 'denied' }
+
+  await runDelivery(msg, delivery)
+  return { outcome: 'delivered' }
+}
+
+async function runDelivery(msg: ChannelMessage, delivery: ChannelInboundDelivery): Promise<void> {
+  if (delivery.withTyping) {
+    await delivery.withTyping(msg, () => delivery.deliver(msg))
+    return
+  }
+  await delivery.deliver(msg)
+}
+
+function providerLabel(provider: DurableChannelProviderName): string {
+  if (provider === 'telegram') return 'Telegram'
+  if (provider === 'discord') return 'Discord'
+  return 'WhatsApp'
+}
+
+function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
+  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
+}

--- a/products/gateway/src/channels/discord-monorepo-adapter.ts
+++ b/products/gateway/src/channels/discord-monorepo-adapter.ts
@@ -1,0 +1,194 @@
+/**
+ * JOE-994 Phase 3: Durable Discord ChannelAdapter façade over monorepo
+ * `@open-cowork/gateway-provider-discord` (signed webhook bridge mode).
+ *
+ * Not a native Discord Interactions client — requires an external relay that
+ * verifies Discord signatures, then re-signs normalized payloads for Gateway.
+ * Default Durable path remains native Interactions + bot REST.
+ */
+import { DiscordProvider } from '@open-cowork/gateway-provider-discord'
+import type { IncomingChannelMessage } from '@open-cowork/gateway-channel'
+import type { ChannelAdapter, ChannelMessage } from './provider.js'
+import {
+  createStructuredMessage,
+  renderStructuredMessage,
+  type ChannelCapabilities,
+} from './renderer.js'
+import { discordAdapterCapabilities } from './capabilities.js'
+import { getConfig } from '../config.js'
+import { queueEvent } from '../wakeup.js'
+import { processDurableChannelInbound } from './channel-inbound-policy.js'
+import type { DiscordInteractionResponse, DiscordReadiness } from './discord.js'
+import { getDiscordConfig, getDiscordReadiness } from './discord.js'
+
+export type DiscordBridgeChannel = ChannelAdapter & {
+  isEnabled(): boolean
+  readiness(): DiscordReadiness
+  verifyInteractionSignature(signatureHeader: string | string[] | undefined, timestampHeader: string | string[] | undefined, rawBody: string): boolean
+  handleInteraction(rawBody: string, headers?: Record<string, string | string[] | undefined>): Promise<DiscordInteractionResponse>
+  handleGatewayEvent(payload: any): Promise<number>
+  /** Bridge-mode ingress (HMAC webhook payload). */
+  handleBridgeWebhook(rawBody: string, headers?: Record<string, string | string[] | undefined>): Promise<number>
+  isMonorepoBridge(): boolean
+}
+
+function mapIncoming(incoming: IncomingChannelMessage): ChannelMessage {
+  return {
+    provider: 'discord',
+    chatId: incoming.target.chatId,
+    threadId: incoming.target.threadId ?? undefined,
+    messageId: incoming.providerMessageId || incoming.providerEventId || incoming.id,
+    userId: incoming.sender.providerUserId,
+    text: incoming.text || incoming.rawText || '',
+    attachments: (incoming.attachments || []).map((a) => ({
+      name: a.filename || a.providerFileId || 'attachment',
+      url: a.downloadUrl || '',
+      mimeType: a.mimeType || 'application/octet-stream',
+    })),
+    timestamp: (incoming.receivedAt instanceof Date ? incoming.receivedAt : new Date()).toISOString(),
+  }
+}
+
+function bridgeConfig(): { deliveryUrl: string; sharedSecret: string } | null {
+  const cfg = getConfig().channels.discord
+  const deliveryUrl = process.env['OPEN_COWORK_DISCORD_BRIDGE_DELIVERY_URL'] || cfg.bridgeDeliveryUrl || ''
+  const sharedSecret = process.env['OPEN_COWORK_DISCORD_BRIDGE_SHARED_SECRET'] || cfg.bridgeSharedSecret || ''
+  if (!deliveryUrl.trim() || !sharedSecret.trim()) return null
+  return { deliveryUrl: deliveryUrl.trim(), sharedSecret: sharedSecret.trim() }
+}
+
+export function createDiscordMonorepoChannelAdapter(): DiscordBridgeChannel {
+  let handler: ((msg: ChannelMessage) => Promise<void>) | null = null
+  let provider: DiscordProvider | null = null
+
+  const adapter: DiscordBridgeChannel = {
+    name: 'discord',
+    get capabilities(): ChannelCapabilities {
+      const cfg = getDiscordConfig()
+      return discordAdapterCapabilities({ enabled: cfg.enabled, richMessagesEnabled: cfg.richMessagesEnabled })
+    },
+    isEnabled() {
+      return getDiscordConfig().enabled
+    },
+    readiness() {
+      const base = getDiscordReadiness()
+      const bridge = bridgeConfig()
+      if (!bridge) {
+        return {
+          ...base,
+          ready: false,
+          issues: [
+            ...base.issues,
+            'Monorepo Discord stack requires bridgeDeliveryUrl + bridgeSharedSecret (or OPEN_COWORK_DISCORD_BRIDGE_* env).',
+          ],
+          summary: 'Discord monorepo bridge credentials missing.',
+        }
+      }
+      return {
+        ...base,
+        summary: base.enabled
+          ? 'Discord monorepo bridge stack enabled (relay must verify native Discord signatures).'
+          : base.summary,
+      }
+    },
+    isMonorepoBridge() {
+      return true
+    },
+    async start() {
+      const cfg = getDiscordConfig()
+      if (!cfg.enabled) {
+        console.error('[discord] alpha channel disabled; monorepo bridge not started')
+        return
+      }
+      const bridge = bridgeConfig()
+      if (!bridge) {
+        console.error('[discord] monorepo bridge credentials missing — façade disabled')
+        queueEvent('Discord monorepo bridge disabled: delivery URL or shared secret missing')
+        return
+      }
+      if (provider) return
+      queueEvent('Discord monorepo protocol stack enabled (JOE-994 Phase 3 bridge façade)')
+      const next = new DiscordProvider({
+        deliveryUrl: bridge.deliveryUrl,
+        sharedSecret: bridge.sharedSecret,
+      })
+      provider = next
+      await next.start(async (incoming) => {
+        if (!handler) return
+        const msg = mapIncoming(incoming)
+        await processDurableChannelInbound('discord', msg, {
+          deliver: (accepted) => handler!(accepted),
+        })
+      })
+      queueEvent('Discord channel ready via monorepo webhook bridge')
+    },
+    async stop() {
+      const current = provider
+      provider = null
+      if (current) await current.stop()
+    },
+    async sendMessage(chatId, text, options) {
+      if (!provider) throw new Error('Discord monorepo bridge is not started')
+      const limit = Math.max(1, Math.min(provider.capabilities.maxTextLength || 2000, 2000))
+      for (let i = 0; i < text.length; i += limit) {
+        const part = text.slice(i, i + limit)
+        await provider.sendText({
+          provider: 'discord',
+          chatId,
+          threadId: options?.threadId ?? null,
+          userId: null,
+          messageId: null,
+        }, part, options?.idempotencyKey ? { deliveryId: options.idempotencyKey } : undefined)
+      }
+    },
+    async sendStructuredMessage(chatId, message, options) {
+      const rendered = renderStructuredMessage(message, adapter.capabilities)
+      await adapter.sendMessage(chatId, rendered.markdown || rendered.plainText || rendered.text || message.summary || message.title || '', options)
+    },
+    async sendCommandMenu(chatId, text, actions, options) {
+      const message = createStructuredMessage({
+        kind: 'status',
+        title: 'Gateway Commands',
+        summary: text,
+        blocks: [
+          { type: 'heading', text: 'Gateway Commands', level: 2 },
+          { type: 'text', text },
+          { type: 'facts', facts: actions.slice(0, 12).map((a) => ({ label: a.label, value: a.description || a.command })) },
+        ],
+        actions: actions.map((a) => ({ label: a.label, command: a.command })),
+      })
+      await adapter.sendStructuredMessage?.(chatId, message, options)
+    },
+    onMessage(h) {
+      handler = h
+    },
+    verifyInteractionSignature() {
+      // Native Discord interaction verify is disabled on monorepo bridge stack.
+      return false
+    },
+    async handleInteraction() {
+      return {
+        status: 400,
+        body: {
+          error: 'native Discord interactions disabled on monorepo bridge stack; relay signed bridge payloads to this endpoint with webhook HMAC headers',
+        },
+      }
+    },
+    async handleGatewayEvent() {
+      return 0
+    },
+    async handleBridgeWebhook(rawBody, headers = {}) {
+      if (!provider) throw new Error('Discord monorepo bridge is not started')
+      let payload: unknown
+      try {
+        payload = JSON.parse(rawBody)
+      } catch {
+        throw new Error('invalid discord bridge payload')
+      }
+      await provider.handleWebhookPayload(payload, { headers, rawBody })
+      return 1
+    },
+  }
+  return adapter
+}
+

--- a/products/gateway/src/channels/discord-protocol-stack.ts
+++ b/products/gateway/src/channels/discord-protocol-stack.ts
@@ -1,0 +1,48 @@
+/**
+ * JOE-994 Phase 3: select Discord protocol implementation.
+ * Env: OPEN_COWORK_DISCORD_PROTOCOL_STACK=durable|monorepo
+ */
+import type { ChannelAdapter } from './provider.js'
+import { discordChannel } from './discord.js'
+import { createDiscordMonorepoChannelAdapter, type DiscordBridgeChannel } from './discord-monorepo-adapter.js'
+import { getConfig } from '../config.js'
+import { resolveChannelProtocolStack, type ChannelProtocolStack } from './bridge-protocol-stack.js'
+
+export type DiscordProtocolStack = ChannelProtocolStack
+export type DiscordChannelSurface = typeof discordChannel | DiscordBridgeChannel
+
+let cachedAdapter: DiscordChannelSurface | null = null
+let cachedStack: DiscordProtocolStack | null = null
+
+export function resolveDiscordProtocolStack(
+  env: NodeJS.ProcessEnv = process.env,
+  configStack?: string | undefined,
+): DiscordProtocolStack {
+  return resolveChannelProtocolStack(
+    env,
+    ['OPEN_COWORK_DISCORD_PROTOCOL_STACK', 'DISCORD_PROTOCOL_STACK'],
+    configStack,
+  )
+}
+
+export function getDiscordChannel(): DiscordChannelSurface {
+  const stack = resolveDiscordProtocolStack(process.env, getConfig().channels.discord.protocolStack)
+  if (cachedAdapter && cachedStack === stack) return cachedAdapter
+  cachedStack = stack
+  cachedAdapter = stack === 'monorepo' ? createDiscordMonorepoChannelAdapter() : discordChannel
+  return cachedAdapter
+}
+
+export function peekDiscordProtocolStack(): DiscordProtocolStack {
+  return resolveDiscordProtocolStack(process.env, getConfig().channels.discord.protocolStack)
+}
+
+export function resetDiscordChannelForTest(): void {
+  cachedAdapter = null
+  cachedStack = null
+}
+
+export function isDiscordMonorepoBridge(channel: ChannelAdapter): channel is DiscordBridgeChannel {
+  return typeof (channel as DiscordBridgeChannel).isMonorepoBridge === 'function'
+    && (channel as DiscordBridgeChannel).isMonorepoBridge()
+}

--- a/products/gateway/src/channels/discord.ts
+++ b/products/gateway/src/channels/discord.ts
@@ -4,11 +4,9 @@ import { DISCORD_ALPHA_CAPABILITIES, discordAdapterCapabilities } from './capabi
 import { planNativeActionDelivery, renderStructuredMessage, type ChannelCapabilities, type MessageAction, type NativeActionDeliveryItem, type RichMessageBlock, type StructuredGatewayMessage } from './renderer.js'
 import { getConfig } from '../config.js'
 import { queueEvent } from '../wakeup.js'
-import { appendChannelInboundDenialAudit } from '../channel-audit.js'
-import { allowsAllChannelTargets, hasChannelAllowlist, isTrustedChannelTarget, redactSensitiveText, redactedChannelTargetLabel } from '../security.js'
-import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
-import { isPreTrustChannelCommandText } from '../channel-commands.js'
+import { allowsAllChannelTargets, hasChannelAllowlist, redactSensitiveText } from '../security.js'
 import { fetchWithTimeout } from '../deadlines.js'
+import { processDurableChannelInbound } from './channel-inbound-policy.js'
 
 const DISCORD_API = 'https://discord.com/api/v10'
 const DISCORD_CONTENT_LIMIT = 2000
@@ -306,43 +304,14 @@ async function acceptDiscordInbound(message: ChannelMessage | null, options: { w
   if (!message || !handler) return false
   if (!getDiscordConfig().enabled) return false
   if (!started) started = true
-  const denialProbe = acceptChannelDenialProbeFromMessage(message)
-  if (denialProbe.status === 'accepted') {
-    queueEvent(`Discord denial probe accepted: ${redactedChannelTargetLabel('discord', message.chatId, message.threadId)}`)
-    return true
-  }
-  if (denialProbe.status === 'denied') return false
-  if (!isTrustedChannelTarget('discord', message.chatId, message.threadId, getConfig())) {
-    const claim = acceptChannelClaimFromMessage(message)
-    if (claim.status === 'accepted') {
-      queueEvent(`Discord claim accepted: ${redactedChannelTargetLabel('discord', message.chatId, message.threadId)}`)
-      return true
-    }
-    if (claim.status === 'denied') return false
-    if (isPreTrustChannelCommandText(message.text)) {
-      if (options.waitForHandler === false) dispatchDiscordInbound(message)
-      else await handler(message)
-      return true
-    }
-    const target = redactedChannelTargetLabel('discord', message.chatId, message.threadId)
-    queueEvent(`Discord rejected untrusted inbound: ${target}`)
-    safeAuditInboundDenial('discord', message.chatId, message.threadId)
-    return false
-  }
-  // A valid claim code from an already-trusted target heals allowlist rules
-  // created before per-sender actor policies existed by merging the claimant
-  // into the rule's userIds (see addTrustedTarget in channel-claims). This is
-  // the only in-band recovery path for a legacy Discord DM rule, whose channel
-  // id never equals the author id and so cannot satisfy the DM actor fallback.
-  const trustedClaim = acceptChannelClaimFromMessage(message)
-  if (trustedClaim.status === 'accepted') {
-    queueEvent(`Discord claim accepted: ${redactedChannelTargetLabel('discord', message.chatId, message.threadId)}`)
-    return true
-  }
-  if (trustedClaim.status === 'denied') return false
-  if (options.waitForHandler === false) dispatchDiscordInbound(message)
-  else await handler(message)
-  return true
+  const inboundHandler = handler
+  const result = await processDurableChannelInbound('discord', message, {
+    deliver: async (accepted) => {
+      if (options.waitForHandler === false) dispatchDiscordInbound(accepted)
+      else await inboundHandler(accepted)
+    },
+  })
+  return result.outcome !== 'denied' && result.outcome !== 'rejected_untrusted'
 }
 
 function dispatchDiscordInbound(message: ChannelMessage): void {
@@ -546,8 +515,4 @@ async function safeJson(res: Response): Promise<unknown> {
 
 async function safeResponseText(res: Response): Promise<string> {
   try { return await res.text() } catch { return res.statusText || 'unknown error' }
-}
-
-function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
-  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
 }

--- a/products/gateway/src/channels/telegram-inbound-policy.ts
+++ b/products/gateway/src/channels/telegram-inbound-policy.ts
@@ -1,75 +1,18 @@
 /**
- * Durable product policy for Telegram inbound (trust, claims, denial probes).
- * Shared by the legacy Durable poll loop and the monorepo-provider façade
- * (JOE-994 Phase 2) so protocol transport can change without forking policy.
+ * Telegram-specific re-export of shared Durable inbound policy (JOE-994).
+ * Prefer `channel-inbound-policy.ts` for new call sites.
  */
+import {
+  processDurableChannelInbound,
+  type ChannelInboundDelivery,
+} from './channel-inbound-policy.js'
 import type { ChannelMessage } from './provider.js'
-import { getConfig } from '../config.js'
-import { queueEvent } from '../wakeup.js'
-import { appendChannelInboundDenialAudit } from '../channel-audit.js'
-import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
-import { isPreTrustChannelCommandText } from '../channel-commands.js'
-import { isTrustedChannelTarget, redactedChannelTargetLabel } from '../security.js'
 
-export type TelegramInboundDelivery = {
-  /** Final delivery into the gateway session pipeline (after policy accepts). */
-  deliver: (msg: ChannelMessage) => Promise<void>
-  /**
-   * Optional typing wrapper (legacy uses sendChatAction heartbeat; monorepo
-   * path can use TelegramProvider.setTyping).
-   */
-  withTyping?: (msg: ChannelMessage, task: () => Promise<void>) => Promise<void>
-}
+export type TelegramInboundDelivery = ChannelInboundDelivery
 
-/**
- * Apply Durable Telegram inbound policy, then deliver accepted messages.
- * Returns without calling deliver when the message is a claim/probe/denial.
- */
 export async function processDurableTelegramInbound(
   msg: ChannelMessage,
   delivery: TelegramInboundDelivery,
 ): Promise<void> {
-  const chatId = msg.chatId
-  const threadId = msg.threadId
-  const denialProbe = acceptChannelDenialProbeFromMessage(msg)
-  if (denialProbe.status === 'accepted') {
-    queueEvent(`Telegram denial probe accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-    return
-  }
-  if (denialProbe.status === 'denied') return
-  if (!isTrustedChannelTarget('telegram', chatId, threadId, getConfig())) {
-    const claim = acceptChannelClaimFromMessage(msg)
-    if (claim.status === 'accepted') {
-      queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-      return
-    }
-    if (claim.status === 'denied') return
-    if (isPreTrustChannelCommandText(msg.text)) {
-      await delivery.deliver(msg)
-      return
-    }
-    const target = redactedChannelTargetLabel('telegram', chatId, threadId)
-    queueEvent(`Telegram rejected untrusted inbound: ${target}`)
-    safeAuditInboundDenial('telegram', chatId, threadId)
-    return
-  }
-  // A valid claim code from an already-trusted target heals allowlist rules
-  // created before per-sender actor policies existed by merging the claimant
-  // into the rule's userIds (see addTrustedTarget in channel-claims).
-  const trustedClaim = acceptChannelClaimFromMessage(msg)
-  if (trustedClaim.status === 'accepted') {
-    queueEvent(`Telegram claim accepted: ${redactedChannelTargetLabel('telegram', chatId, threadId)}`)
-    return
-  }
-  if (trustedClaim.status === 'denied') return
-
-  if (delivery.withTyping) {
-    await delivery.withTyping(msg, () => delivery.deliver(msg))
-    return
-  }
-  await delivery.deliver(msg)
-}
-
-function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
-  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
+  await processDurableChannelInbound('telegram', msg, delivery)
 }

--- a/products/gateway/src/channels/whatsapp-monorepo-adapter.ts
+++ b/products/gateway/src/channels/whatsapp-monorepo-adapter.ts
@@ -1,0 +1,137 @@
+/**
+ * JOE-994 Phase 3: Durable WhatsApp ChannelAdapter façade over monorepo
+ * `@open-cowork/gateway-provider-whatsapp` (signed webhook bridge mode).
+ *
+ * Not Meta Graph native — requires an external relay that verifies Meta
+ * signatures, then re-signs normalized payloads for Gateway. Default Durable
+ * path remains Graph API + Meta hub webhooks.
+ */
+import { WhatsAppProvider } from '@open-cowork/gateway-provider-whatsapp'
+import type { IncomingChannelMessage } from '@open-cowork/gateway-channel'
+import type { ChannelAdapter, ChannelMessage } from './provider.js'
+import { renderStructuredMessage } from './renderer.js'
+import { WHATSAPP_CAPABILITIES } from './capabilities.js'
+import { getConfig } from '../config.js'
+import { queueEvent } from '../wakeup.js'
+import { processDurableChannelInbound } from './channel-inbound-policy.js'
+
+export type WhatsAppBridgeChannel = ChannelAdapter & {
+  verifyWebhook(url: URL): string | null
+  verifySignature(signatureHeader: string | string[] | undefined, rawBody: string): boolean
+  handleWebhook(payload: any): Promise<number>
+  handleBridgeWebhook(rawBody: string, headers?: Record<string, string | string[] | undefined>): Promise<number>
+  isMonorepoBridge(): boolean
+}
+
+function mapIncoming(incoming: IncomingChannelMessage): ChannelMessage {
+  return {
+    provider: 'whatsapp',
+    chatId: incoming.target.chatId,
+    threadId: incoming.target.threadId ?? undefined,
+    messageId: incoming.providerMessageId || incoming.providerEventId || incoming.id,
+    userId: incoming.sender.providerUserId,
+    text: incoming.text || incoming.rawText || '',
+    attachments: (incoming.attachments || []).map((a) => ({
+      name: a.filename || a.providerFileId || 'attachment',
+      url: a.downloadUrl || '',
+      mimeType: a.mimeType || 'application/octet-stream',
+    })),
+    timestamp: (incoming.receivedAt instanceof Date ? incoming.receivedAt : new Date()).toISOString(),
+  }
+}
+
+function bridgeConfig(): { deliveryUrl: string; sharedSecret: string } | null {
+  const cfg = getConfig().channels.whatsapp
+  const deliveryUrl = process.env['OPEN_COWORK_WHATSAPP_BRIDGE_DELIVERY_URL'] || cfg.bridgeDeliveryUrl || ''
+  const sharedSecret = process.env['OPEN_COWORK_WHATSAPP_BRIDGE_SHARED_SECRET'] || cfg.bridgeSharedSecret || ''
+  if (!deliveryUrl.trim() || !sharedSecret.trim()) return null
+  return { deliveryUrl: deliveryUrl.trim(), sharedSecret: sharedSecret.trim() }
+}
+
+export function createWhatsAppMonorepoChannelAdapter(): WhatsAppBridgeChannel {
+  let handler: ((msg: ChannelMessage) => Promise<void>) | null = null
+  let provider: WhatsAppProvider | null = null
+
+  const adapter: WhatsAppBridgeChannel = {
+    name: 'whatsapp',
+    capabilities: WHATSAPP_CAPABILITIES,
+    isMonorepoBridge() {
+      return true
+    },
+    async start() {
+      const bridge = bridgeConfig()
+      if (!bridge) {
+        console.error('[whatsapp] monorepo bridge credentials missing — façade disabled')
+        queueEvent('WhatsApp monorepo bridge disabled: delivery URL or shared secret missing')
+        return
+      }
+      if (provider) return
+      queueEvent('WhatsApp monorepo protocol stack enabled (JOE-994 Phase 3 bridge façade)')
+      const next = new WhatsAppProvider({
+        deliveryUrl: bridge.deliveryUrl,
+        sharedSecret: bridge.sharedSecret,
+      })
+      provider = next
+      await next.start(async (incoming) => {
+        if (!handler) return
+        const msg = mapIncoming(incoming)
+        await processDurableChannelInbound('whatsapp', msg, {
+          deliver: (accepted) => handler!(accepted),
+        })
+      })
+      queueEvent('WhatsApp channel ready via monorepo webhook bridge')
+    },
+    async stop() {
+      const current = provider
+      provider = null
+      if (current) await current.stop()
+    },
+    async sendMessage(chatId, text) {
+      if (!provider) throw new Error('WhatsApp monorepo bridge is not started')
+      const limit = Math.max(1, Math.min(provider.capabilities.maxTextLength || 4096, 4096))
+      for (let i = 0; i < text.length; i += limit) {
+        await provider.sendText({
+          provider: 'whatsapp',
+          chatId,
+          threadId: null,
+          userId: null,
+          messageId: null,
+        }, text.slice(i, i + limit))
+      }
+    },
+    async sendStructuredMessage(chatId, message) {
+      const rendered = renderStructuredMessage(message, WHATSAPP_CAPABILITIES)
+      await adapter.sendMessage(chatId, rendered.plainText || rendered.text || message.summary || message.title || '')
+    },
+    async sendCommandMenu(chatId, text) {
+      await adapter.sendMessage(chatId, text)
+    },
+    onMessage(h) {
+      handler = h
+    },
+    verifyWebhook() {
+      // Meta hub challenge is native-stack only.
+      return null
+    },
+    verifySignature() {
+      // Meta hub HMAC is native-stack only; bridge uses WebhookProvider auth.
+      return false
+    },
+    async handleWebhook() {
+      throw new Error('native Meta hub webhooks disabled on monorepo bridge stack; POST bridge payloads with gateway webhook HMAC headers')
+    },
+    async handleBridgeWebhook(rawBody, headers = {}) {
+      if (!provider) throw new Error('WhatsApp monorepo bridge is not started')
+      let payload: unknown
+      try {
+        payload = JSON.parse(rawBody)
+      } catch {
+        throw new Error('invalid whatsapp bridge payload')
+      }
+      await provider.handleWebhookPayload(payload, { headers, rawBody })
+      return 1
+    },
+  }
+  return adapter
+}
+

--- a/products/gateway/src/channels/whatsapp-protocol-stack.ts
+++ b/products/gateway/src/channels/whatsapp-protocol-stack.ts
@@ -1,0 +1,48 @@
+/**
+ * JOE-994 Phase 3: select WhatsApp protocol implementation.
+ * Env: OPEN_COWORK_WHATSAPP_PROTOCOL_STACK=durable|monorepo
+ */
+import type { ChannelAdapter } from './provider.js'
+import { whatsappChannel } from './whatsapp.js'
+import { createWhatsAppMonorepoChannelAdapter, type WhatsAppBridgeChannel } from './whatsapp-monorepo-adapter.js'
+import { getConfig } from '../config.js'
+import { resolveChannelProtocolStack, type ChannelProtocolStack } from './bridge-protocol-stack.js'
+
+export type WhatsAppProtocolStack = ChannelProtocolStack
+export type WhatsAppChannelSurface = typeof whatsappChannel | WhatsAppBridgeChannel
+
+let cachedAdapter: WhatsAppChannelSurface | null = null
+let cachedStack: WhatsAppProtocolStack | null = null
+
+export function resolveWhatsAppProtocolStack(
+  env: NodeJS.ProcessEnv = process.env,
+  configStack?: string | undefined,
+): WhatsAppProtocolStack {
+  return resolveChannelProtocolStack(
+    env,
+    ['OPEN_COWORK_WHATSAPP_PROTOCOL_STACK', 'WHATSAPP_PROTOCOL_STACK'],
+    configStack,
+  )
+}
+
+export function getWhatsAppChannel(): WhatsAppChannelSurface {
+  const stack = resolveWhatsAppProtocolStack(process.env, getConfig().channels.whatsapp.protocolStack)
+  if (cachedAdapter && cachedStack === stack) return cachedAdapter
+  cachedStack = stack
+  cachedAdapter = stack === 'monorepo' ? createWhatsAppMonorepoChannelAdapter() : whatsappChannel
+  return cachedAdapter
+}
+
+export function peekWhatsAppProtocolStack(): WhatsAppProtocolStack {
+  return resolveWhatsAppProtocolStack(process.env, getConfig().channels.whatsapp.protocolStack)
+}
+
+export function resetWhatsAppChannelForTest(): void {
+  cachedAdapter = null
+  cachedStack = null
+}
+
+export function isWhatsAppMonorepoBridge(channel: ChannelAdapter): channel is WhatsAppBridgeChannel {
+  return typeof (channel as WhatsAppBridgeChannel).isMonorepoBridge === 'function'
+    && (channel as WhatsAppBridgeChannel).isMonorepoBridge()
+}

--- a/products/gateway/src/channels/whatsapp.ts
+++ b/products/gateway/src/channels/whatsapp.ts
@@ -4,12 +4,10 @@ import { planNativeActionDelivery, renderStructuredMessage, type MessageAction, 
 import { getConfig } from '../config.js'
 import { queueEvent } from '../wakeup.js'
 import { verifyMetaHubSignature256, verifyMetaHubVerifyToken } from '@open-cowork/shared/node'
-import { appendChannelInboundDenialAudit } from '../channel-audit.js'
 import { appendWorkEvent } from '../work-store.js'
-import { isTransientInboundError, isTrustedChannelTarget, redactedChannelTargetLabel, redactSensitiveText } from '../security.js'
-import { acceptChannelClaimFromMessage, acceptChannelDenialProbeFromMessage } from '../channel-claims.js'
-import { isPreTrustChannelCommandText } from '../channel-commands.js'
+import { isTransientInboundError, redactSensitiveText } from '../security.js'
 import { fetchWithTimeout } from '../deadlines.js'
+import { processDurableChannelInbound } from './channel-inbound-policy.js'
 
 const GRAPH_VERSION = 'v20.0'
 const WHATSAPP_TEXT_LIMIT = 4096
@@ -120,43 +118,21 @@ export const whatsappChannel: ChannelAdapter & {
 
   async handleWebhook(payload: any): Promise<number> {
     if (!handler) throw new Error('WhatsApp channel handler is not registered')
+    const inboundHandler = handler
     const messages = mapWhatsAppMessages(payload)
     let handled = 0
     for (const msg of messages) {
-      const denialProbe = acceptChannelDenialProbeFromMessage(msg)
-      if (denialProbe.status === 'accepted') {
-        queueEvent(`WhatsApp denial probe accepted: ${redactedChannelTargetLabel('whatsapp', msg.chatId, msg.threadId)}`)
+      let delivered = false
+      const result = await processDurableChannelInbound('whatsapp', msg, {
+        deliver: async (accepted) => {
+          delivered = await dispatchInbound(inboundHandler, accepted)
+        },
+      })
+      if (result.outcome === 'claim_accepted' || result.outcome === 'denial_probe_accepted') {
         handled++
         continue
       }
-      if (denialProbe.status === 'denied') continue
-      if (!isTrustedChannelTarget('whatsapp', msg.chatId, msg.threadId, getConfig())) {
-        const claim = acceptChannelClaimFromMessage(msg)
-        if (claim.status === 'accepted') {
-          queueEvent(`WhatsApp claim accepted: ${redactedChannelTargetLabel('whatsapp', msg.chatId, msg.threadId)}`)
-          handled++
-          continue
-        }
-        if (claim.status === 'denied') continue
-        if (isPreTrustChannelCommandText(msg.text)) {
-          if (await dispatchInbound(handler, msg)) handled++
-          continue
-        }
-        const target = redactedChannelTargetLabel('whatsapp', msg.chatId, msg.threadId)
-        queueEvent(`WhatsApp rejected untrusted inbound: ${target}`)
-        safeAuditInboundDenial('whatsapp', msg.chatId, msg.threadId)
-        continue
-      }
-      // A valid claim code from an already-trusted target heals allowlist rules
-      // created before per-sender actor policies existed (see addTrustedTarget).
-      const trustedClaim = acceptChannelClaimFromMessage(msg)
-      if (trustedClaim.status === 'accepted') {
-        queueEvent(`WhatsApp claim accepted: ${redactedChannelTargetLabel('whatsapp', msg.chatId, msg.threadId)}`)
-        handled++
-        continue
-      }
-      if (trustedClaim.status === 'denied') continue
-      if (await dispatchInbound(handler, msg)) handled++
+      if (result.outcome === 'delivered' && delivered) handled++
     }
     if (handled > 0) queueEvent(`WhatsApp inbound: ${handled} message(s)`)
     return handled
@@ -180,10 +156,6 @@ function whatsappRows(actions: Array<MessageAction & { description?: string }>, 
       ...(description ? { description } : {}),
     }
   })
-}
-
-function safeAuditInboundDenial(provider: string, chatId: string, threadId?: string): void {
-  try { appendChannelInboundDenialAudit({ provider, chatId, threadId }) } catch {}
 }
 
 /**

--- a/products/gateway/src/config-schema.ts
+++ b/products/gateway/src/config-schema.ts
@@ -227,13 +227,27 @@ const zChannels = z.object({
     /** JOE-994 Phase 2: durable (default) | monorepo provider façade. Env OPEN_COWORK_TELEGRAM_PROTOCOL_STACK overrides. */
     protocolStack: z.enum(['durable', 'monorepo']).optional(),
   }),
-  whatsapp: zStringRecord(z.unknown()),
+  whatsapp: z.object({
+    setupMode: z.enum(['cloudApiDirect']).optional(),
+    accessToken: zString.optional(),
+    phoneNumberId: zString.optional(),
+    verifyToken: zString.optional(),
+    appSecret: zString.optional(),
+    /** JOE-994 Phase 3: durable native Meta hub (default) | monorepo webhook bridge. */
+    protocolStack: z.enum(['durable', 'monorepo']).optional(),
+    bridgeDeliveryUrl: zString.optional(),
+    bridgeSharedSecret: zString.optional(),
+  }).catchall(z.unknown()),
   discord: z.object({
     enabled: zBoolean,
     botToken: zString.optional(),
     applicationId: zString.optional(),
     publicKey: zString.optional(),
     richMessages: z.object({ enabled: zBoolean }).optional(),
+    /** JOE-994 Phase 3: durable native Interactions (default) | monorepo webhook bridge. */
+    protocolStack: z.enum(['durable', 'monorepo']).optional(),
+    bridgeDeliveryUrl: zString.optional(),
+    bridgeSharedSecret: zString.optional(),
   }),
 })
 

--- a/products/gateway/src/config.ts
+++ b/products/gateway/src/config.ts
@@ -345,8 +345,22 @@ export interface GatewayConfig {
       phoneNumberId?: string
       verifyToken?: string
       appSecret?: string
+      /** JOE-994 Phase 3: durable native Meta (default) or monorepo webhook bridge. */
+      protocolStack?: 'durable' | 'monorepo'
+      bridgeDeliveryUrl?: string
+      bridgeSharedSecret?: string
     }
-    discord: { enabled: boolean; botToken?: string; applicationId?: string; publicKey?: string; richMessages?: { enabled: boolean } }
+    discord: {
+      enabled: boolean
+      botToken?: string
+      applicationId?: string
+      publicKey?: string
+      richMessages?: { enabled: boolean }
+      /** JOE-994 Phase 3: durable native Interactions (default) or monorepo webhook bridge. */
+      protocolStack?: 'durable' | 'monorepo'
+      bridgeDeliveryUrl?: string
+      bridgeSharedSecret?: string
+    }
   }
 }
 
@@ -914,6 +928,9 @@ function normalizeChannelsConfig(input: Partial<GatewayConfig['channels']> | und
       phoneNumberId: normalizeOptionalText(input?.whatsapp?.phoneNumberId, 256),
       verifyToken: normalizeOptionalText(input?.whatsapp?.verifyToken, 4096),
       appSecret: normalizeOptionalText(input?.whatsapp?.appSecret, 4096),
+      protocolStack: normalizeChannelProtocolStack(input?.whatsapp?.protocolStack, 'channels.whatsapp.protocolStack'),
+      bridgeDeliveryUrl: normalizeOptionalText(input?.whatsapp?.bridgeDeliveryUrl, 2048),
+      bridgeSharedSecret: normalizeOptionalText(input?.whatsapp?.bridgeSharedSecret, 4096),
     },
     discord: {
       enabled: input?.discord?.enabled === true,
@@ -921,6 +938,9 @@ function normalizeChannelsConfig(input: Partial<GatewayConfig['channels']> | und
       applicationId: normalizeOptionalText(input?.discord?.applicationId, 256),
       publicKey: normalizeOptionalText(input?.discord?.publicKey, 256),
       richMessages: { enabled: input?.discord?.richMessages?.enabled !== false },
+      protocolStack: normalizeChannelProtocolStack(input?.discord?.protocolStack, 'channels.discord.protocolStack'),
+      bridgeDeliveryUrl: normalizeOptionalText(input?.discord?.bridgeDeliveryUrl, 2048),
+      bridgeSharedSecret: normalizeOptionalText(input?.discord?.bridgeSharedSecret, 4096),
     },
   }
 }
@@ -1005,9 +1025,13 @@ function normalizeWhatsAppSetupMode(input: unknown, label: string): GatewayConfi
 }
 
 function normalizeTelegramProtocolStack(input: unknown): GatewayConfig['channels']['telegram']['protocolStack'] {
+  return normalizeChannelProtocolStack(input, 'channels.telegram.protocolStack')
+}
+
+function normalizeChannelProtocolStack(input: unknown, label: string): 'durable' | 'monorepo' | undefined {
   if (input === undefined || input === null || input === '') return undefined
   if (input === 'durable' || input === 'monorepo') return input
-  throw new Error('channels.telegram.protocolStack must be durable or monorepo')
+  throw new Error(`${label} must be durable or monorepo`)
 }
 
 function normalizeAgentTeams(input: Record<string, Partial<AgentTeamConfig>>, scheduler: GatewayConfig['scheduler'], profiles: Record<string, AgentProfile>): Record<string, AgentTeamConfig> {

--- a/products/gateway/src/daemon.ts
+++ b/products/gateway/src/daemon.ts
@@ -9,8 +9,8 @@ import { trackWorker, loadWorkerState, reconcileWorkersFromOpenCode } from './wo
 import { renderDashboard } from './dashboard.js'
 import { subscribeToOpenCodeEvents, addLiveClient, closeAllLiveClients, removeLiveClient } from './live.js'
 import { getTelegramChannel } from './channels/telegram-protocol-stack.js'
-import { whatsappChannel } from './channels/whatsapp.js'
-import { discordChannel } from './channels/discord.js'
+import { getWhatsAppChannel, isWhatsAppMonorepoBridge } from './channels/whatsapp-protocol-stack.js'
+import { getDiscordChannel, isDiscordMonorepoBridge } from './channels/discord-protocol-stack.js'
 import { claimInboundWebhookRateLimit, inboundWebhookRateKey, noteInboundWebhookAuthFailure } from './channels/webhook-rate-limit.js'
 import { actionDeliveryForCapabilities } from './channels/capabilities.js'
 import { resolveAgent } from './routing.js'
@@ -112,8 +112,10 @@ export async function serve() {
   // Start heartbeat for Gateway session monitoring
   startHeartbeat()
 
-  // JOE-994 Phase 2: Telegram may be legacy Durable or monorepo-provider façade.
+  // JOE-994 Phase 2–3: Telegram/Discord/WhatsApp may be Durable native or monorepo façades.
   const telegramChannel = getTelegramChannel()
+  const whatsappChannel = getWhatsAppChannel()
+  const discordChannel = getDiscordChannel()
   const channelByName = new Map([
     [telegramChannel.name, telegramChannel],
     [whatsappChannel.name, whatsappChannel],
@@ -494,6 +496,9 @@ export function createDaemonHttpServer(input: DaemonHttpServerInput): http.Serve
   return http.createServer(async (req, res) => {
     const port = input.resolvePort()
     const url = new URL(req.url || '/', `http://localhost:${port}`)
+    // JOE-994: resolve from daemon channel map so monorepo façades wire correctly.
+    const whatsappChannel = input.channels.get('whatsapp') as ReturnType<typeof getWhatsAppChannel> | undefined
+    const discordChannel = input.channels.get('discord') as ReturnType<typeof getDiscordChannel> | undefined
     const security = getConfig().security
     // Exposed-mode-only abuse controls: sliding-window rate limit + auth-failure
     // lockout. Skipped entirely on the local-trusted default path so the
@@ -637,6 +642,10 @@ ev.onerror = () => {
       }
 
       if (req.method === 'GET' && url.pathname === '/webhooks/whatsapp') {
+        if (!whatsappChannel) {
+          res.writeHead(503)
+          return res.end(JSON.stringify({ error: 'whatsapp adapter not ready' }))
+        }
         const rateKey = inboundWebhookRateKey('whatsapp', req)
         const rate = claimInboundWebhookRateLimit(rateKey)
         if (!rate.ok) {
@@ -656,6 +665,10 @@ ev.onerror = () => {
       }
 
       if (req.method === 'POST' && url.pathname === '/webhooks/whatsapp') {
+        if (!whatsappChannel) {
+          res.writeHead(503)
+          return res.end(JSON.stringify({ error: 'whatsapp adapter not ready' }))
+        }
         if (!canCurrentDaemonWrite()) return sendStandbyWebhookResponse(res)
         const rateKey = inboundWebhookRateKey('whatsapp', req)
         const rate = claimInboundWebhookRateLimit(rateKey)
@@ -665,26 +678,45 @@ ev.onerror = () => {
           return res.end(JSON.stringify({ error: 'whatsapp webhook rate limited' }))
         }
         const body = await readBody(req)
-        if (!whatsappChannel.verifySignature(req.headers['x-hub-signature-256'], body)) {
-          noteInboundWebhookAuthFailure(rateKey)
-          res.writeHead(403)
-          return res.end(JSON.stringify({ error: 'invalid whatsapp signature' }))
-        }
         let count: number
         try {
-          count = await whatsappChannel.handleWebhook(parseJsonBody(body))
+          if (isWhatsAppMonorepoBridge(whatsappChannel)) {
+            // Bridge HMAC verified inside monorepo WebhookProvider.
+            count = await whatsappChannel.handleBridgeWebhook(body, {
+              'x-open-cowork-gateway-webhook-signature': req.headers['x-open-cowork-gateway-webhook-signature'],
+              'x-open-cowork-gateway-webhook-timestamp': req.headers['x-open-cowork-gateway-webhook-timestamp'],
+            })
+          } else {
+            if (!whatsappChannel.verifySignature(req.headers['x-hub-signature-256'], body)) {
+              noteInboundWebhookAuthFailure(rateKey)
+              res.writeHead(403)
+              return res.end(JSON.stringify({ error: 'invalid whatsapp signature' }))
+            }
+            count = await whatsappChannel.handleWebhook(parseJsonBody(body))
+          }
         } catch (err: any) {
-          if (!isTransientInboundError(err)) throw err
-          // Do not acknowledge a transiently failed inbound (e.g. OpenCode is
-          // restarting): a non-2xx status makes Meta retry the webhook delivery.
-          res.writeHead(503)
-          return res.end(JSON.stringify({ error: 'transient inbound failure; retry delivery' }))
+          if (isTransientInboundError(err)) {
+            // Do not acknowledge a transiently failed inbound (e.g. OpenCode is
+            // restarting): a non-2xx status makes Meta retry the webhook delivery.
+            res.writeHead(503)
+            return res.end(JSON.stringify({ error: 'transient inbound failure; retry delivery' }))
+          }
+          if (/auth|signature|secret/i.test(String(err?.message || err))) {
+            noteInboundWebhookAuthFailure(rateKey)
+            res.writeHead(403)
+            return res.end(JSON.stringify({ error: 'invalid whatsapp bridge signature' }))
+          }
+          throw err
         }
         res.writeHead(200)
         return res.end(JSON.stringify({ ok: true, messages: count }))
       }
 
       if (req.method === 'POST' && url.pathname === '/webhooks/discord') {
+        if (!discordChannel) {
+          res.writeHead(503)
+          return res.end(JSON.stringify({ error: 'discord adapter not ready' }))
+        }
         if (!canCurrentDaemonWrite()) return sendStandbyWebhookResponse(res)
         const rateKey = inboundWebhookRateKey('discord', req)
         const rate = claimInboundWebhookRateLimit(rateKey)
@@ -694,6 +726,23 @@ ev.onerror = () => {
           return res.end(JSON.stringify({ error: 'discord webhook rate limited' }))
         }
         const body = await readBody(req)
+        if (isDiscordMonorepoBridge(discordChannel)) {
+          try {
+            const count = await discordChannel.handleBridgeWebhook(body, {
+              'x-open-cowork-gateway-webhook-signature': req.headers['x-open-cowork-gateway-webhook-signature'],
+              'x-open-cowork-gateway-webhook-timestamp': req.headers['x-open-cowork-gateway-webhook-timestamp'],
+            })
+            res.writeHead(200)
+            return res.end(JSON.stringify({ ok: true, messages: count }))
+          } catch (err: any) {
+            if (/auth|signature|secret/i.test(String(err?.message || err))) {
+              noteInboundWebhookAuthFailure(rateKey)
+              res.writeHead(401)
+              return res.end(JSON.stringify({ error: 'invalid discord bridge signature' }))
+            }
+            throw err
+          }
+        }
         const response = await discordChannel.handleInteraction(body, {
           'x-signature-ed25519': req.headers['x-signature-ed25519'],
           'x-signature-timestamp': req.headers['x-signature-timestamp'],

--- a/scripts/check-channel-protocol-inventory.mjs
+++ b/scripts/check-channel-protocol-inventory.mjs
@@ -41,16 +41,23 @@ for (const name of ['telegram.ts', 'whatsapp.ts', 'discord.ts', 'provider.ts']) 
   mustExist(`products/gateway/src/channels/${name}`)
 }
 
-// JOE-994 Phase 2: Telegram monorepo façade + stack selector + shared policy
+// JOE-994 Phase 2–3: monorepo façades + stack selectors + shared policy
 for (const name of [
   'telegram-monorepo-adapter.ts',
   'telegram-protocol-stack.ts',
   'telegram-inbound-policy.ts',
+  'channel-inbound-policy.ts',
+  'discord-monorepo-adapter.ts',
+  'discord-protocol-stack.ts',
+  'whatsapp-monorepo-adapter.ts',
+  'whatsapp-protocol-stack.ts',
+  'bridge-protocol-stack.ts',
 ]) {
   mustExist(`products/gateway/src/channels/${name}`)
 }
 mustContain('docs/product-channel-protocol-unification.md', 'Phase 2')
-mustContain('docs/product-channel-ownership.md', 'Telegram monorepo façade')
+mustContain('docs/product-channel-protocol-unification.md', 'Phase 3')
+mustContain('docs/product-channel-ownership.md', 'Protocol stack façades')
 
 // Monorepo provider packages (at least the production set)
 const providerRoot = mustExist('packages')


### PR DESCRIPTION
## Summary

JOE-994 **Phase 3**: remaining Durable channels compose monorepo providers as **opt-in** façades.

- Shared inbound policy: `channel-inbound-policy.ts` (Telegram/Discord/WhatsApp)
- Discord monorepo façade over `@open-cowork/gateway-provider-discord` (**webhook bridge mode**)
- WhatsApp monorepo façade over `@open-cowork/gateway-provider-whatsapp` (**webhook bridge mode**)
- Protocol stack selectors + daemon channel-map webhook wiring
- Defaults remain **durable native** (no operator behavior change)

### Enable monorepo (opt-in)

```yaml
channels:
  discord:
    protocolStack: monorepo
    bridgeDeliveryUrl: https://relay.example/discord
    bridgeSharedSecret: "..."
  whatsapp:
    protocolStack: monorepo
    bridgeDeliveryUrl: https://relay.example/whatsapp
    bridgeSharedSecret: "..."
```

Env: `OPEN_COWORK_DISCORD_PROTOCOL_STACK`, `OPEN_COWORK_WHATSAPP_PROTOCOL_STACK`, `OPEN_COWORK_*_BRIDGE_*`.

### Residuals (explicit)

- Discord/WhatsApp monorepo = **bridge only** (relay must verify native platform signatures)
- Native Durable adapters not deleted (decommission residual)
- Default path unchanged

## Validation

- [x] inventory script
- [x] tsc / knip
- [x] vitest phase3 façades, telegram, discord, daemon-http, release-artifacts
- [ ] full CI

## Dual-channel security checklist

- [ ] N/A — not a channel security/protocol change
- [x] Reviewed **monorepo providers**
- [x] Reviewed **Durable Gateway channels**
- [x] Shared primitives preferred
- [x] Both stacks fixed **or** explicit single-stack ownership noted in Notes with follow-up

## User-visible impact

- [x] No user-visible behavior change (default path)
- [x] Runtime behavior change (only when monorepo/bridge stack enabled)
- [x] Docs change

## Notes

- Dual-stack checklist: both stacks reviewed for Phase 3 composition; security kernels unchanged
- Bridge mode is intentional (monorepo Discord/WhatsApp packages are WebhookProvider bridges)
- Epic residual: native decommission after monorepo/bridge becomes product default

Linear: JOE-994