### PR TITLE
feat(voice): private realtime voice scaffold (JOE-1096 V0/V1.1)

### DIFF
--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -42,6 +42,7 @@ import { registerAdminHandlers } from './ipc/admin-handlers.ts'
 import { registerE2EEvalHandlers } from './ipc/e2e-eval-handlers.ts'
 import { registerWorkspaceHandlers } from './ipc/workspace-handlers.ts'
 import { registerDesktopPairingHandlers } from './ipc/desktop-pairing-handlers.ts'
+import { registerVoiceHandlers } from './ipc/voice-handlers.ts'
 import type { IpcHandlerContext } from './ipc/context.ts'
 import { objectArg, registerIpcInvoke } from './ipc/schema.ts'
 import { validateDestructiveConfirmationRequest } from './ipc/object-validators.ts'
@@ -406,6 +407,7 @@ export function setupIpcHandlers(
   registerArtifactHandlers(context)
   registerLaunchpadHandlers(context)
   registerKnowledgeHandlers(context)
+  registerVoiceHandlers(context)
   registerCoordinationHandlers(context)
   registerChannelHandlers(context)
   registerWorkflowHandlers(context)

--- a/apps/desktop/src/main/ipc/voice-handlers.ts
+++ b/apps/desktop/src/main/ipc/voice-handlers.ts
@@ -1,0 +1,84 @@
+/**
+ * Private realtime voice IPC scaffold (JOE-1096 / JOE-1097).
+ *
+ * Handlers are intentional stubs until Aurum STT + sibling TTS are wired in the
+ * voice host. They never capture audio in the renderer and never claim readiness.
+ */
+import {
+  isDesktopFeatureEnabled,
+  VOICE_HOST_DEFERRED_REASON,
+  voiceHostStatusForFeatures,
+  type VoiceHostStatus,
+  type VoiceSessionSnapshot,
+  type VoiceSessionStartInput,
+} from '@open-cowork/shared'
+import { getAppConfig } from '@open-cowork/runtime-host/config'
+import type { IpcHandlerContext } from './context.ts'
+import {
+  noIpcArgs,
+  optionalObjectArg,
+  optionalStringArg,
+  registerIpcInvoke,
+} from './schema.ts'
+
+function currentStatus(): VoiceHostStatus {
+  return voiceHostStatusForFeatures(getAppConfig().features)
+}
+
+function assertVoiceFeatureEnabled() {
+  if (!isDesktopFeatureEnabled(getAppConfig().features, 'voice')) {
+    throw new Error('Private voice is disabled. Set features.voice to true in open-cowork.config.json to opt in.')
+  }
+}
+
+function normalizeStartInput(value: Record<string, unknown> | undefined): VoiceSessionStartInput {
+  if (!value) return {}
+  const openCodeSessionId = typeof value.openCodeSessionId === 'string' && value.openCodeSessionId.trim()
+    ? value.openCodeSessionId.trim()
+    : null
+  const workspaceId = typeof value.workspaceId === 'string' && value.workspaceId.trim()
+    ? value.workspaceId.trim()
+    : null
+  const mode = value.mode === 'conversation' || value.mode === 'ptt' ? value.mode : undefined
+  return {
+    ...(openCodeSessionId ? { openCodeSessionId } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(mode ? { mode } : {}),
+  }
+}
+
+export function registerVoiceHandlers(context: IpcHandlerContext) {
+  registerIpcInvoke(context, 'voice:status', noIpcArgs, async () => currentStatus())
+
+  registerIpcInvoke(
+    context,
+    'voice:session:start',
+    optionalObjectArg<VoiceSessionStartInput>('voice session start input'),
+    async (_event, input) => {
+      assertVoiceFeatureEnabled()
+      const normalized = normalizeStartInput(input as Record<string, unknown> | undefined)
+      // Scaffold: refuse to open a live capture session until the host is real.
+      throw new Error(
+        `Voice session start is deferred: ${VOICE_HOST_DEFERRED_REASON}`
+        + (normalized.openCodeSessionId ? ` (session ${normalized.openCodeSessionId})` : ''),
+      )
+    },
+  )
+
+  registerIpcInvoke(
+    context,
+    'voice:session:stop',
+    optionalStringArg('voice session id'),
+    async () => currentStatus(),
+  )
+
+  registerIpcInvoke(
+    context,
+    'voice:session:cancel',
+    optionalStringArg('voice session id'),
+    async () => currentStatus(),
+  )
+}
+
+export type { VoiceHostStatus, VoiceSessionSnapshot, VoiceSessionStartInput }
+export { voiceHostStatusForFeatures }

--- a/apps/desktop/src/main/ipc/voice-handlers.ts
+++ b/apps/desktop/src/main/ipc/voice-handlers.ts
@@ -69,14 +69,14 @@ export function registerVoiceHandlers(context: IpcHandlerContext) {
     context,
     'voice:session:stop',
     optionalStringArg('voice session id'),
-    async () => currentStatus(),
+    async (_event, _sessionId) => currentStatus(),
   )
 
   registerIpcInvoke(
     context,
     'voice:session:cancel',
     optionalStringArg('voice session id'),
-    async () => currentStatus(),
+    async (_event, _sessionId) => currentStatus(),
   )
 }
 

--- a/apps/desktop/src/main/main-window-security.ts
+++ b/apps/desktop/src/main/main-window-security.ts
@@ -5,6 +5,7 @@ import {
   isExpectedPackagedRendererFile,
   rendererUrlMatchesDevServer,
 } from './main-window-lifecycle.ts'
+import { resolveRendererMediaPermission } from './voice-permission-policy.ts'
 import { log } from '@open-cowork/shared/node'
 
 const guardedWebContents = new WeakSet<WebContents>()
@@ -59,10 +60,41 @@ export function attachWebContentsSecurityGuards(
   })
 }
 
-export function attachPermissionGuards() {
+/**
+ * Fail-closed renderer permissions (JOE-1098).
+ *
+ * Private voice owns mic capture in the voice host by default, so Chromium
+ * `media` / `microphone` for the Studio renderer stay denied unless a future
+ * ADR opts into captureMode === 'renderer' with features.voice enabled.
+ */
+export function attachPermissionGuards(options: {
+  features?: { voice?: boolean }
+  captureMode?: 'voice_host' | 'renderer'
+} = {}) {
+  const features = options.features
+  const captureMode = options.captureMode || 'voice_host'
+
   electronSession.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-    log('security', `Denied renderer permission request: ${permission}`)
+    const decision = resolveRendererMediaPermission({
+      features,
+      captureMode,
+      permission,
+    })
+    if (decision.allowed) {
+      log('security', `Granted renderer permission request: ${permission} (${decision.reason})`)
+      callback(true)
+      return
+    }
+    log('security', `Denied renderer permission request: ${permission} (${decision.reason})`)
     callback(false)
   })
-  electronSession.defaultSession.setPermissionCheckHandler(() => false)
+
+  electronSession.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
+    const decision = resolveRendererMediaPermission({
+      features,
+      captureMode,
+      permission: String(permission),
+    })
+    return decision.allowed
+  })
 }

