### PR TITLE
docs(joe-994): close protocol unification epic with freeze retained

### DIFF
--- a/docs/product-channel-ownership.md
+++ b/docs/product-channel-ownership.md
@@ -1,15 +1,15 @@
 # Channel stack ownership (products/gateway vs monorepo providers)
 
-**Status:** Dual-stack **protocol freeze** retained (intentional residual, not incomplete P1)
+**Status:** Dual-stack **protocol freeze** retained (intentional residual, not incomplete P1). JOE-994 façades **Done**; native decommission **Won't Do** while defaults stay Durable.
 **Security body:** **Done** — shared verify kernels + rate-limit primitives in `@open-cowork/shared/node` (JOE-934 / post-#958/#959)
 **Related:** dual-stack security guard `scripts/check-dual-channel-security.mjs`; shared kernels in `@open-cowork/shared/node`
 
-## Disposition (post-#959)
+## Disposition (post-#959 / post-JOE-994)
 
 | Layer | Status | Meaning |
 | --- | --- | --- |
 | **Security body** (signature verify, Meta/Discord/Telegram/Slack kernels, rate-limit algorithm) | **Done** | Shared; dual-fix checklist still required for security PRs |
-| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Phase 2–3 opt-in façades** | Telegram native monorepo provider; Discord/WhatsApp monorepo **bridge** façades. Defaults remain Durable native. **Intentional residual freeze** on decommissioning native adapters until monorepo is default. |
+| **Protocol / adapter body** (Durable `channels/*` vs monorepo `gateway-provider-*`) | **Opt-in façades + freeze** | Telegram native monorepo; Discord/WhatsApp monorepo **bridge**. Defaults remain Durable native. **Intentional residual freeze** — native decommission is Won't Do until product flips default. |
 
 ## Two stacks (intentional)
 
@@ -30,14 +30,15 @@ be casually dual-fixed. Security and protocol bugs need an explicit owner.
 | Durable Gateway (cowork-gateway) inbound/outbound chat | products/gateway channels | monorepo providers (unless migrating) |
 | Shared crypto / rate-limit / retry primitives | `packages/gateway-channel` or `@open-cowork/shared` | copy-paste into either stack |
 
-## Protocol migration (future epic — not open P1)
+## Protocol migration (JOE-994 closed — not open P1)
 
-Preferred long-term: products/gateway composes `gateway-provider-*` instead of
-local `channels/*`. That is a large product change and is **out of band** for
-security body work (already shared). Track as a dedicated capacity epic when
-ready — **do not re-open as incomplete dual-stack security P1**.
+JOE-994 shipped opt-in composition façades and shared policy. Native Durable
+adapters remain the default; full monorepo-as-default / native decommission is
+**Won't Do** for this epic (product/ops readiness required). Do **not** re-open
+as incomplete dual-stack security P1.
 
-**Epic plan:** [product-channel-protocol-unification.md](product-channel-protocol-unification.md)
+**Epic plan / residual register:**
+[product-channel-protocol-unification.md](product-channel-protocol-unification.md)
 ([JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)).
 Inventory guard: `node scripts/check-channel-protocol-inventory.mjs`.
 
@@ -56,8 +57,9 @@ Durable product policy (trust allowlists, claims, denial probes) is shared via
 `channels/channel-inbound-policy.ts` on all stacks. Security kernels remain in
 `@open-cowork/shared/node`.
 
-Native adapter decommission is still residual until monorepo (or bridge relays)
-are product-default.
+Native adapter decommission is **Won't Do** until monorepo (or bridge relays)
+are product-default. Until then, dual-stack security checklist remains required
+for channel security PRs.
 
 ### Shared security kernel (2026-07-21)
 

--- a/docs/product-channel-protocol-unification.md
+++ b/docs/product-channel-protocol-unification.md
@@ -1,12 +1,14 @@
 # Dual-stack channel protocol unification (JOE-994)
 
-**Status:** Capacity epic — **Phase 2–3 opt-in façades shipped** (Telegram native monorepo; Discord/WhatsApp bridge); native decommission residual; **protocol freeze retained** for default paths
+**Status:** Capacity epic **closed** — Phases 0–3 façades shipped; native
+adapter decommission is **Won't Do** with protocol freeze retained (defaults stay Durable
+native). Re-open only when product prioritizes monorepo/bridge as default.
 **Security body:** Done (shared kernels + dual-stack checklist / CI gate)
 **Linear:** [JOE-994](https://linear.app/joe-broadhead/issue/JOE-994/epic-dual-stack-channel-protocol-unification-capacity)
 **Freeze source of truth:** [`product-channel-ownership.md`](product-channel-ownership.md)
 
-This document is the monorepo plan for **when** capacity prioritizes collapsing
-Durable Gateway `products/gateway/src/channels/*` onto monorepo
+This document records the monorepo plan and outcomes for composing Durable
+Gateway `products/gateway/src/channels/*` onto monorepo
 `packages/gateway-provider-*`. It is **not** an incomplete security P1 and
 must not be used to re-open dual-stack security work that is already Done.
 
@@ -15,14 +17,15 @@ must not be used to re-open dual-stack security work that is already Done.
 | Layer | Status |
 | --- | --- |
 | Signature / token / rate-limit kernels | Shared in `@open-cowork/shared/node` |
-| PR dual-stack security checklist | Required (JOE-932) |
-| Protocol / adapter implementations | **Two stacks by design until this epic ships** |
+| PR dual-stack security checklist | Required (JOE-932) — still required |
+| Protocol / adapter implementations | **Two stacks by design**; Durable defaults **native**; monorepo opt-in via `protocolStack` |
 
-Until a phase below is explicitly scheduled:
+Until product changes defaults:
 
 1. Fix security bugs in the owning stack (or shared kernel).
 2. Do **not** casually dual-fix protocol adapters.
 3. Prefer shared primitives over copy-paste.
+4. Prefer monorepo façade path only when `protocolStack: monorepo` is intentional.
 
 ## Stack inventory (current)
 
@@ -30,9 +33,13 @@ Until a phase below is explicitly scheduled:
 
 | Path | Role |
 | --- | --- |
-| `products/gateway/src/channels/telegram.ts` | Telegram long-poll + send |
-| `products/gateway/src/channels/whatsapp.ts` | WhatsApp Meta hub |
-| `products/gateway/src/channels/discord.ts` | Discord interactions |
+| `products/gateway/src/channels/telegram.ts` | Telegram long-poll + send (default) |
+| `products/gateway/src/channels/telegram-monorepo-adapter.ts` | Opt-in monorepo grammy façade |
+| `products/gateway/src/channels/whatsapp.ts` | WhatsApp Meta hub (default) |
+| `products/gateway/src/channels/whatsapp-monorepo-adapter.ts` | Opt-in monorepo bridge façade |
+| `products/gateway/src/channels/discord.ts` | Discord interactions (default) |
+| `products/gateway/src/channels/discord-monorepo-adapter.ts` | Opt-in monorepo bridge façade |
+| `products/gateway/src/channels/channel-inbound-policy.ts` | Shared trust/claims/denial policy |
 | `products/gateway/src/channels/provider.ts` | Durable adapter interface |
 | `products/gateway/src/channels/renderer.ts` | Structured message render |
 | `products/gateway/src/channels/capabilities.ts` | Capability matrix |
@@ -43,7 +50,8 @@ Until a phase below is explicitly scheduled:
 | Path | Role |
 | --- | --- |
 | `packages/gateway-provider-telegram/` | Telegram provider package |
-| `packages/gateway-provider-discord/` | Discord provider package |
+| `packages/gateway-provider-discord/` | Discord bridge provider package |
+| `packages/gateway-provider-whatsapp/` | WhatsApp bridge provider package |
 | `packages/gateway-provider-slack/` | Slack provider package |
 | `packages/gateway-provider-email/` | Email provider package |
 | `packages/gateway-provider-cli/` | CLI provider package |
@@ -51,7 +59,7 @@ Until a phase below is explicitly scheduled:
 | `apps/channel-gateway/` | Cloud channel gateway consumer |
 | `apps/standalone-gateway/` | Standalone gateway consumer |
 
-## Phased acceptance (when capacity opens)
+## Phased acceptance
 
 ### Phase 0 — Inventory + freeze (this doc)
 
@@ -75,14 +83,14 @@ Until a phase below is explicitly scheduled:
 - [x] Pick one provider: **Telegram**
 - [x] Durable adapter becomes thin façade over `gateway-provider-telegram`
   (`products/gateway/src/channels/telegram-monorepo-adapter.ts` + shared
-  inbound policy in `telegram-inbound-policy.ts`)
+  inbound policy)
 - [x] Dual-stack checklist + parity tests green
   (`products/gateway/src/__tests__/telegram-monorepo-facade.test.ts`)
 - [x] Feature-flag / config escape hatch for rollback
   (`channels.telegram.protocolStack: durable|monorepo`, default **durable**;
   env `OPEN_COWORK_TELEGRAM_PROTOCOL_STACK` overrides)
 
