### PR TITLE
feat(voice): partial transcripts during PTT (JOE-1102)

### DIFF
--- a/apps/desktop/src/main/voice-host.ts
+++ b/apps/desktop/src/main/voice-host.ts
@@ -1,8 +1,8 @@
 /**
- * Desktop Local private voice host (JOE-1097 / JOE-1101).
+ * Desktop Local private voice host (JOE-1097 / JOE-1101 / JOE-1102).
  *
  * Owns mic capture + PCM + Aurum STT in main. Emits text/status events only —
- * never raw audio.
+ * never raw audio. Partials use a host-side rolling window (not continuous stream).
  */
 import { randomUUID } from 'node:crypto'
 import {
@@ -25,6 +25,11 @@ import {
   sttLogMeta,
   type VoiceSttEngine,
 } from './voice-stt.ts'
+import {
+  dictationPartialPolicy,
+  VoicePartialClock,
+  type VoicePartialWindowPolicy,
+} from './voice-partial-window.ts'
 import { log } from '@open-cowork/shared/node'
 
 export type VoiceHostOptions = {
@@ -35,6 +40,9 @@ export type VoiceHostOptions = {
   /** Override OS mic permission probe (tests). */
   probeMicrophone?: () => Promise<VoicePermissionState>
   onEvent?: (event: VoiceHostEvent) => void
+  partialPolicy?: VoicePartialWindowPolicy
+  /** Disable partial loop (tests that only exercise finalize). */
+  partialsEnabled?: boolean
 }
 
 type ActiveSession = VoiceSessionSnapshot & {
@@ -48,11 +56,17 @@ export class VoiceHost {
   private readonly now: () => Date
   private readonly probeMicrophone: () => Promise<VoicePermissionState>
   private readonly onEvent: (event: VoiceHostEvent) => void
+  private readonly partialPolicy: VoicePartialWindowPolicy
+  private readonly partialsEnabled: boolean
   private mic: VoicePermissionState = 'unknown'
   private session: ActiveSession | null = null
   private phase: VoiceHostStatus['phase'] = 'disabled'
   private lastError: string | null = null
   private lastTranscript: string | null = null
+  private partialClock = new VoicePartialClock()
+  private partialTimer: NodeJS.Timeout | null = null
+  private partialInFlight = false
+  private lastPartialText: string | null = null
 
   constructor(options: VoiceHostOptions = {}) {
     this.features = options.features
@@ -61,6 +75,9 @@ export class VoiceHost {
     this.now = options.now || (() => new Date())
     this.probeMicrophone = options.probeMicrophone || defaultProbeMicrophone
     this.onEvent = options.onEvent || (() => {})
+    this.partialPolicy = options.partialPolicy || dictationPartialPolicy()
+    this.partialsEnabled = options.partialsEnabled !== false
+    this.partialClock = new VoicePartialClock(this.partialPolicy)
     this.phase = isDesktopFeatureEnabled(this.features, 'voice') ? 'ready' : 'disabled'
   }
 
@@ -158,6 +175,8 @@ export class VoiceHost {
 
     this.lastError = null
     this.lastTranscript = null
+    this.lastPartialText = null
+    this.partialClock.reset()
     this.phase = 'starting'
     this.emitStatus()
 
@@ -206,6 +225,7 @@ export class VoiceHost {
     }
 
     this.phase = 'listening'
+    this.startPartialLoop(id)
     this.emitStatus()
     return this.publicSession(this.session)
   }
@@ -220,12 +240,15 @@ export class VoiceHost {
       return this.getStatus()
     }
 
+    this.stopPartialLoop()
+    // Wait for in-flight partial to finish so we don't race finalize on shared CLI.
+    await this.waitForPartialIdle()
+
     await this.capture.stop()
     const pcm = active.buffer.snapshot()
     const sessionIdFinal = active.id
     active.buffer.clear()
 
-    // Transcribe before dropping the session id so final events stay correlated.
     this.phase = 'transcribing'
     this.session = { ...active, phase: 'transcribing', buffer: new VoicePcmBuffer() }
     this.emitStatus()
@@ -237,7 +260,6 @@ export class VoiceHost {
         }
         const result = await this.stt.transcribePcm(pcm)
         this.lastTranscript = result.text
-        // Log metadata only — never transcript body or PCM.
         log('voice', `stt.final ${JSON.stringify(sttLogMeta(result))}`)
         this.onEvent({
           type: 'final',
@@ -261,6 +283,7 @@ export class VoiceHost {
         })
       }
       this.lastError = null
+      this.lastPartialText = null
       this.phase = 'ready'
     } catch (error) {
       this.phase = 'error'
@@ -277,10 +300,13 @@ export class VoiceHost {
   async cancel(sessionId?: string | null): Promise<VoiceHostStatus> {
     const active = this.session
     if (active && (!sessionId || active.id === sessionId)) {
+      this.stopPartialLoop()
+      await this.waitForPartialIdle()
       await this.capture.stop()
       active.buffer.clear()
       this.session = null
     }
+    this.lastPartialText = null
     this.phase = isDesktopFeatureEnabled(this.features, 'voice') ? 'ready' : 'disabled'
     this.lastError = null
     this.emitStatus()
@@ -296,12 +322,79 @@ export class VoiceHost {
     return this.lastTranscript
   }
 
+  getLastPartialText(): string | null {
+    return this.lastPartialText
+  }
+
   getCaptureBackend(): VoiceCaptureBackendId {
     return this.capture.backend
   }
 
   getSttBackend() {
     return this.stt.backend
+  }
+
+  private startPartialLoop(sessionId: string) {
+    this.stopPartialLoop()
+    if (!this.partialsEnabled || !this.stt.isReady()) return
+
+    const tick = () => {
+      void this.maybeEmitPartial(sessionId)
+    }
+    // Tick a bit faster than interval so the clock can fire promptly after min audio.
+    const period = Math.max(200, Math.floor(this.partialPolicy.intervalMs / 2))
+    this.partialTimer = setInterval(tick, period)
+    this.partialTimer.unref?.()
+  }
+
+  private stopPartialLoop() {
+    if (this.partialTimer) {
+      clearInterval(this.partialTimer)
+      this.partialTimer = null
+    }
+  }
+
+  private async waitForPartialIdle() {
+    const deadline = Date.now() + 15_000
+    while (this.partialInFlight && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+    this.partialInFlight = false
+  }
+
+  private async maybeEmitPartial(sessionId: string) {
+    if (this.partialInFlight) return
+    const active = this.session
+    if (!active || active.id !== sessionId || this.phase !== 'listening') return
+    if (!this.stt.isReady()) return
+
+    const samples = active.buffer.snapshot()
+    const slice = this.partialClock.takePartialSlice(samples, this.now().getTime())
+    if (!slice || slice.length === 0) return
+
+    this.partialInFlight = true
+    try {
+      const result = await this.stt.transcribePcm(slice)
+      // Session may have ended while STT ran.
+      if (!this.session || this.session.id !== sessionId || this.phase !== 'listening') return
+      const text = result.text.trim()
+      if (!text || text === this.lastPartialText) return
+      this.lastPartialText = text
+      log('voice', `stt.partial ${JSON.stringify({ ...sttLogMeta(result), frames: slice.length })}`)
+      this.onEvent({
+        type: 'partial',
+        event: {
+          sessionId,
+          text,
+          isFinal: false,
+          at: this.now().toISOString(),
+        },
+      })
+    } catch {
+      // Partials are best-effort; finalize still runs on stop.
+    } finally {
+      this.partialInFlight = false
+    }
   }
 
   private publicSession(session: ActiveSession): VoiceSessionSnapshot {

--- a/apps/desktop/src/main/voice-partial-window.ts
+++ b/apps/desktop/src/main/voice-partial-window.ts
@@ -1,0 +1,72 @@
+/**
+ * Host-side partial STT window (JOE-1102).
+ *
+ * Mirrors Aurum's PartialWindowPolicy / PartialClock defaults for dictation:
+ * min ~1s audio, ~15s rolling window, ~1.2s interval, RMS energy gate.
+ * Does not stream whisper continuously — the host decides when to call STT.
+ */
+import { VOICE_PCM_SAMPLE_RATE } from './voice-pcm-buffer.ts'
+
+export type VoicePartialWindowPolicy = {
+  /** Frames required before the first partial (default ~1s). */
+  minFramesBeforePartial: number
+  /** Rolling decode window in frames (default ~15s). */
+  windowFrames: number
+  /** Minimum ms between partial attempts (default 1200). */
+  intervalMs: number
+  /** Minimum RMS on the decode window to attempt a partial. */
+  minRms: number
+}
+
+export function dictationPartialPolicy(): VoicePartialWindowPolicy {
+  return {
+    minFramesBeforePartial: VOICE_PCM_SAMPLE_RATE * 1,
+    windowFrames: VOICE_PCM_SAMPLE_RATE * 15,
+    intervalMs: 1200,
+    minRms: 0.008,
+  }
+}
+
+export function computeRms(samples: Float32Array): number {
+  if (samples.length === 0) return 0
+  let sum = 0
+  for (let i = 0; i < samples.length; i += 1) {
+    const v = samples[i]!
+    sum += v * v
+  }
+  return Math.sqrt(sum / samples.length)
+}
+
+/**
+ * Pure clock: given full buffer + now, optionally return a trailing slice
+ * eligible for a partial decode. Returns null when gated by time/energy/length.
+ */
+export class VoicePartialClock {
+  /** null until the first successful partial slice is taken. */
+  private lastPartialAtMs: number | null = null
+  private readonly policy: VoicePartialWindowPolicy
+
+  constructor(policy: VoicePartialWindowPolicy = dictationPartialPolicy()) {
+    this.policy = policy
+  }
+
+  reset() {
+    this.lastPartialAtMs = null
+  }
+
+  takePartialSlice(samples: Float32Array, nowMs: number): Float32Array | null {
+    if (samples.length < this.policy.minFramesBeforePartial) return null
+    if (this.lastPartialAtMs !== null && nowMs - this.lastPartialAtMs < this.policy.intervalMs) {
+      return null
+    }
+
+    const start = Math.max(0, samples.length - this.policy.windowFrames)
+    const slice = samples.subarray(start)
+    const rms = computeRms(slice)
+    if (rms < this.policy.minRms) return null
+
+    this.lastPartialAtMs = nowMs
+    // Copy so STT work can run while the host buffer continues to grow.
+    return new Float32Array(slice)
+  }
+}

--- a/docs/adr/private-realtime-voice.md
+++ b/docs/adr/private-realtime-voice.md
@@ -66,6 +66,7 @@ Rules:
 5. **Capture (JOE-1097):** host accumulates mono **16 kHz f32** PCM in main (`VoicePcmBuffer`). Default backend is **ffmpeg** when available; tests inject `FakeVoiceCapture`. PCM is cleared on stop/cancel and is never sent to the renderer.
 6. **STT (JOE-1101):** on release/stop, host runs **Aurum** with **local provider only** (`--provider local`, cleanup via rules). Default model `tiny-q5_1`. **local_only** fail-closed unless `OPEN_COWORK_AURUM_ALLOW_DOWNLOAD=1`. OpenRouter/cloud ASR is never on the default path. Final text is emitted as a `voice:event` final payload (text only).
 7. **PTT UI (JOE-1105):** Chat and Home composers show a mic control when `features.voice` is on **and** the workspace support matrix allows `voice.capture` + `voice.stt` (Desktop Local). **Click-to-toggle** is the shipped interaction (start → Listening → click again → Transcribing → inject text into the composer). Control is hidden on Cloud Web / unsupported authorities.
+8. **Partials during PTT (JOE-1102):** While listening, the host runs a **PartialClock** (min ~1s audio, ~15s rolling window, ~1.2s interval, RMS energy gate) and emits `voice:event` **partial** payloads (text only). This is **not** a continuous Whisper stream — the host decides when to call STT. The composer snapshots a **baseline** at PTT start; partials/finals replace the dictation segment after the baseline (cancel/error restores baseline).
 
 ### 4. Workspace support APIs
 

--- a/packages/app/src/components/chat/ChatInput.tsx
+++ b/packages/app/src/components/chat/ChatInput.tsx
@@ -78,6 +78,8 @@ function readKeyboardHintsDismissed() {
 
 export function ChatInput() {
   const [input, setInput] = useState('')
+  const inputRef = useRef(input)
+  inputRef.current = input
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [dragOver, setDragOver] = useState(false)
   const [submitInFlight, setSubmitInFlight] = useState(false)
@@ -196,8 +198,9 @@ export function ChatInput() {
 
   const voice = useVoicePtt({
     openCodeSessionId: currentSessionId,
-    onFinalText: (text) => {
-      setInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${text}` : text))
+    getComposerText: () => inputRef.current,
+    setComposerText: (text) => {
+      setInput(text)
       requestAnimationFrame(() => resizeComposerTextarea())
     },
     onError: (message) => addGlobalError(message),

--- a/packages/app/src/components/home/HomeComposer.tsx
+++ b/packages/app/src/components/home/HomeComposer.tsx
@@ -59,6 +59,8 @@ export function HomeComposer({
   modelControlsReason?: string | null
 }) {
   const [text, setText] = useState('')
+  const textRef = useRef(text)
+  textRef.current = text
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [dragOver, setDragOver] = useState(false)
   const [showModelMenu, setShowModelMenu] = useState(false)
@@ -121,8 +123,9 @@ export function HomeComposer({
 
   const voice = useVoicePtt({
     openCodeSessionId: null,
-    onFinalText: (dictated) => {
-      setText((current) => (current.trim() ? `${current.trimEnd()} ${dictated}` : dictated))
+    getComposerText: () => textRef.current,
+    setComposerText: (next) => {
+      setText(next)
       requestAnimationFrame(() => autosize())
     },
     onError: (message) => addGlobalError(message),

--- a/packages/app/src/hooks/useVoicePtt.test.ts
+++ b/packages/app/src/hooks/useVoicePtt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { useVoicePtt } from './useVoicePtt'
+import { appendDictation, useVoicePtt } from './useVoicePtt'
 
 const supportFlags = {
   canVoiceCapture: true,
@@ -25,12 +25,25 @@ vi.mock('../runtime-env', () => ({
   isDesktopRuntime: () => true,
 }))
 
+describe('appendDictation', () => {
+  it('joins baseline and segment with a single space', () => {
+    expect(appendDictation('hello', 'world')).toBe('hello world')
+    expect(appendDictation('hello ', 'world')).toBe('hello world')
+    expect(appendDictation('', 'world')).toBe('world')
+    expect(appendDictation('hello', '')).toBe('hello')
+  })
+})
+
 describe('useVoicePtt', () => {
+  let listeners: Array<(event: unknown) => void>
+  let composerText: string
+
   beforeEach(() => {
     supportFlags.canVoiceCapture = true
     supportFlags.canVoiceStt = true
     supportFlags.canPrompt = true
-    const listeners: Array<(event: unknown) => void> = []
+    listeners = []
+    composerText = 'Draft: '
     // @ts-expect-error test double
     window.coworkApi = {
       app: {
@@ -110,12 +123,18 @@ describe('useVoicePtt', () => {
     }
   })
 
-  it('toggles listening and injects final text', async () => {
-    const onFinalText = vi.fn()
-    const { result } = renderHook(() => useVoicePtt({
+  function renderVoicePtt() {
+    return renderHook(() => useVoicePtt({
       openCodeSessionId: 'ses_1',
-      onFinalText,
+      getComposerText: () => composerText,
+      setComposerText: (text) => {
+        composerText = text
+      },
     }))
+  }
+
+  it('toggles listening and replaces baseline with final text', async () => {
+    const { result } = renderVoicePtt()
 
     await waitFor(() => expect(result.current.visible).toBe(true))
     await waitFor(() => expect(result.current.enabled).toBe(true))
@@ -130,14 +149,115 @@ describe('useVoicePtt', () => {
       await result.current.toggle()
     })
     expect(window.coworkApi.voice.stopSession).toHaveBeenCalled()
-    expect(onFinalText).toHaveBeenCalledWith('hello dictated')
+    expect(composerText).toBe('Draft: hello dictated')
+  })
+
+  it('applies partials against the baseline and final replaces the segment', async () => {
+    // Don't auto-emit final from stop — drive events manually.
+    // @ts-expect-error test double
+    window.coworkApi.voice.stopSession = vi.fn(async () => ({
+      enabled: true,
+      phase: 'ready',
+      captureMode: 'voice_host',
+      stt: { engine: 'aurum_local', ready: true },
+      tts: { engine: 'sibling', ready: false },
+      permissions: { microphone: 'granted' },
+      reason: null,
+      sessionId: null,
+    }))
+
+    const { result } = renderVoicePtt()
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    await act(async () => {
+      await result.current.toggle()
+    })
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          type: 'partial',
+          event: {
+            sessionId: 'voice-1',
+            text: 'hello',
+            isFinal: false,
+            at: new Date().toISOString(),
+          },
+        })
+      }
+    })
+    expect(composerText).toBe('Draft: hello')
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          type: 'partial',
+          event: {
+            sessionId: 'voice-1',
+            text: 'hello world',
+            isFinal: false,
+            at: new Date().toISOString(),
+          },
+        })
+      }
+    })
+    // Second partial replaces the dictation segment (no double append).
+    expect(composerText).toBe('Draft: hello world')
+
+    await act(async () => {
+      await result.current.toggle()
+      for (const listener of listeners) {
+        listener({
+          type: 'final',
+          event: {
+            sessionId: 'voice-1',
+            text: 'hello world final',
+            isFinal: true,
+            at: new Date().toISOString(),
+          },
+        })
+      }
+    })
+    expect(composerText).toBe('Draft: hello world final')
+  })
+
+  it('restores baseline on cancel after partials', async () => {
+    const { result } = renderVoicePtt()
+    await waitFor(() => expect(result.current.enabled).toBe(true))
+
+    await act(async () => {
+      await result.current.toggle()
+    })
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          type: 'partial',
+          event: {
+            sessionId: 'voice-1',
+            text: 'scratch this',
+            isFinal: false,
+            at: new Date().toISOString(),
+          },
+        })
+      }
+    })
+    expect(composerText).toBe('Draft: scratch this')
+
+    await act(async () => {
+      await result.current.cancel()
+    })
+    expect(window.coworkApi.voice.cancel).toHaveBeenCalled()
+    expect(composerText).toBe('Draft: ')
+    expect(result.current.phase).toBe('idle')
   })
 
   it('hides when features.voice is off', async () => {
     // @ts-expect-error test double
     window.coworkApi.app.config = vi.fn(async () => ({ features: {} }))
     const { result } = renderHook(() => useVoicePtt({
-      onFinalText: vi.fn(),
+      getComposerText: () => '',
+      setComposerText: vi.fn(),
     }))
     await waitFor(() => expect(result.current.visible).toBe(false))
   })

--- a/packages/app/src/hooks/useVoicePtt.ts
+++ b/packages/app/src/hooks/useVoicePtt.ts
@@ -1,8 +1,9 @@
 /**
- * Push-to-talk for private voice (JOE-1105).
+ * Push-to-talk for private voice (JOE-1105 / JOE-1102).
  *
  * Click-to-toggle ships as the primary control (keyboard/a11y friendly).
- * Host owns capture + STT; this hook only drives IPC and injects final text.
+ * Host owns capture + STT; this hook drives IPC and applies partial/final text
+ * against a composer baseline (partials replace the dictation segment).
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -30,6 +31,15 @@ export type VoicePttController = {
   cancel: () => Promise<void>
 }
 
+/** Join pre-dictation composer text with the current STT segment. */
+export function appendDictation(baseline: string, dictated: string): string {
+  const text = dictated.trim()
+  if (!text) return baseline
+  if (!baseline.trim()) return text
+  if (/\s$/.test(baseline)) return `${baseline}${text}`
+  return `${baseline.trimEnd()} ${text}`
+}
+
 function mapPhase(phase: VoiceHostPhase | undefined): VoicePttUiPhase {
   if (phase === 'listening') return 'listening'
   if (phase === 'transcribing' || phase === 'starting') return 'transcribing'
@@ -46,7 +56,13 @@ function statusLabelFor(phase: VoicePttUiPhase, reason: string | null): string |
 
 export function useVoicePtt(options: {
   openCodeSessionId?: string | null
-  onFinalText: (text: string) => void
+  /**
+   * Read the live composer value (parent should back this with a ref so the
+   * hook does not capture a stale render).
+   */
+  getComposerText: () => string
+  /** Replace the full composer text (baseline + current dictation segment). */
+  setComposerText: (text: string) => void
   onError?: (message: string) => void
 }): VoicePttController {
   const workspaceSupport = useActiveWorkspaceSupport()
@@ -56,10 +72,30 @@ export function useVoicePtt(options: {
   const [errorReason, setErrorReason] = useState<string | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const busyRef = useRef(false)
-  const onFinalTextRef = useRef(options.onFinalText)
+  /** Composer text at the moment listening began; partials replace after this. */
+  const baselineRef = useRef<string | null>(null)
+  const getComposerTextRef = useRef(options.getComposerText)
+  const setComposerTextRef = useRef(options.setComposerText)
   const onErrorRef = useRef(options.onError)
-  onFinalTextRef.current = options.onFinalText
+  getComposerTextRef.current = options.getComposerText
+  setComposerTextRef.current = options.setComposerText
   onErrorRef.current = options.onError
+
+  const applyDictation = useCallback((segment: string) => {
+    const baseline = baselineRef.current
+    if (baseline === null) return
+    setComposerTextRef.current(appendDictation(baseline, segment))
+  }, [])
+
+  const restoreBaseline = useCallback(() => {
+    if (baselineRef.current === null) return
+    setComposerTextRef.current(baselineRef.current)
+    baselineRef.current = null
+  }, [])
+
+  const clearBaseline = useCallback(() => {
+    baselineRef.current = null
+  }, [])
 
   useEffect(() => {
     if (!isDesktopRuntime() || !window.coworkApi?.app?.config) return
@@ -89,15 +125,30 @@ export function useVoicePtt(options: {
           setUiPhase(mapPhase(event.status.phase))
         }
       }
-      if (event.type === 'final') {
+      if (event.type === 'partial') {
+        // Ignore events for a session we already finished/cancelled.
+        if (sessionIdRef.current && event.event.sessionId !== sessionIdRef.current) return
+        if (baselineRef.current === null) return
         const text = event.event.text?.trim() || ''
-        if (text) onFinalTextRef.current(text)
+        if (text) applyDictation(text)
+      }
+      if (event.type === 'final') {
+        if (sessionIdRef.current && event.event.sessionId !== sessionIdRef.current) return
+        const text = event.event.text?.trim() || ''
+        if (text) {
+          applyDictation(text)
+        } else if (baselineRef.current !== null) {
+          // Empty final: keep baseline (drop any partial preview).
+          setComposerTextRef.current(baselineRef.current)
+        }
+        clearBaseline()
         sessionIdRef.current = null
         setUiPhase('idle')
         setErrorReason(null)
       }
       if (event.type === 'error') {
         const message = event.message || 'Voice failed'
+        restoreBaseline()
         setErrorReason(message)
         setUiPhase('error')
         sessionIdRef.current = null
@@ -108,7 +159,7 @@ export function useVoicePtt(options: {
       cancelled = true
       unsub?.()
     }
-  }, [])
+  }, [applyDictation, clearBaseline, restoreBaseline])
 
   const featureOn = isDesktopFeatureEnabled(features, 'voice')
   const authorityOk = workspaceSupport.flags.canVoiceCapture && workspaceSupport.flags.canVoiceStt
@@ -144,6 +195,8 @@ export function useVoicePtt(options: {
     setErrorReason(null)
     setUiPhase('listening')
     try {
+      // Snapshot before start so partials never include mid-start keystrokes only.
+      baselineRef.current = getComposerTextRef.current()
       const snapshot = await window.coworkApi.voice.startSession({
         mode: 'ptt',
         openCodeSessionId: options.openCodeSessionId || null,
@@ -153,6 +206,7 @@ export function useVoicePtt(options: {
       setUiPhase('listening')
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      baselineRef.current = null
       sessionIdRef.current = null
       setUiPhase('error')
       setErrorReason(message)
@@ -174,10 +228,12 @@ export function useVoicePtt(options: {
     try {
       await window.coworkApi.voice.stopSession(sessionId)
       // Final text arrives via voiceEvent; clear session id after stop.
+      // Keep baseline until final/error so late partials still replace correctly.
       sessionIdRef.current = null
       if (uiPhase !== 'error') setUiPhase('idle')
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      restoreBaseline()
       sessionIdRef.current = null
       setUiPhase('error')
       setErrorReason(message)
@@ -185,12 +241,13 @@ export function useVoicePtt(options: {
     } finally {
       busyRef.current = false
     }
-  }, [uiPhase])
+  }, [restoreBaseline, uiPhase])
 
   const cancel = useCallback(async () => {
     if (!window.coworkApi?.voice) return
     const sessionId = sessionIdRef.current
     sessionIdRef.current = null
+    restoreBaseline()
     setUiPhase('idle')
     setErrorReason(null)
     try {
@@ -198,7 +255,7 @@ export function useVoicePtt(options: {
     } catch {
       // Cancel is best-effort.
     }
-  }, [])
+  }, [restoreBaseline])
 
   const toggle = useCallback(async () => {
     if (uiPhase === 'listening') {

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -88,6 +88,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'startup-splash.ts',
   'voice-capture.ts',
   'voice-host.ts',
+  'voice-partial-window.ts',
   'voice-pcm-buffer.ts',
   'voice-permission-policy.ts',
   'voice-stt.ts',

--- a/tests/private-voice-scaffold.test.ts
+++ b/tests/private-voice-scaffold.test.ts
@@ -154,4 +154,10 @@ test('private voice: IPC and preload channels are scaffolded', () => {
   const host = readFileSync(join(root, 'apps/desktop/src/main/voice-host.ts'), 'utf8')
   assert.match(host, /VoicePcmBuffer/)
   assert.match(host, /getHostPcmSnapshot/)
+  assert.match(host, /VoicePartialClock/)
+  assert.match(host, /type: 'partial'/)
+
+  const partialWindow = readFileSync(join(root, 'apps/desktop/src/main/voice-partial-window.ts'), 'utf8')
+  assert.match(partialWindow, /dictationPartialPolicy/)
+  assert.match(partialWindow, /takePartialSlice/)
 })

--- a/tests/voice-host-capture.test.ts
+++ b/tests/voice-host-capture.test.ts
@@ -46,6 +46,8 @@ test('voice host captures PCM with fake backend without exposing samples on stat
     stt: new FakeVoiceStt({ text: 'capture test' }),
     probeMicrophone: async () => 'granted',
     onEvent: (e) => events.push(e),
+    // Existing capture tests focus on PCM ownership; partials covered in voice-partial-window.
+    partialsEnabled: false,
   })
 
   const idle = host.getStatus()
@@ -110,6 +112,7 @@ test('voice host cancel clears buffer mid-session', async () => {
     capture: fake,
     stt: new FakeVoiceStt(),
     probeMicrophone: async () => 'granted',
+    partialsEnabled: false,
   })
   const session = await host.startSession()
   await new Promise((r) => setTimeout(r, 30))

--- a/tests/voice-partial-window.test.ts
+++ b/tests/voice-partial-window.test.ts
@@ -1,0 +1,164 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  VoicePartialClock,
+  computeRms,
+  dictationPartialPolicy,
+} from '../apps/desktop/src/main/voice-partial-window.ts'
+import { VOICE_PCM_SAMPLE_RATE } from '../apps/desktop/src/main/voice-pcm-buffer.ts'
+import { FakeVoiceCapture } from '../apps/desktop/src/main/voice-capture.ts'
+import { VoiceHost } from '../apps/desktop/src/main/voice-host.ts'
+import type { VoiceSttEngine, VoiceSttResult } from '../apps/desktop/src/main/voice-stt.ts'
+
+test('computeRms is zero for empty / silent and positive for signal', () => {
+  assert.equal(computeRms(new Float32Array(0)), 0)
+  assert.equal(computeRms(new Float32Array(100)), 0)
+  const tone = new Float32Array(100)
+  for (let i = 0; i < tone.length; i += 1) tone[i] = 0.1
+  assert.ok(computeRms(tone) > 0.09)
+})
+
+test('dictation partial policy matches Aurum-ish defaults', () => {
+  const policy = dictationPartialPolicy()
+  assert.equal(policy.minFramesBeforePartial, VOICE_PCM_SAMPLE_RATE)
+  assert.equal(policy.windowFrames, VOICE_PCM_SAMPLE_RATE * 15)
+  assert.equal(policy.intervalMs, 1200)
+  assert.ok(policy.minRms > 0)
+})
+
+test('VoicePartialClock gates on min frames, interval, and RMS', () => {
+  const clock = new VoicePartialClock({
+    minFramesBeforePartial: 100,
+    windowFrames: 50,
+    intervalMs: 1000,
+    minRms: 0.01,
+  })
+
+  const quiet = new Float32Array(200)
+  assert.equal(clock.takePartialSlice(quiet, 0), null)
+
+  const loud = new Float32Array(200)
+  for (let i = 0; i < loud.length; i += 1) loud[i] = 0.2
+  const first = clock.takePartialSlice(loud, 0)
+  assert.ok(first)
+  assert.equal(first!.length, 50)
+
+  // Interval gate
+  assert.equal(clock.takePartialSlice(loud, 500), null)
+  const second = clock.takePartialSlice(loud, 1001)
+  assert.ok(second)
+
+  // Too short
+  const short = new Float32Array(50)
+  for (let i = 0; i < short.length; i += 1) short[i] = 0.2
+  clock.reset()
+  assert.equal(clock.takePartialSlice(short, 0), null)
+})
+
+class ScriptedVoiceStt implements VoiceSttEngine {
+  readonly backend = 'fake' as const
+  readonly detail = 'scripted'
+  readonly model = 'tiny-q5_1'
+  private readonly texts: string[]
+  private index = 0
+  calls = 0
+  lastFrames = 0
+
+  constructor(texts: string[]) {
+    this.texts = texts
+  }
+
+  isReady() {
+    return true
+  }
+
+  async transcribePcm(samples: Float32Array): Promise<VoiceSttResult> {
+    this.calls += 1
+    this.lastFrames = samples.length
+    const text = this.texts[Math.min(this.index, this.texts.length - 1)] ?? ''
+    this.index += 1
+    return {
+      text,
+      model: this.model,
+      backend: 'fake',
+      durationMs: 1,
+      cleaned: true,
+    }
+  }
+}
+
+test('voice host emits partial events during listening (JOE-1102)', async () => {
+  const events: Array<{ type?: string; event?: { text?: string; isFinal?: boolean } }> = []
+  const stt = new ScriptedVoiceStt(['hello', 'hello world', 'hello world final'])
+  const capture = new FakeVoiceCapture({ chunkFrames: 0, intervalMs: 60_000 })
+  const host = new VoiceHost({
+    features: { voice: true },
+    capture,
+    stt,
+    probeMicrophone: async () => 'granted',
+    onEvent: (e) => events.push(e as typeof events[number]),
+    partialPolicy: {
+      minFramesBeforePartial: 100,
+      windowFrames: 500,
+      intervalMs: 50,
+      minRms: 0.01,
+    },
+  })
+
+  const session = await host.startSession({ mode: 'ptt' })
+  // Loud enough PCM for the energy gate.
+  const chunk = new Float32Array(400)
+  for (let i = 0; i < chunk.length; i += 1) chunk[i] = 0.2
+  capture.push(chunk)
+
+  // Allow partial loop ticks + STT microtasks.
+  await new Promise((r) => setTimeout(r, 200))
+  capture.push(chunk)
+  await new Promise((r) => setTimeout(r, 200))
+
+  const partials = events.filter((e) => e.type === 'partial')
+  assert.ok(partials.length >= 1, `expected partial events, got ${JSON.stringify(events)}`)
+  assert.equal(partials[0]!.event?.isFinal, false)
+  assert.ok((partials[0]!.event?.text || '').length > 0)
+  assert.equal(host.getLastPartialText(), partials[partials.length - 1]!.event?.text)
+  assert.ok(stt.calls >= 1)
+
+  const stopped = await host.stopSession(session.id)
+  assert.equal(stopped.phase, 'ready')
+  const finals = events.filter((e) => e.type === 'final')
+  assert.equal(finals.length, 1)
+  assert.equal(finals[0]!.event?.isFinal, true)
+  assert.equal(host.getLastTranscript(), finals[0]!.event?.text)
+  assert.equal(host.getLastPartialText(), null)
+})
+
+test('voice host can disable partials for finalize-only tests', async () => {
+  const events: Array<{ type?: string }> = []
+  const stt = new ScriptedVoiceStt(['only final'])
+  const capture = new FakeVoiceCapture({ chunkFrames: 0, intervalMs: 60_000 })
+  const host = new VoiceHost({
+    features: { voice: true },
+    capture,
+    stt,
+    probeMicrophone: async () => 'granted',
+    onEvent: (e) => events.push(e),
+    partialsEnabled: false,
+    partialPolicy: {
+      minFramesBeforePartial: 1,
+      windowFrames: 100,
+      intervalMs: 10,
+      minRms: 0,
+    },
+  })
+
+  const session = await host.startSession()
+  const chunk = new Float32Array(200)
+  for (let i = 0; i < chunk.length; i += 1) chunk[i] = 0.2
+  capture.push(chunk)
+  await new Promise((r) => setTimeout(r, 80))
+  assert.equal(events.filter((e) => e.type === 'partial').length, 0)
+
+  await host.stopSession(session.id)
+  assert.equal(events.filter((e) => e.type === 'final').length, 1)
+  assert.equal(host.getLastTranscript(), 'only final')
+})


### PR DESCRIPTION
## Summary

- Host-side **PartialClock** (JOE-1102): min ~1s audio, ~15s rolling window, ~1.2s interval, RMS energy gate — decides when to call STT during PTT (not continuous Whisper stream).
- Emits text-only `partial` events on the existing `voice:event` path; still never sends PCM to the renderer.
- Composer **baseline** snapshot at PTT start: partials/finals replace the dictation segment; cancel/error restores baseline.
- ADR note + tests for clock policy, host partial loop, and `useVoicePtt` baseline replace.

## Validation

- [x] `node scripts/run-node-tests.mjs tests/voice-partial-window.test.ts tests/voice-host-capture.test.ts tests/voice-stt.test.ts tests/private-voice-scaffold.test.ts tests/desktop-main-source-map.test.ts`
- [x] `pnpm --filter @open-cowork/app test:renderer` (includes `useVoicePtt` + ChatInput)
- [ ] `pnpm test` (full suite via CI)
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [x] Dual-stack checklist: exempt — private Desktop voice host only; no channel security/protocol changes

## User-visible impact

- [x] UI change — live partial text in Chat/Home composers while PTT listening (behind `features.voice`)
- [x] Runtime behavior change — host partial STT window during listening
- [x] Docs change — ADR partials rule

## Notes

- Linear: JOE-1102 under private voice epic JOE-1096
- Partials are best-effort; finalize on stop still owns the final transcript
- Does not claim product shipping until broader voice milestone complete