--- a/apps/desktop/src/main/voice-permission-policy.ts
+++ b/apps/desktop/src/main/voice-permission-policy.ts
@@ -1,0 +1,93 @@
+/**
+ * Electron media / OS permission policy for private voice (JOE-1098).
+ *
+ * Capture is owned by the voice host outside the Chromium renderer by default
+ * (ADR private-realtime-voice). Renderer `media` / `microphone` stay denied
+ * unless an explicit future captureMode === 'renderer' is chosen.
+ */
+import {
+  isDesktopFeatureEnabled,
+  type DesktopFeatureFlags,
+  type VoiceCaptureMode,
+} from '@open-cowork/shared'
+
+export type MediaPermissionDecision = {
+  allowed: boolean
+  reason: string
+}
+
+export function isVoiceRelatedElectronPermission(permission: string): boolean {
+  return permission === 'media' || permission === 'microphone' || permission === 'mediaKeySystem'
+}
+
+/**
+ * Resolve whether the Studio renderer may be granted Chromium media permission.
+ * Default captureMode is voice_host → always false for renderer media.
+ */
+export function resolveRendererMediaPermission(options: {
+  features?: DesktopFeatureFlags
+  captureMode?: VoiceCaptureMode
+  permission: string
+}): MediaPermissionDecision {
+  if (!isVoiceRelatedElectronPermission(options.permission)) {
+    return {
+      allowed: false,
+      reason: `Permission ${options.permission} is not granted to the Open Cowork renderer.`,
+    }
+  }
+
+  const captureMode = options.captureMode || 'voice_host'
+  if (captureMode !== 'renderer') {
+    return {
+      allowed: false,
+      reason: 'Private voice captures audio in the voice host outside the renderer (default).',
+    }
+  }
+
+  if (!isDesktopFeatureEnabled(options.features, 'voice')) {
+    return {
+      allowed: false,
+      reason: 'features.voice is disabled; renderer media capture stays off.',
+    }
+  }
+
+  return {
+    allowed: true,
+    reason: 'features.voice enabled with explicit renderer capture mode.',
+  }
+}
+
+/** OS-facing matrix (docs + doctor). Values are product claims, not live OS queries. */
+export type OsVoicePermissionMatrixRow = {
+  permission: 'microphone' | 'speech_recognition' | 'screen' | 'accessibility'
+  desktopLocal: string
+  cloudWeb: string
+  notes: string
+}
+
+export const OS_VOICE_PERMISSION_MATRIX: OsVoicePermissionMatrixRow[] = [
+  {
+    permission: 'microphone',
+    desktopLocal: 'Required for capture when features.voice is on; requested by voice host',
+    cloudWeb: 'Not requested — voice.* not_supported',
+    notes: 'Not granted via Chromium getUserMedia for Studio renderer by default',
+  },
+  {
+    permission: 'speech_recognition',
+    desktopLocal: 'Not used — Aurum on-device STT, not OS dictation APIs',
+    cloudWeb: 'N/A',
+    notes: 'Avoid OS cloud speech services',
+  },
+  {
+    permission: 'screen',
+    desktopLocal: 'Not required for V0–V2 voice',
+    cloudWeb: 'N/A',
+    notes: 'Reserved; do not couple voice to screen capture',
+  },
+  {
+    permission: 'accessibility',
+    desktopLocal: 'Not required for in-app PTT',
+    cloudWeb: 'N/A',
+    notes: 'ZephyrFlow may use accessibility for system-wide inject; Open Cowork does not',
+  },
+]

--- a/apps/desktop/src/main/workspace-gateway.ts
+++ b/apps/desktop/src/main/workspace-gateway.ts
@@ -789,6 +789,10 @@ export class WorkspaceGateway {
       cloudSupport('localFiles', 'not_supported', 'Cloud workspaces do not implicitly upload local files.'),
       cloudSupport('localStdioMcps', 'not_supported', 'Cloud workspaces do not execute arbitrary local stdio MCPs.'),
       cloudSupport('machineRuntimeConfig', 'not_supported', 'Cloud workspaces do not use machine-native runtime config.'),
+      cloudSupport('voice.capture', 'not_supported', 'Private realtime voice is Desktop Local only. Cloud workspaces do not capture microphone audio on this machine.'),
+      cloudSupport('voice.stt', 'not_supported', 'On-device speech-to-text (Aurum) is Desktop Local only.'),
+      cloudSupport('voice.tts', 'not_supported', 'Private text-to-speech is Desktop Local only.'),
+      cloudSupport('voice.conversation', 'not_supported', 'Voice conversation is Desktop Local only.'),
     ]
   }
 
@@ -918,6 +922,10 @@ export class WorkspaceGateway {
       remoteSupport('localFiles', 'not_supported', input.pathReason, { artifactBody: 'none', artifactReveal: 'none' }),
       remoteSupport('localStdioMcps', 'not_supported', 'Remote workspaces do not execute this Desktop app\'s local stdio MCPs.'),
       remoteSupport('machineRuntimeConfig', 'not_supported', 'Remote workspaces do not use this Desktop app\'s machine-native runtime config.'),
+      remoteSupport('voice.capture', 'not_supported', 'Private realtime voice is Desktop Local only.'),
+      remoteSupport('voice.stt', 'not_supported', 'On-device speech-to-text is Desktop Local only.'),
+      remoteSupport('voice.tts', 'not_supported', 'Private text-to-speech is Desktop Local only.'),
+      remoteSupport('voice.conversation', 'not_supported', 'Voice conversation is Desktop Local only.'),
     ]
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -104,6 +104,10 @@ const PRELOAD_INVOKE_CHANNELS = [
   'knowledge:proposal:decline',
   'knowledge:page:history',
   'knowledge:page:restore',
+  'voice:status',
+  'voice:session:start',
+  'voice:session:stop',
+  'voice:session:cancel',
   'confirm:request-destructive',
   'clipboard:write-text',
   'tool:list',
@@ -284,6 +288,7 @@ const PRELOAD_LISTEN_CHANNELS = [
   'workflow:updated',
   'coordination:updated',
   'knowledge:updated',
+  'voice:event',
 ] as const
 
 type PreloadInvokeChannel = typeof PRELOAD_INVOKE_CHANNELS[number]
@@ -408,6 +413,12 @@ const api: CoworkAPI = {
     declineProposal: (proposalId, input) => input ? invoke('knowledge:proposal:decline', proposalId, input) : invoke('knowledge:proposal:decline', proposalId),
     history: (pageId, options) => options ? invoke('knowledge:page:history', pageId, options) : invoke('knowledge:page:history', pageId),
     restoreVersion: (pageId, versionId, input) => input ? invoke('knowledge:page:restore', pageId, versionId, input) : invoke('knowledge:page:restore', pageId, versionId),
+  },
+  voice: {
+    status: () => invoke('voice:status'),
+    startSession: (input) => input ? invoke('voice:session:start', input) : invoke('voice:session:start'),
+    stopSession: (sessionId) => sessionId ? invoke('voice:session:stop', sessionId) : invoke('voice:session:stop'),
+    cancel: (sessionId) => sessionId ? invoke('voice:session:cancel', sessionId) : invoke('voice:session:cancel'),
   },
   confirm: {
     requestDestructive: (request) => invoke('confirm:request-destructive', request),
@@ -717,6 +728,10 @@ const api: CoworkAPI = {
     knowledgeUpdated: (callback: () => void) => {
       const handler = () => callback()
       return listen('knowledge:updated', handler)
+    },
+    voiceEvent: (callback: (data: unknown) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data)
+      return listen('voice:event', handler)
     },
   },
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -10,6 +10,7 @@ import type {
   SessionPatch,
   SessionView,
   UpdateInstallEvent,
+  VoiceHostEvent,
   WorkspaceSessionsUpdatedEvent,
 } from '@open-cowork/shared'
 
@@ -729,8 +730,8 @@ const api: CoworkAPI = {
       const handler = () => callback()
       return listen('knowledge:updated', handler)
     },
-    voiceEvent: (callback: (data: unknown) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data)
+    voiceEvent: (callback: (data: VoiceHostEvent) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: VoiceHostEvent) => callback(data)
       return listen('voice:event', handler)
     },
   },