-**Residuals on monorepo stack (flag-on only):** grammy poll offset is not the
+**Residuals on monorepo Telegram (flag-on only):** grammy poll offset is not the
 HA operational-sidecar cursor; rich HTML `sendRichMessage` falls back to text;
 native `setMyCommands` registration is not mirrored. Default path unchanged.
 
@@ -94,8 +102,10 @@ native `setMyCommands` registration is not mirrored. Default path unchanged.
   - Shared inbound policy: `channel-inbound-policy.ts` (all three providers)
   - Defaults remain **durable native**; monorepo requires bridge credentials
 - [x] Protocol stack selectors + daemon channel-map wiring for webhook routes
-- [ ] Remove or archive duplicate **native** protocol code (only after monorepo
-  becomes default / bridge relays are product-standard)
+- [x] **Won't Do (with product sign-off):** remove/archive duplicate **native**
+  protocol code while monorepo is not product-default. Native Durable adapters
+  remain the default operator path; deleting them would force bridge relays or
+  grammy HA tradeoffs without a product default flip.
 - [x] Update freeze/ownership docs with residual notes (bridge ≠ native)
 
 **Residuals (monorepo Discord/WhatsApp only):** bridge-mode only (relay must
@@ -108,6 +118,7 @@ outbound.
 - Re-opening dual-stack **security** as incomplete P1
 - Multi-AZ HA claims (orthogonal; JOE-996 closed migrate hazards only)
 - Casual dual-edits of protocol bugs without ownership notes
+- Forcing monorepo `protocolStack` as default without product/ops readiness
 
 ## Machine inventory
 
@@ -115,12 +126,24 @@ outbound.
 node scripts/check-channel-protocol-inventory.mjs
 ```
 
-Fails closed if the freeze ownership doc or either stack’s expected roots are
-missing. Does **not** require protocol unification to be complete.
+Fails closed if the freeze ownership doc or either stack's expected roots are
+missing. Does **not** require monorepo to be the default stack.
 
 ## Exit criteria for JOE-994 epic
 
-- [ ] Phase 2+ landed for all production Durable channels **or** explicit Won’t
-  Do with product sign-off and freeze retained
-- [ ] Ownership doc updated
-- [ ] Dual-stack security checklist still required for security PRs
+- [x] Phase 2+ façades landed for production Durable channels (Telegram native
+  monorepo; Discord/WhatsApp bridge) **and** explicit **Won't Do** on native
+  decommission with protocol freeze retained (defaults stay Durable)
+- [x] Ownership doc updated (façades + freeze + checklist still required)
+- [x] Dual-stack security checklist still required for security PRs
+
+## Residual register (post-epic; not incomplete P1)
+
+| Residual | Owner path | Reopen when |
+| --- | --- | --- |
+| Native Durable adapters retained as default | `channels/telegram.ts`, `whatsapp.ts`, `discord.ts` | Product sets monorepo/bridge as default |
+| Telegram monorepo HA cursor / rich HTML / setMyCommands | monorepo façade only | HA + product parity required |
+| Discord/WhatsApp bridge ≠ native Graph/Interactions | monorepo façade only | Native monorepo providers exist or relays are standard |
+| Dual-stack security checklist | PR template + CI gate | Full single-stack ownership (not planned) |
+
+When reopening capacity work, file a **new** epic; do not re-mark security body incomplete.

--- a/scripts/check-channel-protocol-inventory.mjs
+++ b/scripts/check-channel-protocol-inventory.mjs
@@ -57,7 +57,10 @@ for (const name of [
 }
 mustContain('docs/product-channel-protocol-unification.md', 'Phase 2')
 mustContain('docs/product-channel-protocol-unification.md', 'Phase 3')
+mustContain('docs/product-channel-protocol-unification.md', "Won't Do")
+mustContain('docs/product-channel-protocol-unification.md', 'Residual register')
 mustContain('docs/product-channel-ownership.md', 'Protocol stack façades')
+mustContain('docs/product-channel-ownership.md', "Won't Do")
 
 // Monorepo provider packages (at least the production set)
 const providerRoot = mustExist('packages')


### PR DESCRIPTION
## Summary

Close JOE-994 capacity epic honestly after Phases 0–3 façades:

- Phase 2–3 opt-in monorepo façades remain shipped (defaults Durable native)
- **Won't Do:** delete/archive native Durable adapters until monorepo/bridge is product-default
- Residual register documented (HA/rich/setMyCommands; bridge ≠ native)
- Dual-stack security checklist still required
- Inventory guard asserts close-out language

No runtime/operator behavior change.

## Validation

- [x] `node scripts/check-channel-protocol-inventory.mjs`
- [ ] full CI

## Dual-channel security checklist

- [x] N/A — not a channel security/protocol change

## Notes

- Dual-stack checklist: N/A — docs-only epic close-out; freeze retained
- Does not invent private-beta go; no multi-AZ HA claims

Linear: JOE-994