### PR TITLE
feat(voice): security audit log redaction + local_only (JOE-1111)

### DIFF
--- a/apps/desktop/src/main/voice-host.ts
+++ b/apps/desktop/src/main/voice-host.ts
@@ -49,6 +49,7 @@ import {
   type VoiceAssetEnsureResult,
   type VoiceAssetStatus,
 } from './voice-assets.ts'
+import { ttsLogMeta } from './voice-security.ts'
 import { log } from '@open-cowork/shared/node'
 
 export type VoiceHostOptions = {
@@ -490,7 +491,11 @@ export class VoiceHost {
         voiceId: input.voiceId,
         rate: input.rate,
       })
-      log('voice', `tts.speak ${JSON.stringify({ chars: text.length, backend: this.tts.backend, bargedIn })}`)
+      log('voice', `tts.speak ${JSON.stringify(ttsLogMeta({
+        text,
+        backend: this.tts.backend,
+        bargedIn,
+      }))}`)
       this.phase = bargedIn ? 'ready' : 'ready'
     } catch (error) {
       // Barge-in cancel surfaces as speak abort — not a hard error.

--- a/apps/desktop/src/main/voice-security.ts
+++ b/apps/desktop/src/main/voice-security.ts
@@ -1,0 +1,130 @@
+/**
+ * Private voice security policy helpers (JOE-1111).
+ *
+ * Private-by-construction rules for the Desktop voice host:
+ * - Logs / diagnostics: lengths + engine metadata only — never PCM or transcript text
+ * - Network: Aurum STT default is local_only; OpenRouter/cloud ASR must not appear on the default path
+ * - Download: model files only when OPEN_COWORK_AURUM_ALLOW_DOWNLOAD=1 (never audio upload)
+ * - IPC: text/status/vad only — no raw samples on the renderer path
+ *
+ * Greppable audit notes also live in docs/adr/private-realtime-voice.md §Security audit (JOE-1111).
+ */
+
+/** Substrings that must never appear in host log lines for voice. */
+export const VOICE_LOG_FORBIDDEN_KEYS = [
+  'samples',
+  'pcm',
+  'float32',
+  'arraybuffer',
+  'waveform',
+  'rawAudio',
+  'audioBase64',
+] as const
+
+/**
+ * Keys allowed on STT/TTS log metadata objects. Anything else is treated as a leak risk.
+ * Intentionally excludes `text` / transcript bodies.
+ */
+export const VOICE_STT_LOG_ALLOWED_KEYS = [
+  'backend',
+  'model',
+  'textChars',
+  'durationMs',
+  'cleaned',
+  'frames',
+] as const
+
+export const VOICE_TTS_LOG_ALLOWED_KEYS = [
+  'chars',
+  'backend',
+  'bargedIn',
+  'voiceId',
+] as const
+
+export type VoiceTtsLogMeta = {
+  chars: number
+  backend: string
+  bargedIn?: boolean
+  voiceId?: string | null
+}
+
+/** TTS log meta: length + backend only — never the spoken string. */
+export function ttsLogMeta(input: {
+  text: string
+  backend: string
+  bargedIn?: boolean
+  voiceId?: string | null
+}): VoiceTtsLogMeta {
+  return {
+    chars: input.text.length,
+    backend: input.backend,
+    ...(input.bargedIn !== undefined ? { bargedIn: input.bargedIn } : {}),
+    ...(input.voiceId ? { voiceId: input.voiceId } : {}),
+  }
+}
+
+/**
+ * True when a JSON-serialized status/event payload looks free of bulk audio.
+ * Allows intentional product text fields (`text` on partial/final events) when
+ * `allowEventText` is true — those are renderer product surface, not logs.
+ */
+export function payloadLooksFreeOfAudio(
+  serialized: string,
+  options: { allowEventText?: boolean } = {},
+): boolean {
+  // Explicit audio sample keys (not sampleRate).
+  if (/"samples"\s*:/i.test(serialized)) return false
+  if (/"pcm"\s*:/i.test(serialized)) return false
+  if (/"rawAudio"\s*:/i.test(serialized)) return false
+  if (/"audioBase64"\s*:/i.test(serialized)) return false
+  if (/"waveform"\s*:/i.test(serialized)) return false
+  if (/Float32Array|ArrayBuffer|Int16Array/.test(serialized)) return false
+  if (!options.allowEventText && /"text"\s*:\s*"[^"]{3,}"/.test(serialized)) {
+    // Status/log paths should not embed transcript bodies
+    return false
+  }
+  return true
+}
+
+/** Assert log meta objects only use allowlisted keys (no transcript body). */
+export function assertVoiceLogMetaKeys(
+  meta: Record<string, unknown>,
+  allowed: readonly string[],
+): { ok: true } | { ok: false; extra: string[] } {
+  const extra = Object.keys(meta).filter((k) => !allowed.includes(k))
+  if (extra.length > 0) return { ok: false, extra }
+  if ('text' in meta) return { ok: false, extra: ['text'] }
+  return { ok: true }
+}
+
+/**
+ * Residual risks accepted for private voice (documented, not ignored).
+ * Keep in sync with ADR §Security audit.
+ */
+export const VOICE_SECURITY_RESIDUAL_RISKS = [
+  {
+    id: 'R-VOICE-01',
+    summary: 'Partial/final IPC intentionally carries transcript text to the renderer for product UX.',
+    mitigation: 'No raw audio on IPC; renderer must not re-log full text to adoption telemetry.',
+  },
+  {
+    id: 'R-VOICE-02',
+    summary: 'STT writes a short-lived temp WAV on disk for the Aurum CLI; cleared in finally.',
+    mitigation: 'Work dir under OS temp; rmSync recursive after each call; never under project roots.',
+  },
+  {
+    id: 'R-VOICE-03',
+    summary: 'OS TTS may write a temp AIFF/WAV for afplay/say; local filesystem only.',
+    mitigation: 'Host-owned playback; no upload; cancel best-effort deletes.',
+  },
+  {
+    id: 'R-VOICE-04',
+    summary: 'OPEN_COWORK_AURUM_ALLOW_DOWNLOAD=1 permits model file fetch (weights only).',
+    mitigation: 'Default off; never audio/transcript upload; Settings copy states opt-in.',
+  },
+  {
+    id: 'R-VOICE-05',
+    summary: 'getLastTranscript() exists for tests/host diagnostics; not exposed on renderer IPC.',
+    mitigation: 'Preload surface has no lastTranscript channel; only status/session/tts/assets.',
+  },
+] as const