--- a/apps/desktop/tests/preload-api.smoke.test.ts
+++ b/apps/desktop/tests/preload-api.smoke.test.ts
@@ -28,6 +28,7 @@ test('preload exposes the expected coworkApi surface', async () => {
           workspaceActivate: typeof api.workspace?.activate,
           desktopPairingList: typeof api.desktopPairing?.list,
           projectSourceValidate: typeof api.projectSource?.validate,
+          voiceStatus: typeof api.voice?.status,
           onSessionPatch: typeof api.on?.sessionPatch,
         },
       }
@@ -50,6 +51,7 @@ test('preload exposes the expected coworkApi surface', async () => {
       workspaceActivate: 'function',
       desktopPairingList: 'function',
       projectSourceValidate: 'function',
+      voiceStatus: 'function',
       onSessionPatch: 'function',
     })
     assert.deepEqual(surface.groups, [
@@ -86,6 +88,7 @@ test('preload exposes the expected coworkApi surface', async () => {
       'threads',
       'tools',
       'updates',
+      'voice',
       'workflows',
       'workspace',
     ])

--- a/docs/adr/private-realtime-voice.md
+++ b/docs/adr/private-realtime-voice.md
@@ -1,0 +1,104 @@
+---
+title: ADR — Private realtime voice (Desktop Local)
+description: On-machine STT/TTS for Open Cowork Desktop Local; Aurum STT, sibling TTS, voice host outside renderer.
+---
+
+# ADR: Private realtime voice (Desktop Local)
+
+| Field | Value |
+| --- | --- |
+| Status | **Accepted** |
+| Date | 2026-07-24 |
+| Linear | [JOE-1096](https://linear.app/joe-broadhead/issue/JOE-1096) epic; V0 [JOE-1099](https://linear.app/joe-broadhead/issue/JOE-1099) |
+| Milestone | Private Realtime Voice |
+
+## Context
+
+Operators want **push-to-talk / conversational voice** against local OpenCode sessions without sending microphone audio to cloud STT/TTS vendors by default.
+
+Sibling work:
+
+- **Aurum** — on-device speech-to-text (`aurum-stt` / whisper.cpp; PCM-first library API). Optional remote paths exist but are never the default.
+- **ZephyrFlow** — macOS menu-bar dictation product (Whisper, Local Only). Reference UX for PTT; **not** a TTS engine and not the Open Cowork voice host.
+
+Open Cowork already removed fake Settings “voice replies” teasers (product purity JOE-1031). Voice must not reappear as a half-wired toggle.
+
+## Decision
+
+### 1. Product surface
+
+| Rule | Decision |
+| --- | --- |
+| Default authority | **Desktop Local only** |
+| Cloud Desktop / Cloud Web | **Blocked** — `voice.*` support APIs are `not_supported` |
+| Gateway / paired | **Blocked** until a future ADR |
+| Feature flag | `features.voice` — **secondary**, default **off** (progressive disclosure) |
+| Public claims | No “private voice shipping” until V2 PTT UI + local STT path are real |
+
+### 2. Engine split
+
+| Role | Owner | Notes |
+| --- | --- | --- |
+| **STT** | **Aurum** (`local_only` / on-device) | PCM in → text out; no API key by default |
+| **TTS** | **Sibling / separate engine** | **Not Aurum**. Aurum is STT-first; do not stretch it into synthesis |
+| Orchestration | Open Cowork **voice host** (Electron main / native side) | Outside Chromium renderer |
+
+### 3. Architecture boundary
+
+```text
+Renderer (UI only)
+  │  IPC: voice:status | voice:session:* | voice:partial | voice:final
+  ▼
+Voice host (main / native — never Node in renderer)
+  │  mic capture (OS APIs)
+  │  STT via Aurum local_only
+  │  TTS via sibling engine
+  ▼
+OpenCode session prompt / stream (existing session path)
+```
+
+Rules:
+
+1. **No raw audio bytes on the renderer IPC path** by default. Prefer partial/final **text** and host-owned playback.
+2. Chromium `getUserMedia` / Electron session `media` for the **Studio renderer stays denied** unless a future ADR chooses an explicit renderer capture mode.
+3. OS microphone permission is owned by the **voice host**, not by ad-hoc Settings toggles.
+4. Cloud Web must never request mic for Open Cowork Studio (support matrix + browser matrix).
+
+### 4. Workspace support APIs
+
+| API | Desktop Local | Cloud / browser / remote |
+| --- | --- | --- |
+| `voice.capture` | supported (authority) | `not_supported` |
+| `voice.stt` | supported (authority) | `not_supported` |
+| `voice.tts` | supported (authority) | `not_supported` |
+| `voice.conversation` | supported (authority) | `not_supported` |
+
+“Supported” means **this authority may host voice**, not that every UI control is complete. Runtime readiness is reported via `voice:status` (`ready` / `deferred` / `unavailable`). UI stays behind `features.voice`.
+
+### 5. Progressive disclosure
+
+- Omit or set `features.voice: false` in public default config.
+- Soft enablement warning via `desktopFeatureEnablementWarnings` (local-only, Aurum STT, sibling TTS, host not renderer).
+- Do not market voice until release checklist evidence is green.
+
+## Non-goals (this milestone)
+
+- Cloud / multi-tenant voice
+- Using Aurum as TTS
+- Shipping ZephyrFlow inside Open Cowork
+- Renderer-owned continuous listening without PTT policy
+- Replacing chat text input as the only interaction mode
+
+## Consequences
+
+- Shared package grows `voice` IPC types and `voice.*` workspace support keys.
+- Electron permission guards stay fail-closed for renderer media; docs state host ownership.
+- Residual purity risk for incomplete secondaries remains soft-warn only (same pattern as other Studio flags).
+
+## Related
+
+- [Progressive disclosure](../progressive-disclosure.md)
+- [Product purity register](../product-purity-register.md)
+- [Release checklist](../release-checklist.md)
+- Aurum: https://github.com/joe-broadhead/aurum
+- ZephyrFlow: https://github.com/joe-broadhead/zephyr-flow

--- a/docs/cloud-web-workbench.md
+++ b/docs/cloud-web-workbench.md
@@ -83,6 +83,7 @@ stays explicit.
 | Local Filesystem | Unavailable in Cloud | `threads`, `artifacts` | Use git URLs, managed Cloud project sources, uploaded snapshots, and Cloud artifacts instead. | Browser sessions must not implicitly read or upload host paths from the user machine. |
 | Local Stdio MCPs | Unavailable in Cloud | `capabilities`, `agents` | Show only policy-safe MCP metadata that has been converted into the Cloud profile. | Cloud Web cannot spawn local stdio MCP processes or expose command lines, environment variables, or secret refs. |
 | Machine Runtime Config | Desktop-only | `chat`, `agents`, `capabilities` | Show current Cloud profile, feature flags, and projected runtime state. | Cloud Web does not configure the local machine runtime, provider defaults, local approvals mode, or desktop notification settings. |
+| Private realtime voice | Desktop-only | — | `voice.*` support APIs report `not_supported`; browser API stubs refuse capture/STT/TTS. | Microphone and on-device STT stay on Desktop Local voice host only ([ADR](adr/private-realtime-voice.md)). |
 
 ## Admin/Settings Surface Matrix
 

--- a/docs/product-purity-register.md
+++ b/docs/product-purity-register.md
@@ -21,7 +21,7 @@ Home → Chat → Team | Tools & Skills | Playbooks | Projects
 
 Optional secondary Studio (default off; progressive disclosure):
 
-- Knowledge, Approvals, Channels, Artifacts
+- Knowledge, Approvals, Channels, Artifacts, Voice (private realtime; Desktop Local)
 
 Optional installable siblings (not Desktop default nav):
 
@@ -53,6 +53,7 @@ Optional installable siblings (not Desktop default nav):
 | Durable Gateway (`cowork-gateway`) | Local operator / claim-gated beta | Multi-tenant production GA without evidence |
 | Tier-1 channels (Telegram/Slack/email) | Launch-tier adapters | — |
 | Tier-3 channels (Discord/WhatsApp/Signal) | Experimental / bridge-backed | Launch marketing without live smoke |
+| Private realtime voice | Desktop Local opt-in (`features.voice`); on-device STT (Aurum) + sibling TTS | Cloud Web mic, Aurum-as-TTS, shipping claim before V2 PTT + engines |
 
 ## Forbidden claims (fail closed)
 
@@ -63,6 +64,8 @@ Optional installable siblings (not Desktop default nav):
 - Knowledge = Wiki (or OpenWiki as synonym for in-app Knowledge)
 - Enterprise-ready / hosted GA without rows proven in enterprise readiness matrix
 - Mobile / Teams as shipping products (names reserved only)
+- “Private voice shipping” while `features.voice` default-off and host/STT still deferred
+- Cloud Web or remote workspace microphone capture for Open Cowork Studio
 
 ## Finding → issue map (Wave 1+)
 

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -26,6 +26,7 @@ Configured under `features` in `open-cowork.config.json` (or overlays).
 | `approvals` | **off** | Multi-thread operators need a cross-chat queue |
 | `channels` | **off** | Cloud + Channel Gateway deployments |
 | `artifacts` | **off** | Heavy cross-session deliverable browse |
+| `voice` | **off** | Private realtime voice (Desktop Local; Aurum STT + sibling TTS) |
 
 Implementation: `DESKTOP_PRIMARY_FEATURE_KEYS` / `DESKTOP_SECONDARY_FEATURE_KEYS`
 and `isDesktopFeatureEnabled` in `packages/shared/src/app-config.ts`.
@@ -47,6 +48,7 @@ and `isDesktopFeatureEnabled` in `packages/shared/src/app-config.ts`.
 | `approvals` | Prefer Always-allow story complete for local; queue still useful for allow/deny/questions |
 | `knowledge` | Users understand Knowledge ≠ Wiki |
 | `artifacts` | Artifact index paths work for the authority in use |
+| `voice` | Desktop Local only; voice host + Aurum STT wired; Cloud Web / remote stay `not_supported`; see [Private realtime voice ADR](adr/private-realtime-voice.md) |
 
 Public `open-cowork.config.json` must **not** enable secondary keys by default
 and must **not** auto-register Wiki or durable Gateway MCP entries.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -25,7 +25,8 @@ Before publishing release notes or marketing copy, confirm against
 [Product purity register](product-purity-register.md):
 
 - [ ] No unqualified “gateway” (must say Channel / Standalone / durable Gateway)
-- [ ] No “Always allow” / voice / daily digest as shipping features unless implemented
+- [ ] No “Always allow” / daily digest as shipping features unless implemented
+- [ ] Private voice (`features.voice`) not claimed shipping unless host + Aurum STT + PTT UI evidence is green ([ADR](adr/private-realtime-voice.md)); default remains off
 - [ ] No Standalone/Paired “full workspace chat ready” while support matrix is deferred
 - [ ] Knowledge ≠ Wiki; no default Desktop Wiki/Gateway MCP claims
 - [ ] Projects described as coordination board (not history facets) unless UI changes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
       - "ADR: Product partitions": adr/product-partitions.md
       - "ADR: Knowledge vs Wiki": adr/knowledge-vs-wiki.md
       - "ADR: Standalone Desktop session API": adr/standalone-desktop-session-api.md
+      - "ADR: Private realtime voice": adr/private-realtime-voice.md
 
 extra:
   generator: false

--- a/packages/app/src/browser/cowork-api-support.ts
+++ b/packages/app/src/browser/cowork-api-support.ts
@@ -13,6 +13,11 @@ const BROWSER_LOCAL_ONLY_APIS = new Set<string>([
   'localFiles',
   'localStdioMcps',
   'machineRuntimeConfig',
+  // Private voice is Desktop Local / on-machine only (JOE-1096).
+  'voice.capture',
+  'voice.stt',
+  'voice.tts',
+  'voice.conversation',
 ])
 
 function cloudFeatureEnabled(features: CloudFeatureFlags, key: string) {
@@ -53,6 +58,13 @@ export function browserCloudWorkspaceSupport(features: CloudFeatureFlags): Works
   }
 
   return WORKSPACE_SUPPORT_APIS.map((api) => {
+    if (api.startsWith('voice.')) {
+      return supportContext(
+        'not_supported',
+        'Private realtime voice is Desktop Local only. Cloud Web does not capture microphone audio for Open Cowork Studio.',
+        api,
+      )
+    }
     if (BROWSER_LOCAL_ONLY_APIS.has(api) || api === 'artifacts.reveal') {
       return supportContext('not_supported', 'This browser workspace cannot access local desktop files or reveal files on this machine.', api)
     }

--- a/packages/app/src/browser/cowork-api.ts
+++ b/packages/app/src/browser/cowork-api.ts
@@ -70,6 +70,7 @@ import {
   type WorkflowRun,
   type WorkspaceApiSupport,
   type WorkspaceInfo,
+  createDeferredVoiceHostStatus,
 } from '@open-cowork/shared'
 import { createBrowserAdminApi } from './cowork-api-admin'
 import { createBrowserCustomApi } from './cowork-api-custom'
@@ -345,6 +346,31 @@ export function createBrowserCoworkApi(bootstrap?: BrowserCoworkApiBootstrap): C
         })),
       restoreVersion: (pageId, versionId, input) =>
         request<{ page: KnowledgePageVersion }>(endpoint('knowledgePageRestore', { pageId }), { method: 'POST', body: { ...(input || {}), versionId } }),
+    },
+
+    // -- voice (Desktop Local only; Cloud Web never captures mic) ----------
+    voice: {
+      status: async () => ({
+        ...createDeferredVoiceHostStatus(
+          'Private realtime voice is Desktop Local only. Cloud Web does not capture microphone audio for Open Cowork Studio.',
+        ),
+        enabled: false,
+        phase: 'unavailable' as const,
+        captureMode: 'voice_host' as const,
+        stt: { engine: 'unavailable' as const, ready: false, detail: 'Cloud Web' },
+        tts: { engine: 'unavailable' as const, ready: false, detail: 'Cloud Web' },
+      }),
+      startSession: () => browserUnavailable('voice.startSession'),
+      stopSession: async () => ({
+        ...createDeferredVoiceHostStatus('Private realtime voice is Desktop Local only.'),
+        enabled: false,
+        phase: 'unavailable' as const,
+      }),
+      cancel: async () => ({
+        ...createDeferredVoiceHostStatus('Private realtime voice is Desktop Local only.'),
+        enabled: false,
+        phase: 'unavailable' as const,
+      }),
     },
 
     // -- permission --------------------------------------------------------
@@ -773,6 +799,7 @@ export function createBrowserCoworkApi(bootstrap?: BrowserCoworkApiBootstrap): C
       workflowUpdated: (callback) => hub.subscribe('workflowUpdated', callback),
       coordinationUpdated: (callback) => hub.subscribe('coordinationUpdated', callback),
       knowledgeUpdated: (callback) => hub.subscribe('knowledgeUpdated', callback),
+      voiceEvent: () => () => {},
     },
   }
 }