--- a/apps/desktop/src/main/voice-stt.ts
+++ b/apps/desktop/src/main/voice-stt.ts
@@ -346,7 +346,10 @@ export function hashTranscriptText(text: string) {
   return createHash('sha256').update(text).digest('hex')
 }
 
-/** Ensure no PCM-looking bulk payload is logged (length only). */
+/**
+ * Ensure no PCM-looking bulk payload or transcript body is logged (length only).
+ * JOE-1111: never include `text` — use textChars + hashTranscriptText for correlation.
+ */
 export function sttLogMeta(result: VoiceSttResult) {
   return {
     backend: result.backend,

--- a/docs/adr/private-realtime-voice.md
+++ b/docs/adr/private-realtime-voice.md
@@ -99,6 +99,32 @@ Rules:
 - Renderer-owned continuous listening without PTT policy
 - Replacing chat text input as the only interaction mode
 
+## Security audit (JOE-1111)
+
+**Greppable claim:** private voice is **private-by-construction** on the default Desktop Local path.
+
+| Control | Rule | Evidence |
+| --- | --- | --- |
+| Logs | Lengths + engine metadata only (`sttLogMeta` / `ttsLogMeta`) — **never** transcript text or PCM | `apps/desktop/src/main/voice-stt.ts`, `voice-security.ts`, `tests/voice-security.test.ts` |
+| Network STT | Aurum `--provider local` only; OpenRouter key cleared on spawn; model missing → fail-closed when local_only | `voice-stt.ts`, security tests |
+| Network TTS | OS system speech sibling; no cloud TTS vendor on default path | `voice-tts.ts` |
+| IPC | Status / partial / final **text** / vad / assets — **no** raw samples | `voice-handlers.ts`, preload channel list |
+| Renderer mic | `getUserMedia` / session `media` denied when captureMode is `voice_host` | `voice-permission-policy.ts` |
+| Support matrix | Cloud Web / non-local: all `voice.*` APIs `not_supported` | `browserCloudWorkspaceSupport`, workspace support store |
+| Model download | Default off; `OPEN_COWORK_AURUM_ALLOW_DOWNLOAD=1` = **file weights only**, never audio upload | `voice-assets.ts` |
+
+### Residual risks (accepted)
+
+| ID | Risk | Mitigation |
+| --- | --- | --- |
+| R-VOICE-01 | Partial/final IPC carries transcript text (product UX) | No audio on IPC; do not ship adoption telemetry of free-text transcripts |
+| R-VOICE-02 | Short-lived temp WAV for Aurum CLI | OS temp dir; `rmSync` in `finally` after each transcribe |
+| R-VOICE-03 | OS TTS may write temp AIFF/WAV for playback | Local host only; cancel best-effort cleanup |
+| R-VOICE-04 | Opt-in model download env | Default off; Settings copy; never audio |
+| R-VOICE-05 | `getLastTranscript()` host memory for tests | Not on preload/IPC |
+
+Automated gates: `tests/voice-security.test.ts` (plus existing STT/TTS/scaffold tests).
+
 ## Consequences
 
 - Shared package grows `voice` IPC types and `voice.*` workspace support keys.
@@ -112,3 +138,4 @@ Rules:
 - [Release checklist](../release-checklist.md)
 - Aurum: https://github.com/joe-broadhead/aurum
 - ZephyrFlow: https://github.com/joe-broadhead/zephyr-flow
+

--- a/docs/adr/private-realtime-voice.md
+++ b/docs/adr/private-realtime-voice.md
@@ -138,4 +138,3 @@ Automated gates: `tests/voice-security.test.ts` (plus existing STT/TTS/scaffold 
 - [Release checklist](../release-checklist.md)
 - Aurum: https://github.com/joe-broadhead/aurum
 - ZephyrFlow: https://github.com/joe-broadhead/zephyr-flow
-

--- a/docs/product-purity-register.md
+++ b/docs/product-purity-register.md
@@ -53,7 +53,7 @@ Optional installable siblings (not Desktop default nav):
 | Durable Gateway (`cowork-gateway`) | Local operator / claim-gated beta | Multi-tenant production GA without evidence |
 | Tier-1 channels (Telegram/Slack/email) | Launch-tier adapters | — |
 | Tier-3 channels (Discord/WhatsApp/Signal) | Experimental / bridge-backed | Launch marketing without live smoke |
-| Private realtime voice | Desktop Local opt-in (`features.voice`); on-device STT (Aurum) + sibling TTS | Cloud Web mic, Aurum-as-TTS, shipping claim before V2 PTT + engines |
+| Private realtime voice | Desktop Local opt-in (`features.voice`); on-device STT (Aurum) + sibling TTS; security audit JOE-1111 (log redaction + local_only tests) | Cloud Web mic, Aurum-as-TTS, silent model download, shipping claim without dogfood evidence |
 
 ## Forbidden claims (fail closed)
 

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -92,6 +92,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'voice-partial-window.ts',
   'voice-pcm-buffer.ts',
   'voice-permission-policy.ts',
+  'voice-security.ts',
   'voice-stt.ts',
   'voice-tts.ts',
   'voice-vad.ts',

--- a/tests/private-voice-scaffold.test.ts
+++ b/tests/private-voice-scaffold.test.ts
@@ -211,4 +211,13 @@ test('private voice: IPC and preload channels are scaffolded', () => {
   assert.match(handlers, /voice:assets:ensure/)
   assert.match(preload, /'voice:assets:status'/)
   assert.match(preload, /assetsStatus/)
+
+  const security = readFileSync(join(root, 'apps/desktop/src/main/voice-security.ts'), 'utf8')
+  assert.match(security, /ttsLogMeta/)
+  assert.match(security, /VOICE_SECURITY_RESIDUAL_RISKS/)
+  assert.match(security, /JOE-1111/)
+  assert.match(host, /ttsLogMeta/)
+  const adrSecurity = readFileSync(join(root, 'docs/adr/private-realtime-voice.md'), 'utf8')
+  assert.match(adrSecurity, /Security audit \(JOE-1111\)/)
+  assert.match(adrSecurity, /R-VOICE-01/)
 })

--- a/tests/voice-security.test.ts
+++ b/tests/voice-security.test.ts
@@ -1,0 +1,213 @@
+/**
+ * JOE-1111 — private voice security gates.
+ * Proves local_only fail-closed, log redaction (no PCM/transcript), and
+ * non-local support matrix blocks. Greppable audit: docs/adr/private-realtime-voice.md.
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  VOICE_SECURITY_RESIDUAL_RISKS,
+  VOICE_STT_LOG_ALLOWED_KEYS,
+  VOICE_TTS_LOG_ALLOWED_KEYS,
+  assertVoiceLogMetaKeys,
+  payloadLooksFreeOfAudio,
+  ttsLogMeta,
+} from '../apps/desktop/src/main/voice-security.ts'
+import {
+  AurumCliVoiceStt,
+  FakeVoiceStt,
+  hashTranscriptText,
+  sttLogMeta,
+} from '../apps/desktop/src/main/voice-stt.ts'
+import { FakeVoiceTts } from '../apps/desktop/src/main/voice-tts.ts'
+import { FakeVoiceCapture } from '../apps/desktop/src/main/voice-capture.ts'
+import { VoiceHost } from '../apps/desktop/src/main/voice-host.ts'
+import { browserCloudWorkspaceSupport } from '../packages/app/src/browser/cowork-api-support.ts'
+import { VOICE_WORKSPACE_SUPPORT_APIS } from '../packages/shared/src/voice.ts'
+import {
+  resolveRendererMediaPermission,
+} from '../apps/desktop/src/main/voice-permission-policy.ts'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const mainDir = join(root, 'apps/desktop/src/main')
+
+function readMainVoiceSources(): { name: string; source: string }[] {
+  return readdirSync(mainDir)
+    .filter((name) => name.startsWith('voice-') && name.endsWith('.ts'))
+    .map((name) => ({ name, source: readFileSync(join(mainDir, name), 'utf8') }))
+}
+
+test('sttLogMeta never includes transcript text (length only)', () => {
+  const secret = 'user said something private about ACME-42'
+  const meta = sttLogMeta({
+    text: secret,
+    model: 'tiny-q5_1',
+    backend: 'fake',
+    durationMs: 12,
+    cleaned: true,
+  })
+  const check = assertVoiceLogMetaKeys(meta as Record<string, unknown>, VOICE_STT_LOG_ALLOWED_KEYS)
+  assert.equal(check.ok, true)
+  assert.equal(meta.textChars, secret.length)
+  assert.equal('text' in meta, false)
+  const json = JSON.stringify(meta)
+  assert.doesNotMatch(json, /ACME-42/)
+  assert.doesNotMatch(json, /private/)
+  // Correlation hash is available without logging the body
+  assert.equal(hashTranscriptText(secret).length, 64)
+  assert.notEqual(hashTranscriptText(secret), hashTranscriptText('other'))
+})
+
+test('ttsLogMeta never includes spoken string', () => {
+  const spoken = 'Assistant reply with secrets XYZ'
+  const meta = ttsLogMeta({ text: spoken, backend: 'fake', bargedIn: false })
+  const check = assertVoiceLogMetaKeys(meta as Record<string, unknown>, VOICE_TTS_LOG_ALLOWED_KEYS)
+  assert.equal(check.ok, true)
+  assert.equal(meta.chars, spoken.length)
+  assert.doesNotMatch(JSON.stringify(meta), /XYZ|Assistant reply/)
+})
+
+test('payloadLooksFreeOfAudio rejects samples and typed arrays', () => {
+  assert.equal(payloadLooksFreeOfAudio(JSON.stringify({ sampleRate: 16000, frames: 10 })), true)
+  assert.equal(payloadLooksFreeOfAudio(JSON.stringify({ samples: [0.1, 0.2] })), false)
+  assert.equal(payloadLooksFreeOfAudio('{"pcm":[1]}'), false)
+  assert.equal(payloadLooksFreeOfAudio('Float32Array(320)'), false)
+  assert.equal(
+    payloadLooksFreeOfAudio(JSON.stringify({ type: 'final', text: 'hello there' }), { allowEventText: true }),
+    true,
+  )
+  assert.equal(
+    payloadLooksFreeOfAudio(JSON.stringify({ type: 'status', text: 'hello there' })),
+    false,
+  )
+})
+
+test('Aurum STT local_only fails closed without model (offline)', async () => {
+  const stt = new AurumCliVoiceStt({
+    binPath: '/usr/bin/false',
+    model: 'tiny-q5_1',
+    cacheDir: join(root, '.no-such-aurum-cache-joe-1111'),
+    localOnly: true,
+    isModelCached: () => false,
+  })
+  assert.equal(stt.isReady(), false)
+  await assert.rejects(
+    () => stt.transcribePcm(new Float32Array(1600)),
+    /local_only|not present/i,
+  )
+})
+
+test('Aurum STT default path never passes openrouter provider', async () => {
+  const calls: string[][] = []
+  const { EventEmitter } = await import('node:events')
+  const fakeSpawn = ((cmd: string, args: string[]) => {
+    calls.push(args)
+    const ee = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter }
+    ee.stdout = new EventEmitter()
+    ee.stderr = new EventEmitter()
+    queueMicrotask(() => {
+      ee.stdout.emit('data', 'ok\n')
+      ee.emit('close', 0)
+    })
+    return ee
+  }) as unknown as typeof import('node:child_process').spawn
+
+  const stt = new AurumCliVoiceStt({
+    binPath: 'aurum',
+    localOnly: true,
+    isModelCached: () => true,
+    spawnImpl: fakeSpawn,
+  })
+  await stt.transcribePcm(new Float32Array(400))
+  assert.equal(calls.length, 1)
+  const args = calls[0]!
+  assert.equal(args[args.indexOf('--provider') + 1], 'local')
+  assert.ok(!args.some((a) => /openrouter|openai|elevenlabs/i.test(a)))
+})
+
+test('voice host status JSON never smuggles PCM; logs use redacted meta shape', async () => {
+  const host = new VoiceHost({
+    features: { voice: true },
+    capture: new FakeVoiceCapture({ intervalMs: 5, chunkFrames: 160 }),
+    stt: new FakeVoiceStt({ text: 'classified utterance alpha' }),
+    tts: new FakeVoiceTts(),
+    probeMicrophone: async () => 'granted',
+    partialsEnabled: false,
+  })
+
+  const session = await host.startSession({ mode: 'ptt' })
+  await new Promise((r) => setTimeout(r, 25))
+  const listening = host.getStatus()
+  assert.equal(payloadLooksFreeOfAudio(JSON.stringify(listening), { allowEventText: false }), true)
+  assert.doesNotMatch(JSON.stringify(listening), /classified utterance/)
+
+  await host.stopSession(session.id)
+  // Host may retain last transcript in memory for tests — must not appear on status.
+  assert.equal(host.getLastTranscript(), 'classified utterance alpha')
+  assert.doesNotMatch(JSON.stringify(host.getStatus()), /classified utterance/)
+
+  await host.speak({ text: 'spoken classified beta' })
+  assert.doesNotMatch(JSON.stringify(host.getStatus()), /spoken classified/)
+})
+
+test('browser cloud support matrix blocks all voice.* APIs', () => {
+  const support = browserCloudWorkspaceSupport({})
+  for (const api of VOICE_WORKSPACE_SUPPORT_APIS) {
+    const entry = support.find((row) => row.api === api)
+    assert.ok(entry, api)
+    assert.equal(entry!.status, 'not_supported')
+  }
+})
+
+test('renderer media permission stays denied for voice_host capture mode', () => {
+  const denied = resolveRendererMediaPermission({
+    features: { voice: true },
+    captureMode: 'voice_host',
+    permission: 'media',
+  })
+  assert.equal(denied.allowed, false)
+})
+
+test('preload surface has no lastTranscript / raw audio channels', () => {
+  const preload = readFileSync(join(root, 'apps/desktop/src/preload/index.ts'), 'utf8')
+  assert.doesNotMatch(preload, /lastTranscript|getHostPcm|rawAudio|voice:pcm/i)
+  assert.match(preload, /'voice:status'/)
+  assert.match(preload, /'voice:assets:status'/)
+})
+
+test('voice main sources never log OPENROUTER as default STT provider', () => {
+  for (const { name, source } of readMainVoiceSources()) {
+    // Clearing the key is fine; selecting openrouter as provider is not.
+    if (/--provider['"]?\s*,\s*['"]openrouter|provider:\s*['"]openrouter/i.test(source)) {
+      assert.fail(`${name} selects openrouter STT provider`)
+    }
+    // Log lines must use sttLogMeta / ttsLogMeta rather than raw result.text
+    if (name === 'voice-host.ts') {
+      assert.match(source, /sttLogMeta/)
+      assert.match(source, /ttsLogMeta/)
+      assert.doesNotMatch(source, /log\('voice',\s*`[^`]*\$\{[^}]*\.text/)
+    }
+  }
+})
+
+test('security residual risk register is non-empty and stable', () => {
+  assert.ok(VOICE_SECURITY_RESIDUAL_RISKS.length >= 4)
+  const ids = new Set(VOICE_SECURITY_RESIDUAL_RISKS.map((r) => r.id))
+  assert.equal(ids.size, VOICE_SECURITY_RESIDUAL_RISKS.length)
+  for (const risk of VOICE_SECURITY_RESIDUAL_RISKS) {
+    assert.match(risk.id, /^R-VOICE-\d+$/)
+    assert.ok(risk.summary.length > 10)
+    assert.ok(risk.mitigation.length > 10)
+  }
+})
+
+test('ADR documents JOE-1111 security audit notes', () => {
+  const adr = readFileSync(join(root, 'docs/adr/private-realtime-voice.md'), 'utf8')
+  assert.match(adr, /JOE-1111/)
+  assert.match(adr, /Security audit|security audit/i)
+  assert.match(adr, /local_only|textChars|never.*PCM|never.*transcript/i)
+  assert.match(adr, /R-VOICE-/)
+})


### PR DESCRIPTION
## Summary
- **JOE-1111 security gates:** `voice-security.ts` with `ttsLogMeta`, payload audio freeness, residual risk register (R-VOICE-01…05).
- Host TTS logs go through `ttsLogMeta` (chars only); STT already used `sttLogMeta` (no `text`).
- ADR **Security audit (JOE-1111)** table + residual risks; purity register updated.
- Automated tests: local_only fail-closed, no openrouter provider, status JSON free of PCM/transcript, preload has no lastTranscript, matrix blocks Cloud Web voice.

## Test plan
- [x] `tests/voice-security.test.ts`
- [x] private-voice scaffold + source-map + STT/TTS
- [ ] CI full suite

Linear: JOE-1111