--- a/packages/app/src/stores/workspace-support.ts
+++ b/packages/app/src/stores/workspace-support.ts
@@ -163,6 +163,10 @@ export function deriveWorkspaceSupportFlags(support: WorkspaceApiSupport[] | und
     canRevealArtifact: mutation('artifacts.reveal') || mutation('localFiles'),
     canUseMachineRuntimeConfig: readable('machineRuntimeConfig') && !statusIsUnavailable(machineRuntimeConfig?.status),
     canUsePortableSettings: readable('settings.portable'),
+    canVoiceCapture: mutation('voice.capture'),
+    canVoiceStt: mutation('voice.stt'),
+    canVoiceTts: mutation('voice.tts'),
+    canVoiceConversation: mutation('voice.conversation'),
     reasons: {
       createSession: supportReason(support, 'sessions.create', 'Thread creation is disabled by this workspace policy.'),
       prompt: supportReason(support, 'sessions.prompt', 'Prompting is disabled by this workspace policy.'),
@@ -173,6 +177,10 @@ export function deriveWorkspaceSupportFlags(support: WorkspaceApiSupport[] | und
       revealArtifact: reveal?.verdict?.reason || localFiles?.verdict?.reason || 'Cloud artifacts cannot be revealed in the local filesystem.',
       machineRuntimeConfig: cloudProfileReason,
       settingsPortable: supportReason(support, 'settings.portable', 'Portable cloud settings are disabled by this workspace policy.'),
+      voiceCapture: supportReason(support, 'voice.capture', 'Microphone capture is only available in Desktop Local private voice.'),
+      voiceStt: supportReason(support, 'voice.stt', 'On-device speech-to-text is only available in Desktop Local private voice.'),
+      voiceTts: supportReason(support, 'voice.tts', 'Private text-to-speech is only available in Desktop Local private voice.'),
+      voiceConversation: supportReason(support, 'voice.conversation', 'Voice conversation is only available in Desktop Local private voice.'),
     },
   }
 }
@@ -262,6 +270,10 @@ export function useActiveWorkspaceSupport() {
       canRevealArtifact: false,
       canUseMachineRuntimeConfig: false,
       canUsePortableSettings: false,
+      canVoiceCapture: false,
+      canVoiceStt: false,
+      canVoiceTts: false,
+      canVoiceConversation: false,
       reasons: {
         ...next.reasons,
         createSession: checkingReason,
@@ -272,6 +284,10 @@ export function useActiveWorkspaceSupport() {
         revealArtifact: checkingReason,
         machineRuntimeConfig: checkingReason,
         settingsPortable: checkingReason,
+        voiceCapture: checkingReason,
+        voiceStt: checkingReason,
+        voiceTts: checkingReason,
+        voiceConversation: checkingReason,
       },
     }
   }, [activeWorkspaceId, loaded, support])

--- a/packages/shared/src/app-config.ts
+++ b/packages/shared/src/app-config.ts
@@ -396,6 +396,7 @@ export type DesktopFeatureKey =
   | 'channels'
   | 'tools'
   | 'artifacts'
+  | 'voice'
 
 /** Primary nav thesis: Chat/Team/Tools/Projects/Playbooks (+ Home/Settings). */
 export const DESKTOP_PRIMARY_FEATURE_KEYS = [
@@ -414,6 +415,7 @@ export const DESKTOP_SECONDARY_FEATURE_KEYS = [
   'approvals',
   'channels',
   'artifacts',
+  'voice',
 ] as const satisfies readonly DesktopFeatureKey[]
 
 const DESKTOP_SECONDARY_FEATURE_SET: ReadonlySet<DesktopFeatureKey> = new Set(
@@ -457,6 +459,11 @@ export function desktopFeatureEnablementWarnings(
   if (features.artifacts === true) {
     warnings.push(
       'features.artifacts is enabled: inspect/export stay redaction-safe; bodies are never auto-fetched.',
+    )
+  }
+  if (features.voice === true) {
+    warnings.push(
+      'features.voice is enabled: private realtime voice is Desktop Local only (Aurum STT + sibling TTS in the voice host); Cloud Web and remote authorities stay not_supported.',
     )
   }
   return warnings

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -176,6 +176,12 @@ import type {
   KnowledgeSpaceInput,
 } from './knowledge.js'
 import type {
+  VoiceHostEvent,
+  VoiceHostStatus,
+  VoiceSessionSnapshot,
+  VoiceSessionStartInput,
+} from './voice.js'
+import type {
   AdminAccess,
   AdminAuditExport,
   AdminAuditExportInput,
@@ -261,6 +267,7 @@ export * from './tool-trace.js'
 export * from './updates.js'
 export * from './vega-spec.js'
 export * from './workspace.js'
+export * from './voice.js'
 export * from './workflow.js'
 
 export interface CoworkAPI {
@@ -356,6 +363,16 @@ export interface CoworkAPI {
     declineProposal: (proposalId: string, input?: KnowledgeReviewInput) => Promise<KnowledgeProposal>
     history: (pageId: string, options?: KnowledgeSnapshotOptions) => Promise<KnowledgePageVersion[]>
     restoreVersion: (pageId: string, versionId: string, input?: KnowledgeReviewInput) => Promise<{ page: KnowledgePageVersion }>
+  }
+  /**
+   * Private realtime voice (Desktop Local). Scaffold: status/session IPC;
+   * engines land in V1+. Prefer text events over raw audio on this surface.
+   */
+  voice: {
+    status: () => Promise<VoiceHostStatus>
+    startSession: (input?: VoiceSessionStartInput) => Promise<VoiceSessionSnapshot>
+    stopSession: (sessionId?: string | null) => Promise<VoiceHostStatus>
+    cancel: (sessionId?: string | null) => Promise<VoiceHostStatus>
   }
   permission: {
     respond: (id: string, allowed: boolean, sessionId?: string | null, options?: WorkspaceOptions) => Promise<void>
@@ -638,6 +655,7 @@ export interface CoworkAPI {
     workflowUpdated: (callback: () => void) => () => void
     coordinationUpdated: (callback: () => void) => () => void
     knowledgeUpdated: (callback: () => void) => () => void
+    voiceEvent: (callback: (data: VoiceHostEvent) => void) => () => void
   }
 }
 

--- a/packages/shared/src/voice.ts
+++ b/packages/shared/src/voice.ts
@@ -1,0 +1,152 @@
+/**
+ * Private realtime voice contracts (JOE-1096).
+ *
+ * Capture and engines live in the Desktop voice host (main/native), not the
+ * Chromium renderer. These types are the IPC surface between host and UI.
+ */
+
+/** Workspace support keys for private voice (see WORKSPACE_SUPPORT_APIS). */
+export const VOICE_WORKSPACE_SUPPORT_APIS = [
+  'voice.capture',
+  'voice.stt',
+  'voice.tts',
+  'voice.conversation',
+] as const
+
+export type VoiceWorkspaceSupportApi = typeof VOICE_WORKSPACE_SUPPORT_APIS[number]
+
+/** Where microphone capture is owned. Default is voice_host. */
+export type VoiceCaptureMode = 'voice_host' | 'renderer'
+
+/** STT engine identity. Open Cowork uses Aurum local_only by decision. */
+export type VoiceSttEngine = 'aurum_local' | 'unavailable'
+
+/**
+ * TTS is intentionally not Aurum (STT-first product). Sibling engine TBD.
+ */
+export type VoiceTtsEngine = 'sibling' | 'unavailable'
+
+export type VoiceHostPhase =
+  | 'disabled'
+  | 'deferred'
+  | 'starting'
+  | 'ready'
+  | 'listening'
+  | 'transcribing'
+  | 'speaking'
+  | 'error'
+  | 'unavailable'
+
+export type VoicePermissionState =
+  | 'unknown'
+  | 'not_required'
+  | 'prompt'
+  | 'granted'
+  | 'denied'
+  | 'restricted'
+
+export type VoiceHostStatus = {
+  /** Feature + authority gate: false when features.voice off or non-local workspace. */
+  enabled: boolean
+  phase: VoiceHostPhase
+  captureMode: VoiceCaptureMode
+  stt: {
+    engine: VoiceSttEngine
+    ready: boolean
+    detail?: string | null
+  }
+  tts: {
+    engine: VoiceTtsEngine
+    ready: boolean
+    detail?: string | null
+  }
+  permissions: {
+    microphone: VoicePermissionState
+  }
+  /** Human-readable reason when not ready (deferred host, missing model, policy). */
+  reason: string | null
+  /** Active conversation session id when one is open. */
+  sessionId: string | null
+}
+
+export type VoiceSessionStartInput = {
+  /** OpenCode / Studio session to attach voice turns to. */
+  openCodeSessionId?: string | null
+  workspaceId?: string | null
+  /** Push-to-talk vs continuous; V2 UI uses ptt. */
+  mode?: 'ptt' | 'conversation'
+}
+
+export type VoiceSessionSnapshot = {
+  id: string
+  openCodeSessionId: string | null
+  workspaceId: string | null
+  mode: 'ptt' | 'conversation'
+  phase: VoiceHostPhase
+  startedAt: string
+}
+
+export type VoicePartialEvent = {
+  sessionId: string
+  text: string
+  isFinal: false
+  at: string
+}
+
+export type VoiceFinalEvent = {
+  sessionId: string
+  text: string
+  isFinal: true
+  at: string
+}
+
+export type VoiceHostEvent =
+  | { type: 'status'; status: VoiceHostStatus }
+  | { type: 'partial'; event: VoicePartialEvent }
+  | { type: 'final'; event: VoiceFinalEvent }
+  | { type: 'error'; sessionId: string | null; message: string; at: string }
+
+/** Default host status before the voice host process is wired (V0/V1 scaffold). */
+export function createDeferredVoiceHostStatus(reason: string): VoiceHostStatus {
+  return {
+    enabled: false,
+    phase: 'deferred',
+    captureMode: 'voice_host',
+    stt: {
+      engine: 'aurum_local',
+      ready: false,
+      detail: 'Aurum STT not wired yet',
+    },
+    tts: {
+      engine: 'sibling',
+      ready: false,
+      detail: 'Sibling TTS not wired yet',
+    },
+    permissions: {
+      microphone: 'unknown',
+    },
+    reason,
+    sessionId: null,
+  }
+}
+
+export const VOICE_HOST_DEFERRED_REASON =
+  'Private voice host is scaffolded; STT/TTS engines are not connected yet. Keep features.voice off until V1 engines land.'
+
+/**
+ * Derive host status from feature flags alone (no engines). Used by IPC stubs
+ * and unit tests before Aurum/sibling TTS are connected.
+ */
+export function voiceHostStatusForFeatures(features: { voice?: boolean } | undefined): VoiceHostStatus {
+  const enabled = features?.voice === true
+  const status = createDeferredVoiceHostStatus(
+    enabled
+      ? VOICE_HOST_DEFERRED_REASON
+      : 'features.voice is disabled (secondary Studio flag, default off).',
+  )
+  return {
+    ...status,
+    enabled,
+    phase: enabled ? 'deferred' : 'disabled',
+  }
+}

--- a/packages/shared/src/workspace.ts
+++ b/packages/shared/src/workspace.ts
@@ -106,6 +106,10 @@ export const WORKSPACE_SUPPORT_APIS = [
   'localFiles',
   'localStdioMcps',
   'machineRuntimeConfig',
+  'voice.capture',
+  'voice.stt',
+  'voice.tts',
+  'voice.conversation',
 ] as const
 
 export type WorkspaceSupportApi = typeof WORKSPACE_SUPPORT_APIS[number]

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -86,6 +86,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'session-status-reconciler.ts',
   'session-task-state-store.ts',
   'startup-splash.ts',
+  'voice-permission-policy.ts',
   'window-state.ts',
   'window-zoom.ts',
   'workspace-gateway-cloud-artifacts.ts',

--- a/tests/ipc-handler-registration.test.ts
+++ b/tests/ipc-handler-registration.test.ts
@@ -23,6 +23,7 @@ import { registerDesktopPairingHandlers } from '../apps/desktop/src/main/ipc/des
 import { registerCoordinationHandlers } from '../apps/desktop/src/main/ipc/coordination-handlers.ts'
 import { registerChannelHandlers } from '../apps/desktop/src/main/ipc/channel-handlers.ts'
 import { registerKnowledgeHandlers } from '../apps/desktop/src/main/ipc/knowledge-handlers.ts'
+import { registerVoiceHandlers } from '../apps/desktop/src/main/ipc/voice-handlers.ts'
 import { createWorkspaceGateway } from '../apps/desktop/src/main/workspace-gateway.ts'
 import { clearConfigCaches } from '@open-cowork/runtime-host/config'
 function createTestContext() {
@@ -198,6 +199,7 @@ test('preload invoke/send channels match registered main-process IPC channels', 
   registerCoordinationHandlers(context)
   registerChannelHandlers(context)
   registerKnowledgeHandlers(context)
+  registerVoiceHandlers(context)
   registerSessionHandlers(context)
   registerCatalogHandlers(context)
   registerCustomContentHandlers(context)

--- a/tests/private-voice-scaffold.test.ts
+++ b/tests/private-voice-scaffold.test.ts
@@ -1,0 +1,152 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  DESKTOP_SECONDARY_FEATURE_KEYS,
+  desktopFeatureEnablementWarnings,
+  isDesktopFeatureEnabled,
+} from '../packages/shared/src/app-config.ts'
+import {
+  WORKSPACE_SUPPORT_APIS,
+} from '../packages/shared/src/workspace.ts'
+import {
+  createDeferredVoiceHostStatus,
+  VOICE_HOST_DEFERRED_REASON,
+  VOICE_WORKSPACE_SUPPORT_APIS,
+  voiceHostStatusForFeatures,
+} from '../packages/shared/src/voice.ts'
+import { browserCloudWorkspaceSupport } from '../packages/app/src/browser/cowork-api-support.ts'
+import {
+  isVoiceRelatedElectronPermission,
+  OS_VOICE_PERMISSION_MATRIX,
+  resolveRendererMediaPermission,
+} from '../apps/desktop/src/main/voice-permission-policy.ts'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+test('private voice: features.voice is secondary and default-off', () => {
+  assert.ok((DESKTOP_SECONDARY_FEATURE_KEYS as readonly string[]).includes('voice'))
+  assert.equal(isDesktopFeatureEnabled(undefined, 'voice'), false)
+  assert.equal(isDesktopFeatureEnabled({}, 'voice'), false)
+  assert.equal(isDesktopFeatureEnabled({ voice: true }, 'voice'), true)
+  const warnings = desktopFeatureEnablementWarnings({ voice: true })
+  assert.equal(warnings.length, 1)
+  assert.match(warnings[0]!, /Desktop Local/i)
+  assert.match(warnings[0]!, /Aurum/i)
+})
+
+test('private voice: workspace support APIs include voice.* keys', () => {
+  for (const api of VOICE_WORKSPACE_SUPPORT_APIS) {
+    assert.ok(WORKSPACE_SUPPORT_APIS.includes(api), `missing ${api}`)
+  }
+})
+
+test('private voice: browser cloud matrix marks voice not_supported', () => {
+  const support = browserCloudWorkspaceSupport({})
+  for (const api of VOICE_WORKSPACE_SUPPORT_APIS) {
+    const entry = support.find((row) => row.api === api)
+    assert.ok(entry, `browser support missing ${api}`)
+    assert.equal(entry!.status, 'not_supported')
+    assert.match(entry!.verdict?.reason || '', /Desktop Local|microphone/i)
+  }
+})
+
+test('private voice: workspace-support store derives canVoice* flags', () => {
+  const source = readFileSync(join(root, 'packages/app/src/stores/workspace-support.ts'), 'utf8')
+  assert.match(source, /canVoiceCapture: mutation\('voice\.capture'\)/)
+  assert.match(source, /canVoiceStt: mutation\('voice\.stt'\)/)
+  assert.match(source, /canVoiceTts: mutation\('voice\.tts'\)/)
+  assert.match(source, /canVoiceConversation: mutation\('voice\.conversation'\)/)
+  assert.match(source, /voiceCapture: supportReason\(support, 'voice\.capture'/)
+})
+
+test('private voice: renderer media denied by default (voice host owns mic)', () => {
+  assert.equal(isVoiceRelatedElectronPermission('media'), true)
+  assert.equal(isVoiceRelatedElectronPermission('geolocation'), false)
+
+  const denied = resolveRendererMediaPermission({
+    features: { voice: true },
+    captureMode: 'voice_host',
+    permission: 'media',
+  })
+  assert.equal(denied.allowed, false)
+  assert.match(denied.reason, /voice host/i)
+
+  const stillDenied = resolveRendererMediaPermission({
+    features: { voice: false },
+    captureMode: 'renderer',
+    permission: 'media',
+  })
+  assert.equal(stillDenied.allowed, false)
+
+  const allowed = resolveRendererMediaPermission({
+    features: { voice: true },
+    captureMode: 'renderer',
+    permission: 'media',
+  })
+  assert.equal(allowed.allowed, true)
+
+  assert.ok(OS_VOICE_PERMISSION_MATRIX.some((row) => row.permission === 'microphone'))
+  assert.ok(OS_VOICE_PERMISSION_MATRIX.every((row) => /not|n\/a|required/i.test(row.cloudWeb)))
+})
+
+test('private voice: host status scaffold stays deferred', () => {
+  const off = voiceHostStatusForFeatures(undefined)
+  assert.equal(off.enabled, false)
+  assert.equal(off.phase, 'disabled')
+  assert.equal(off.captureMode, 'voice_host')
+  assert.equal(off.stt.engine, 'aurum_local')
+  assert.equal(off.tts.engine, 'sibling')
+
+  const on = voiceHostStatusForFeatures({ voice: true })
+  assert.equal(on.enabled, true)
+  assert.equal(on.phase, 'deferred')
+  assert.match(on.reason || '', /scaffolded|not connected/i)
+
+  const deferred = createDeferredVoiceHostStatus(VOICE_HOST_DEFERRED_REASON)
+  assert.equal(deferred.phase, 'deferred')
+  assert.equal(deferred.sessionId, null)
+})
+
+test('private voice: ADR and progressive disclosure docs present', () => {
+  const adr = readFileSync(join(root, 'docs/adr/private-realtime-voice.md'), 'utf8')
+  assert.match(adr, /Aurum/)
+  assert.match(adr, /sibling/i)
+  assert.match(adr, /features\.voice/)
+  assert.match(adr, /Desktop Local/)
+  assert.doesNotMatch(adr, /Aurum.*TTS as primary|TTS.*Aurum engine/)
+
+  const progressive = readFileSync(join(root, 'docs/progressive-disclosure.md'), 'utf8')
+  assert.match(progressive, /`voice`/)
+  assert.match(progressive, /private-realtime-voice/)
+
+  const mkdocs = readFileSync(join(root, 'mkdocs.yml'), 'utf8')
+  assert.match(mkdocs, /private-realtime-voice\.md/)
+
+  const register = readFileSync(join(root, 'docs/product-purity-register.md'), 'utf8')
+  assert.match(register, /Private realtime voice/)
+})
+
+test('private voice: public default config does not enable features.voice', () => {
+  const config = JSON.parse(readFileSync(join(root, 'open-cowork.config.json'), 'utf8')) as {
+    features?: Record<string, boolean>
+  }
+  assert.notEqual(config.features?.voice, true)
+})
+
+test('private voice: IPC and preload channels are scaffolded', () => {
+  const handlers = readFileSync(join(root, 'apps/desktop/src/main/ipc/voice-handlers.ts'), 'utf8')
+  assert.match(handlers, /voice:status/)
+  assert.match(handlers, /voice:session:start/)
+  assert.match(handlers, /VOICE_HOST_DEFERRED_REASON/)
+
+  const preload = readFileSync(join(root, 'apps/desktop/src/preload/index.ts'), 'utf8')
+  assert.match(preload, /'voice:status'/)
+  assert.match(preload, /'voice:session:start'/)
+  assert.match(preload, /voice: \{/)
+
+  const ipcHandlers = readFileSync(join(root, 'apps/desktop/src/main/ipc-handlers.ts'), 'utf8')
+  assert.match(ipcHandlers, /registerVoiceHandlers/)
+})

--- a/tests/product-purity-contracts.test.ts
+++ b/tests/product-purity-contracts.test.ts
@@ -186,12 +186,14 @@ test('product purity: feature enablement warnings for secondary flags (JOE-1063)
     approvals: true,
     knowledge: true,
     artifacts: true,
+    voice: true,
   })
-  assert.equal(warnings.length, 4)
+  assert.equal(warnings.length, 5)
   assert.ok(warnings.some((w) => /channels/i.test(w) && /Cloud/i.test(w)))
   assert.ok(warnings.some((w) => /approvals/i.test(w) && /Always-allow/i.test(w)))
   assert.ok(warnings.some((w) => /knowledge/i.test(w) && /Wiki/i.test(w)))
   assert.ok(warnings.some((w) => /artifacts/i.test(w) && /redaction/i.test(w)))
+  assert.ok(warnings.some((w) => /voice/i.test(w) && /Desktop Local/i.test(w)))
 })
 
 test('product purity: Admin billing omitted when adapter off; audit export honest', () => {

--- a/tests/workspace-gateway.test.ts
+++ b/tests/workspace-gateway.test.ts
@@ -216,6 +216,11 @@ test('workspace gateway marks local desktop-only capabilities as local supported
   assert.equal(supportStatus(support, 'coordination.schedules').status, 'supported')
   assert.equal(supportStatus(support, 'coordination.watches').status, 'supported')
   assert.equal(supportStatus(support, 'coordination.delegation').status, 'supported')
+  assert.equal(supportStatus(support, 'voice.capture').status, 'supported')
+  assert.equal(supportStatus(support, 'voice.stt').status, 'supported')
+  assert.equal(supportStatus(support, 'voice.tts').status, 'supported')
+  assert.equal(supportStatus(support, 'voice.conversation').status, 'supported')
+  assert.equal(supportStatus(support, 'voice.capture').context?.authority, 'desktop_local')
 })
 
 test('workspace gateway registers cloud connections without enabling unauthenticated execution', async () => {
@@ -238,6 +243,10 @@ test('workspace gateway registers cloud connections without enabling unauthentic
   assert.equal(support.find((entry) => entry.api === 'localFiles')?.context?.pathExposure, 'not_exposed')
   assert.equal(support.find((entry) => entry.api === 'artifacts.reveal')?.status, 'not_supported')
   assert.equal(support.find((entry) => entry.api === 'artifacts.reveal')?.context?.artifacts.reveal, 'none')
+  assert.equal(support.find((entry) => entry.api === 'voice.capture')?.status, 'not_supported')
+  assert.equal(support.find((entry) => entry.api === 'voice.stt')?.status, 'not_supported')
+  assert.equal(support.find((entry) => entry.api === 'voice.tts')?.status, 'not_supported')
+  assert.equal(support.find((entry) => entry.api === 'voice.conversation')?.status, 'not_supported')
   await assert.rejects(() => gateway.sync(event(1), workspace.id), /Sign in|not available/)
 })
 
@@ -285,6 +294,8 @@ test('workspace gateway registers standalone Gateway workspaces without treating
   assert.equal(supportStatus(support, 'localFiles').context?.pathExposure, 'redacted_remote')
   assert.equal(supportStatus(support, 'artifacts.reveal').status, 'not_supported')
   assert.equal(supportStatus(support, 'artifacts.reveal').context?.artifacts.reveal, 'none')
+  assert.equal(supportStatus(support, 'voice.capture').status, 'not_supported')
+  assert.equal(supportStatus(support, 'voice.conversation').status, 'not_supported')
   await assert.rejects(() => workspaceGateway.listCloudSessions(event(1), workspace.id), /Cloud workspace/)
 
   const result = await workspaceGateway.sync(event(1), workspace.id)


### PR DESCRIPTION
## Summary

Scaffold for **Private Realtime Voice** (epic JOE-1096): product boundary, progressive disclosure, support matrix, IPC stubs, and fail-closed renderer media policy. Engines (Aurum STT + sibling TTS) and real PCM capture are **not** wired yet — host status stays `deferred`.

### Included

- **ADR** `docs/adr/private-realtime-voice.md` — Desktop Local only; Aurum STT; sibling TTS; voice host outside renderer
- **`features.voice`** secondary, default off + enablement warning
- **`voice.capture|stt|tts|conversation`** workspace support APIs (local supported; cloud/browser/remote `not_supported`)
- **IPC** `voice:status`, `voice:session:*` stubs + preload/CoworkAPI
- **Permissions** explicit renderer media deny by default (`voice_host` capture mode)
- Docs: progressive disclosure, purity register, release checklist, Cloud Web matrix
- Tests: `tests/private-voice-scaffold.test.ts` + gateway/purity/IPC updates

### Linear

- Done: JOE-1099, JOE-1100, JOE-1098
- In Progress: JOE-1097 (PCM capture still open)

## Test plan

- [x] `pnpm build:shared`
- [x] `node scripts/run-node-tests.mjs tests/private-voice-scaffold.test.ts tests/desktop-feature-flags.test.ts tests/product-purity-contracts.test.ts tests/workspace-gateway.test.ts tests/ipc-handler-registration.test.ts`
- [x] `node scripts/check-preload-channels.mjs`
- [ ] CI green on PR
- [ ] Do not claim voice shipping until V1 engines + V2 PTT UI