### PR TITLE
feat(voice): packaging, a11y, dogfood, epic close-out (JOE-1106–1114)

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -86,6 +86,12 @@ extraResources:
     filter:
       - "dist/**/*"
       - "package.json"
+  # Optional private voice sidecars (JOE-1106). README always ships; operators may
+  # drop `aurum` / `ffmpeg` binaries next to it. CI does not pre-bundle weights.
+  - from: resources/voice
+    to: voice
+    filter:
+      - "**/*"
 
 asar: true
 asarUnpack:

--- a/apps/desktop/resources/voice/README.md
+++ b/apps/desktop/resources/voice/README.md
@@ -1,0 +1,38 @@
+# Packaged private voice sidecars (JOE-1106)
+
+This folder is copied into the Desktop app bundle as `resources/voice/`.
+
+## What ships by default
+
+- This README only (no Aurum model weights, no prebuilt aurum-ffi dylib).
+
+## Optional drop-ins (local-only)
+
+Place platform binaries next to this file:
+
+| File | Role |
+| --- | --- |
+| `aurum` / `aurum.exe` | Aurum CLI for STT (`local_only`) |
+| `ffmpeg` / `ffmpeg.exe` | Mic capture pipe (mono 16 kHz f32) |
+
+Resolution order (host):
+
+1. `OPEN_COWORK_AURUM_BIN` / `OPEN_COWORK_FFMPEG_PATH`
+2. Packaged path: `{resourcesPath}/voice/aurum` (or `.exe`)
+3. System `PATH` (`aurum`, `ffmpeg`)
+
+Models still live under the user data cache (`userData/voice/aurum` or system Aurum cache). See Settings → Privacy → Voice assets.
+
+## Platform support (honest)
+
+| Platform | Capture | STT | TTS | Claim |
+| --- | --- | --- | --- | --- |
+| macOS arm64/x64 | ffmpeg | aurum CLI + cached model | OS `say`+`afplay` | **Supported** when tools present |
+| Windows | ffmpeg dshow | aurum when installed | OS residual | **Best-effort** |
+| Linux | ffmpeg pulse | aurum when installed | OS residual | **Best-effort** |
+
+Do not claim “private voice ships fully offline in every package” without models + aurum present.
+
+## Codesign notes
+
+Any Mach-O / PE you drop into this folder must be signed with the same pipeline as other extraResources on release builds, or macOS Gatekeeper / Windows SmartScreen will block spawn. Preview CI packages intentionally omit binaries so missing tools fail closed with a clear status string.

--- a/apps/desktop/src/main/voice-capture.ts
+++ b/apps/desktop/src/main/voice-capture.ts
@@ -7,6 +7,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { platform } from 'node:os'
 import { VOICE_PCM_SAMPLE_RATE } from './voice-pcm-buffer.ts'
+import { resolvePackagedAwareFfmpegBin } from './voice-packaging.ts'
 
 export type VoiceCaptureBackendId = 'fake' | 'ffmpeg' | 'unavailable'
 
@@ -218,16 +219,8 @@ export function buildFfmpegCaptureArgs(platformId: NodeJS.Platform): string[] {
 }
 
 function resolveFfmpegPath(): string | null {
-  const candidates = [
-    process.env.OPEN_COWORK_FFMPEG_PATH,
-    process.env.FFMPEG_PATH,
-    'ffmpeg',
-  ].filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
-  for (const candidate of candidates) {
-    if (candidate === 'ffmpeg') return 'ffmpeg'
-    if (existsSync(candidate)) return candidate
-  }
-  return null
+  // JOE-1106: packaged resources/voice/ffmpeg before bare PATH name.
+  return resolvePackagedAwareFfmpegBin()
 }
 
 /** Production default: ffmpeg when resolvable, otherwise unavailable. */

--- a/apps/desktop/src/main/voice-capture.ts
+++ b/apps/desktop/src/main/voice-capture.ts
@@ -4,7 +4,6 @@
  * Capture stays in main/native. Renderers never receive raw audio bytes.
  */
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync } from 'node:fs'
 import { platform } from 'node:os'
 import { VOICE_PCM_SAMPLE_RATE } from './voice-pcm-buffer.ts'
 import { resolvePackagedAwareFfmpegBin } from './voice-packaging.ts'

--- a/apps/desktop/src/main/voice-packaging.ts
+++ b/apps/desktop/src/main/voice-packaging.ts
@@ -1,0 +1,229 @@
+/**
+ * Desktop packaging layout for private voice native deps (JOE-1106).
+ *
+ * Default STT path is the Aurum CLI (optional drop-in under resources/voice
+ * or PATH). Capture uses ffmpeg (PATH or packaged). TTS is OS tools (say /
+ * afplay) — no neural model bundle in the app by default.
+ *
+ * Honest residual: we do **not** ship Aurum model weights or a prebuilt
+ * aurum-ffi dylib in CI packages today. Operators install Aurum + cache
+ * tiny-q5_1, or drop binaries into the packaged voice resources folder.
+ */
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { platform as osPlatform } from 'node:os'
+
+export type VoicePackagingPlatform = 'darwin' | 'linux' | 'win32' | 'other'
+
+export type VoiceNativeBinaryKind = 'aurum' | 'ffmpeg'
+
+export type VoicePlatformPackagingRow = {
+  platform: VoicePackagingPlatform
+  /** Capture backend expectation when feature is on. */
+  capture: string
+  /** STT expectation. */
+  stt: string
+  /** TTS expectation. */
+  tts: string
+  /** Support level for shipping claims. */
+  support: 'supported' | 'best_effort' | 'residual'
+  residual: string | null
+}
+
+/** Operator-facing packaging matrix (also mirrored in ADR / dogfood runbook). */
+export const VOICE_PACKAGING_MATRIX: VoicePlatformPackagingRow[] = [
+  {
+    platform: 'darwin',
+    capture: 'ffmpeg (PATH or OPEN_COWORK_FFMPEG_PATH) → mono 16 kHz f32',
+    stt: 'aurum CLI (PATH, OPEN_COWORK_AURUM_BIN, or resources/voice/aurum); model tiny-q5_1 local cache',
+    tts: 'system_os (say + afplay)',
+    support: 'supported',
+    residual: 'Aurum binary and model weights are not pre-bundled in CI packages; install or drop into resources/voice.',
+  },
+  {
+    platform: 'win32',
+    capture: 'ffmpeg dshow (PATH) best-effort',
+    stt: 'aurum CLI when available on PATH or packaged voice/aurum.exe',
+    tts: 'system_os residual (PowerShell/SAPI deferred — may report unavailable)',
+    support: 'best_effort',
+    residual: 'Windows TTS OS backend and signed aurum.exe packaging are residual; fail-closed when tools missing.',
+  },
+  {
+    platform: 'linux',
+    capture: 'ffmpeg pulse/alsa (PATH) best-effort',
+    stt: 'aurum CLI when available on PATH or packaged voice/aurum',
+    tts: 'system_os residual (espeak/spd-say deferred — may report unavailable)',
+    support: 'best_effort',
+    residual: 'Linux neural TTS packaging deferred; capture/STT require host-installed ffmpeg + aurum.',
+  },
+]
+
+export function voicePackagingPlatform(id = osPlatform()): VoicePackagingPlatform {
+  if (id === 'darwin' || id === 'linux' || id === 'win32') return id
+  return 'other'
+}
+
+export function isElectronPackaged(
+  env: NodeJS.ProcessEnv = process.env,
+  electronApp?: { isPackaged?: boolean } | null,
+): boolean {
+  if (electronApp && typeof electronApp.isPackaged === 'boolean') {
+    return electronApp.isPackaged
+  }
+  // electron-builder / Electron set these in production.
+  return env.OPEN_COWORK_PACKAGED === '1'
+    || Boolean(env.PORTABLE_EXECUTABLE_DIR)
+    || (typeof process.resourcesPath === 'string'
+      && process.resourcesPath.length > 0
+      && !process.resourcesPath.includes(`${join('node_modules', 'electron')}`))
+}
+
+/**
+ * Packaged resources root for optional voice sidecars.
+ * Layout: `{resourcesPath}/voice/aurum` (+ optional `ffmpeg`, README).
+ */
+export function voicePackagedResourcesDir(
+  resourcesPath: string | null | undefined = typeof process.resourcesPath === 'string'
+    ? process.resourcesPath
+    : null,
+): string | null {
+  if (!resourcesPath) return null
+  return join(resourcesPath, 'voice')
+}
+
+export function packagedBinaryName(kind: VoiceNativeBinaryKind, platform = osPlatform()): string {
+  if (platform === 'win32') {
+    return kind === 'aurum' ? 'aurum.exe' : 'ffmpeg.exe'
+  }
+  return kind === 'aurum' ? 'aurum' : 'ffmpeg'
+}
+
+/**
+ * Ordered candidates for Aurum CLI. Never invents non-existent absolute paths
+ * as "ready" — only returns PATH names or paths that exist on disk.
+ */
+export function listAurumBinCandidates(options: {
+  env?: NodeJS.ProcessEnv
+  resourcesPath?: string | null
+  platform?: NodeJS.Platform
+} = {}): string[] {
+  const env = options.env || process.env
+  const platform = options.platform || osPlatform()
+  const resources = options.resourcesPath !== undefined
+    ? options.resourcesPath
+    : (typeof process.resourcesPath === 'string' ? process.resourcesPath : null)
+  const voiceDir = voicePackagedResourcesDir(resources)
+  const packaged = voiceDir
+    ? join(voiceDir, packagedBinaryName('aurum', platform))
+    : null
+
+  const out: string[] = []
+  const push = (value: string | null | undefined) => {
+    const v = value?.trim()
+    if (v && !out.includes(v)) out.push(v)
+  }
+  push(env.OPEN_COWORK_AURUM_BIN)
+  push(env.AURUM_BIN)
+  push(packaged)
+  // Dev convenience: sibling checkout of aurum
+  if (platform === 'darwin') {
+    push(join(homedir(), '.local', 'bin', 'aurum'))
+  }
+  push('aurum')
+  return out
+}
+
+export function listFfmpegBinCandidates(options: {
+  env?: NodeJS.ProcessEnv
+  resourcesPath?: string | null
+  platform?: NodeJS.Platform
+} = {}): string[] {
+  const env = options.env || process.env
+  const platform = options.platform || osPlatform()
+  const resources = options.resourcesPath !== undefined
+    ? options.resourcesPath
+    : (typeof process.resourcesPath === 'string' ? process.resourcesPath : null)
+  const voiceDir = voicePackagedResourcesDir(resources)
+  const packaged = voiceDir
+    ? join(voiceDir, packagedBinaryName('ffmpeg', platform))
+    : null
+
+  const out: string[] = []
+  const push = (value: string | null | undefined) => {
+    const v = value?.trim()
+    if (v && !out.includes(v)) out.push(v)
+  }
+  push(env.OPEN_COWORK_FFMPEG_PATH)
+  push(env.FFMPEG_PATH)
+  push(packaged)
+  push('ffmpeg')
+  return out
+}
+
+/**
+ * Resolve first usable binary. PATH bare names (`aurum`, `ffmpeg`) are returned
+ * without existsSync so spawn can search PATH. Absolute/relative paths must exist.
+ */
+export function resolveFirstExistingBinary(candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (candidate === 'aurum' || candidate === 'ffmpeg' || candidate === 'aurum.exe' || candidate === 'ffmpeg.exe') {
+      return candidate
+    }
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+export function resolvePackagedAwareAurumBin(options?: {
+  env?: NodeJS.ProcessEnv
+  resourcesPath?: string | null
+  platform?: NodeJS.Platform
+}): string | null {
+  return resolveFirstExistingBinary(listAurumBinCandidates(options))
+}
+
+export function resolvePackagedAwareFfmpegBin(options?: {
+  env?: NodeJS.ProcessEnv
+  resourcesPath?: string | null
+  platform?: NodeJS.Platform
+}): string | null {
+  return resolveFirstExistingBinary(listFfmpegBinCandidates(options))
+}
+
+/**
+ * CI gate helper: packaged absolute candidates under a fake resources tree must
+ * not be returned when files are missing (no broken dylib/dll claims).
+ */
+export function assertNoBrokenPackagedVoicePaths(
+  resourcesRoot: string,
+  platform: NodeJS.Platform = 'darwin',
+): { ok: true } | { ok: false; leaked: string[] } {
+  const aurum = listAurumBinCandidates({ resourcesPath: resourcesRoot, platform, env: {} })
+    .filter((c) => c.startsWith(resourcesRoot) && !existsSync(c))
+  const ffmpeg = listFfmpegBinCandidates({ resourcesPath: resourcesRoot, platform, env: {} })
+    .filter((c) => c.startsWith(resourcesRoot) && !existsSync(c))
+  // Candidates may list missing paths; resolveFirstExistingBinary must skip them.
+  const resolvedA = resolveFirstExistingBinary(
+    listAurumBinCandidates({ resourcesPath: resourcesRoot, platform, env: {} }),
+  )
+  const resolvedF = resolveFirstExistingBinary(
+    listFfmpegBinCandidates({ resourcesPath: resourcesRoot, platform, env: {} }),
+  )
+  const leaked: string[] = []
+  if (resolvedA && resolvedA.startsWith(resourcesRoot) && !existsSync(resolvedA)) {
+    leaked.push(resolvedA)
+  }
+  if (resolvedF && resolvedF.startsWith(resourcesRoot) && !existsSync(resolvedF)) {
+    leaked.push(resolvedF)
+  }
+  // Also ensure we don't treat missing packaged path as the only candidate "ready"
+  void aurum
+  void ffmpeg
+  if (leaked.length > 0) return { ok: false, leaked }
+  return { ok: true }
+}
+
+export function packagingRowForPlatform(platform = voicePackagingPlatform()): VoicePlatformPackagingRow | null {
+  return VOICE_PACKAGING_MATRIX.find((row) => row.platform === platform) || null
+}

--- a/apps/desktop/src/main/voice-security.ts
+++ b/apps/desktop/src/main/voice-security.ts
@@ -127,4 +127,14 @@ export const VOICE_SECURITY_RESIDUAL_RISKS = [
     summary: 'getLastTranscript() exists for tests/host diagnostics; not exposed on renderer IPC.',
     mitigation: 'Preload surface has no lastTranscript channel; only status/session/tts/assets.',
   },
+  {
+    id: 'R-VOICE-06',
+    summary: 'Aurum CLI and ffmpeg are not pre-bundled in every CI package.',
+    mitigation: 'resources/voice drop-in + fail-closed status; packaging matrix documents macOS supported vs Win/Linux best-effort.',
+  },
+  {
+    id: 'R-VOICE-07',
+    summary: 'Windows/Linux OS TTS backends remain residual.',
+    mitigation: 'system_os reports unavailable when tools missing; no cloud TTS default.',
+  },
 ] as const

--- a/apps/desktop/src/main/voice-stt.ts
+++ b/apps/desktop/src/main/voice-stt.ts
@@ -12,6 +12,7 @@ import { tmpdir, homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { getAppPathHost } from '@open-cowork/shared/node'
 import { VOICE_PCM_SAMPLE_RATE } from './voice-pcm-buffer.ts'
+import { resolvePackagedAwareAurumBin } from './voice-packaging.ts'
 
 export const AURUM_DEFAULT_MODEL = 'tiny-q5_1'
 export const AURUM_DEFAULT_MODEL_FILE = 'ggml-tiny-q5_1.bin'
@@ -257,16 +258,8 @@ export function isAurumModelAvailable(model: string, cacheDir: string): boolean 
 }
 
 export function resolveAurumBinPath(): string | null {
-  const candidates = [
-    process.env.OPEN_COWORK_AURUM_BIN,
-    process.env.AURUM_BIN,
-    'aurum',
-  ].filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
-  for (const candidate of candidates) {
-    if (candidate === 'aurum') return 'aurum'
-    if (existsSync(candidate)) return candidate
-  }
-  return null
+  // JOE-1106: packaged resources/voice/aurum before bare PATH name.
+  return resolvePackagedAwareAurumBin()
 }
 
 export function createDefaultVoiceStt(): VoiceSttEngine {

--- a/docs/adr/private-realtime-voice.md
+++ b/docs/adr/private-realtime-voice.md
@@ -73,6 +73,8 @@ Rules:
 12. **Conversation controller (JOE-1107):** Pure state machine `Idle → Listening → FinalizingSTT → Prompting → Streaming → Speaking → Idle` drives **PTT-gated** voice turns when the user enables conversation mode (default **off**). Release mic → STT final → `session.prompt` → wait for generation idle → local TTS of the latest assistant message. **Cancel / barge-in** stops TTS, cancels listen, and aborts generation.
 13. **Continuous VAD + barge-in (JOE-1104):** Opt-in **energy VAD** (RMS gate, not neural) on the voice host when conversation mode **and** continuous listen are both on (default **off** — never silent always-on). Host auto-finalizes on end-of-utterance silence or max-listen timeout; UI shows a privacy mic-armed indicator. After `SPEAK_DONE` with continuous on, the machine re-arms listening. During TTS, host monitors mic energy and emits `vad` `barge_in` (cancels local speak; renderer aborts gen + re-listens). Still text/status/vad IPC only — no raw audio to the renderer.
 14. **First-run assets (JOE-1109):** STT models are **local files** under OC `userData/voice/aurum` (or system Aurum cache). Default **local_only fail-closed** when missing — no silent network download. Integrity uses size floor + optional sibling `.sha256`. `OPEN_COWORK_AURUM_ALLOW_DOWNLOAD=1` is explicit operator opt-in for a **file** fetch residual (never audio/transcript upload). Settings → Privacy shows offline-ready status + **Ensure local model** (copy from system cache when present). TTS readiness remains OS speech probe.
+15. **Packaging (JOE-1106):** Optional sidecars under packaged `resources/voice/` (`aurum` / `ffmpeg`); resolution prefers env → packaged path → PATH. CI packages ship the folder + README **without** pre-bundled model weights or aurum-ffi dylibs (fail closed when missing). macOS **supported** when tools present; Windows/Linux **best-effort** with residual TTS backends. Codesign any drop-in binaries with the release pipeline.
+16. **Accessibility (JOE-1112):** Mic control exposes `aria-pressed` / `aria-busy`; phase chrome uses a single polite live region; disabled reasons render as a status region (permission denied / model missing / unsupported workspace), not a mute one-liner.
 
 ### 4. Workspace support APIs
 
@@ -122,8 +124,10 @@ Rules:
 | R-VOICE-03 | OS TTS may write temp AIFF/WAV for playback | Local host only; cancel best-effort cleanup |
 | R-VOICE-04 | Opt-in model download env | Default off; Settings copy; never audio |
 | R-VOICE-05 | `getLastTranscript()` host memory for tests | Not on preload/IPC |
+| R-VOICE-06 | Aurum/ffmpeg not pre-bundled in CI packages | Packaging README + fail-closed status; optional drop-in |
+| R-VOICE-07 | Windows/Linux OS TTS residual | Best-effort claim; unavailable status when tools missing |
 
-Automated gates: `tests/voice-security.test.ts` (plus existing STT/TTS/scaffold tests).
+Automated gates: `tests/voice-security.test.ts`, `tests/voice-packaging.test.ts` (plus existing STT/TTS/scaffold tests). Dogfood: [voice-private-dogfood.md](../runbooks/voice-private-dogfood.md). Close-out: [voice-private-epic-closeout.md](../voice-private-epic-closeout.md).
 
 ## Consequences
 

--- a/docs/product-purity-register.md
+++ b/docs/product-purity-register.md
@@ -53,7 +53,7 @@ Optional installable siblings (not Desktop default nav):
 | Durable Gateway (`cowork-gateway`) | Local operator / claim-gated beta | Multi-tenant production GA without evidence |
 | Tier-1 channels (Telegram/Slack/email) | Launch-tier adapters | — |
 | Tier-3 channels (Discord/WhatsApp/Signal) | Experimental / bridge-backed | Launch marketing without live smoke |
-| Private realtime voice | Desktop Local opt-in (`features.voice`); on-device STT (Aurum) + sibling TTS; security audit JOE-1111 (log redaction + local_only tests) | Cloud Web mic, Aurum-as-TTS, silent model download, shipping claim without dogfood evidence |
+| Private realtime voice | Desktop Local opt-in (`features.voice`); on-device STT (Aurum) + sibling OS TTS; PTT/conversation/VAD; security + packaging residuals documented | Cloud Web mic, enterprise voice GA, always-on without consent, Aurum-as-TTS, silent model download, “ships fully offline in every package” without tools/models |
 
 ## Forbidden claims (fail closed)
 
@@ -64,8 +64,10 @@ Optional installable siblings (not Desktop default nav):
 - Knowledge = Wiki (or OpenWiki as synonym for in-app Knowledge)
 - Enterprise-ready / hosted GA without rows proven in enterprise readiness matrix
 - Mobile / Teams as shipping products (names reserved only)
-- “Private voice shipping” while `features.voice` default-off and host/STT still deferred
+- “Private voice shipping” / GA while `features.voice` default-off or without dogfood evidence ([runbook](runbooks/voice-private-dogfood.md))
 - Cloud Web or remote workspace microphone capture for Open Cowork Studio
+- Always-on continuous listen without explicit user enable
+- Bundled-offline private voice claim when Aurum CLI / model weights are not present
 
 ## Finding → issue map (Wave 1+)
 

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -48,7 +48,7 @@ and `isDesktopFeatureEnabled` in `packages/shared/src/app-config.ts`.
 | `approvals` | Prefer Always-allow story complete for local; queue still useful for allow/deny/questions |
 | `knowledge` | Users understand Knowledge ≠ Wiki |
 | `artifacts` | Artifact index paths work for the authority in use |
-| `voice` | Desktop Local only; voice host + Aurum STT wired; Cloud Web / remote stay `not_supported`; see [Private realtime voice ADR](adr/private-realtime-voice.md) |
+| `voice` | Desktop Local only; voice host + Aurum STT + local OS TTS + PTT/conversation; Cloud Web / remote stay `not_supported`; dogfood: [voice-private-dogfood.md](runbooks/voice-private-dogfood.md); [ADR](adr/private-realtime-voice.md) |
 
 Public `open-cowork.config.json` must **not** enable secondary keys by default
 and must **not** auto-register Wiki or durable Gateway MCP entries.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -26,7 +26,7 @@ Before publishing release notes or marketing copy, confirm against
 
 - [ ] No unqualified “gateway” (must say Channel / Standalone / durable Gateway)
 - [ ] No “Always allow” / daily digest as shipping features unless implemented
-- [ ] Private voice (`features.voice`) not claimed shipping unless host + Aurum STT + PTT UI evidence is green ([ADR](adr/private-realtime-voice.md)); default remains off
+- [ ] Private voice (`features.voice`) claims follow [claim freeze](runbooks/voice-private-dogfood.md#claim-freeze-allowed-vs-forbidden): Local Desktop opt-in only; no Cloud Web mic, no always-on without consent, no “fully offline package” without aurum + model; evidence via [epic close-out](voice-private-epic-closeout.md) / dogfood runbook; default remains **off**
 - [ ] No Standalone/Paired “full workspace chat ready” while support matrix is deferred
 - [ ] Knowledge ≠ Wiki; no default Desktop Wiki/Gateway MCP claims
 - [ ] Projects described as coordination board (not history facets) unless UI changes

--- a/docs/runbooks/voice-private-dogfood.md
+++ b/docs/runbooks/voice-private-dogfood.md
@@ -1,0 +1,101 @@
+# Private voice dogfood runbook (JOE-1113)
+
+Desktop Local only. Feature flag **`features.voice`** default **off**.
+
+## Preconditions
+
+1. Open Cowork Desktop on **macOS** (primary). Windows/Linux are best-effort (see packaging residual).
+2. Set in `open-cowork.config.json` (or operator overlay):
+
+```json
+{
+  "features": {
+    "voice": true
+  }
+}
+```
+
+3. Install tools (not pre-bundled in every CI package):
+   - **ffmpeg** on `PATH` (or `OPEN_COWORK_FFMPEG_PATH`)
+   - **aurum** CLI on `PATH` (or `OPEN_COWORK_AURUM_BIN`), model `tiny-q5_1` cached
+   - Optional: drop binaries under packaged `resources/voice/` (see `apps/desktop/resources/voice/README.md`)
+4. Grant **microphone** permission when prompted (host-owned, not renderer `getUserMedia`).
+5. Workspace must be **Desktop Local** — Cloud Web / paired authorities stay `not_supported`.
+
+## Scenarios
+
+### A. Dictation PTT (JOE-1105 / JOE-1102)
+
+1. Open Chat or Home composer.
+2. Confirm mic control visible (`data-testid="voice-ptt-button"`).
+3. Click mic → status **Listening…** (live region).
+4. Speak a short phrase; click again → **Transcribing…** then text injects into composer.
+5. Cancel mid-listen (if exposed) must not send a prompt.
+6. Partials may update the dictation segment while holding; final replaces them.
+
+### B. Hotkey (JOE-1110)
+
+1. Focus Open Cowork (app-focused only — not OS-wide paste).
+2. Default: `Cmd+Shift+Space` / `Ctrl+Shift+Space`.
+3. Settings → Privacy → Private voice shows accelerator when flag on.
+4. Avoid collision with command palette (`Cmd/Ctrl+Shift+P`).
+
+### C. Read-aloud (JOE-1103)
+
+1. Complete an assistant message.
+2. **Read aloud** on the bubble (when TTS ready).
+3. Stop cancels immediately; starting PTT stops read-aloud.
+
+### D. Conversation mode (JOE-1107)
+
+1. Toggle **conversation** (radio icon) on.
+2. Mic starts a listen → final → agent prompt → stream → local TTS of reply.
+3. Status cycles Listening / Transcribing / Thinking / Speaking.
+
+### E. Continuous VAD + barge-in (JOE-1104)
+
+1. Conversation mode on → toggle **continuous** (activity icon).
+2. Privacy red dot while mic armed.
+3. After speak, mic re-arms; speak over TTS to barge-in (cancels speech + re-listens).
+4. Continuous stays **off** by default; never silent always-on.
+
+### F. Assets offline (JOE-1109)
+
+1. Settings → Privacy → Voice assets.
+2. **Refresh status** / **Ensure local model**.
+3. Missing model + no download env → clear fail-closed message (no silent network).
+
+### G. Security smoke (JOE-1111)
+
+1. Enable voice, dictate once.
+2. Confirm logs show `textChars` / `chars` only — **no** transcript body or PCM in main logs.
+3. Cloud Web build: voice controls absent / `not_supported`.
+
+## Evidence to record
+
+| Field | Example |
+| --- | --- |
+| Git SHA | `git rev-parse HEAD` |
+| Platform | macOS arm64 15.x |
+| Config | `features.voice=true` |
+| Aurum | version + model `tiny-q5_1` present |
+| Scenarios | A–E pass / fail notes |
+| Residual | Windows TTS, Linux TTS, no bundled model weights |
+
+Paste evidence as a comment on [JOE-1096](https://linear.app/joe-broadhead/issue/JOE-1096).
+
+## Claim freeze (allowed vs forbidden)
+
+### Allowed (when flag on + tools present)
+
+- “Desktop Local private voice (opt-in): on-device STT via Aurum, local OS TTS, PTT and optional conversation.”
+- “Audio stays on-machine on the default path (`local_only`).”
+
+### Forbidden
+
+- Cloud / multi-tenant / enterprise voice GA
+- Browser / Cloud Web microphone for Studio
+- Always-on continuous listen without explicit user enable
+- “Ships fully offline in every package” without aurum + model present
+- Aurum-as-TTS, cloud STT/TTS as default
+- OS-wide Accessibility dictation into other apps (ZephyrFlow territory)

--- a/docs/voice-private-epic-closeout.md
+++ b/docs/voice-private-epic-closeout.md
@@ -1,0 +1,71 @@
+# Private realtime voice — epic close-out (JOE-1114)
+
+Parent epic: [JOE-1096](https://linear.app/joe-broadhead/issue/JOE-1096).
+
+## Children status
+
+| ID | Title | Status |
+| --- | --- | --- |
+| JOE-1099 | V0.1 Spec + claim boundary | Done |
+| JOE-1100 | V0.2 Feature flag + support matrix | Done |
+| JOE-1098 | V0.3 OS permissions | Done |
+| JOE-1097 | V1.1 Voice host PCM + IPC | Done |
+| JOE-1101 | V1.2 Aurum STT local_only | Done |
+| JOE-1102 | V1.3 Partials | Done |
+| JOE-1105 | V2.1 Chat/Home PTT UI | Done |
+| JOE-1110 | V2.2 Hotkey | Done |
+| JOE-1108 | V3.1 Local TTS sibling | Done |
+| JOE-1103 | V3.2 Read-aloud | Done |
+| JOE-1107 | V4.1 Conversation controller | Done |
+| JOE-1104 | V4.2 VAD continuous + barge-in | Done |
+| JOE-1109 | V5.1 Assets first-run | Done |
+| JOE-1106 | V5.2 Packaging | Done (honest residual documented) |
+| JOE-1111 | V6.1 Security audit | Done |
+| JOE-1112 | V6.3 Accessibility | Done |
+| JOE-1113 | V6.2 Dogfood + claim freeze | Done |
+| JOE-1114 | V6.4 Epic close-out | Done (this doc) |
+
+**P0 open children without Waive:** none.
+
+## Residual risk register
+
+| ID | Severity | Risk | Mitigation / Waive |
+| --- | --- | --- | --- |
+| R-VOICE-01 | P2 | Partial/final IPC carries transcript text | Product requirement; no audio on IPC; no free-text adoption telemetry |
+| R-VOICE-02 | P2 | Temp WAV for Aurum CLI | OS temp + `rmSync` in finally |
+| R-VOICE-03 | P2 | OS TTS temp AIFF | Local host; cancel best-effort |
+| R-VOICE-04 | P2 | Opt-in model download env | Default off; files only |
+| R-VOICE-05 | P3 | `getLastTranscript` host memory | Not on preload/IPC |
+| R-VOICE-06 | P2 | Aurum/ffmpeg not pre-bundled in CI packages | Fail-closed + packaging README; macOS supported when tools present |
+| R-VOICE-07 | P2 | Windows/Linux TTS OS backends residual | Best-effort claim; status unavailable when tools missing |
+| R-VOICE-08 | P3 | Energy VAD is RMS not neural | Documented; opt-in continuous only |
+
+No P0 residual without Waive.
+
+## Demo evidence template
+
+```text
+Epic: JOE-1096 Private realtime voice
+SHA: 48b3df4396a933c0809f5d77d557849d5f166458 (pre-merge; update after merge)
+Platform: macOS arm64
+features.voice: true
+Scenarios:
+  - PTT dictation: pass/fail
+  - Read-aloud: pass/fail
+  - Conversation + optional continuous: pass/fail
+Aurum model: tiny-q5_1 cached: yes/no
+Notes:
+```
+
+Automated evidence (CI): voice unit/security/packaging tests on PRs; ADR + dogfood runbook in tree.
+
+## Claim freeze pointer
+
+- Runbook: [voice-private-dogfood.md](./runbooks/voice-private-dogfood.md)
+- ADR: [private-realtime-voice.md](./adr/private-realtime-voice.md)
+- Purity register: [product-purity-register.md](./product-purity-register.md)
+- Release checklist purity gate includes voice claim check
+
+## Milestone
+
+Milestone **Private Realtime Voice — STT + TTS (2026-07)** children complete; mark epic Done when Linear children reflect this table.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,8 @@ nav:
       - Product purity final wave: product-purity-final-wave.md
       - Pairing connector scope: pairing-connector-scope.md
       - Product purity dogfood: runbooks/product-purity-dogfood.md
+      - Private voice dogfood: runbooks/voice-private-dogfood.md
+      - Private voice epic close-out: voice-private-epic-closeout.md
       - Cloud sync dogfood: runbooks/cloud-sync-dogfood.md
       - Enterprise readiness matrix: enterprise-readiness-matrix.md
       - Maintainer product map: maintainer-product-map.md

--- a/packages/app/src/components/chat/VoicePttButton.test.tsx
+++ b/packages/app/src/components/chat/VoicePttButton.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { VoicePttButton } from './VoicePttButton'
+import type { VoicePttController } from '../../hooks/useVoicePtt'
+import type { VoiceConversationController } from '../../hooks/useVoiceConversation'
+
+function baseVoice(overrides: Partial<VoicePttController> = {}): VoicePttController {
+  return {
+    visible: true,
+    enabled: true,
+    disabledReason: null,
+    phase: 'idle',
+    statusLabel: null,
+    isActive: false,
+    toggle: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+function baseConversation(
+  overrides: Partial<VoiceConversationController> = {},
+): VoiceConversationController {
+  return {
+    visible: true,
+    enabled: true,
+    disabledReason: null,
+    phase: 'idle',
+    chromePhase: 'idle',
+    statusLabel: null,
+    isActive: false,
+    conversationMode: false,
+    setConversationMode: vi.fn(),
+    continuousVad: false,
+    setContinuousVad: vi.fn(),
+    privacyListening: false,
+    toggle: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+describe('VoicePttButton a11y (JOE-1112)', () => {
+  it('exposes aria-pressed and status live region while listening', () => {
+    render(
+      <VoicePttButton
+        voice={baseVoice({ phase: 'listening', statusLabel: 'Listening…', isActive: true })}
+      />,
+    )
+    const mic = screen.getByTestId('voice-ptt-button')
+    expect(mic).toHaveAttribute('aria-pressed', 'true')
+    const status = screen.getByTestId('voice-status-label')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveTextContent(/Listening/)
+  })
+
+  it('shows disabled reason as a status region (not a mute one-liner)', () => {
+    render(
+      <VoicePttButton
+        voice={baseVoice({
+          enabled: false,
+          disabledReason: 'Microphone permission is denied. Enable it in system settings.',
+        })}
+      />,
+    )
+    const banner = screen.getByTestId('voice-disabled-reason')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveTextContent(/Microphone permission/)
+    expect(screen.getByTestId('voice-ptt-button')).toBeDisabled()
+  })
+
+  it('toggles conversation mode and continuous VAD with aria-pressed', () => {
+    const setConversationMode = vi.fn()
+    const setContinuousVad = vi.fn()
+    render(
+      <VoicePttButton
+        voice={baseVoice()}
+        conversation={baseConversation({
+          conversationMode: true,
+          setConversationMode,
+          continuousVad: false,
+          setContinuousVad,
+          chromePhase: 'idle',
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('voice-conversation-mode'))
+    expect(setConversationMode).toHaveBeenCalledWith(false)
+    fireEvent.click(screen.getByTestId('voice-continuous-vad'))
+    expect(setContinuousVad).toHaveBeenCalledWith(true)
+  })
+
+  it('hides control when voice is not visible', () => {
+    render(<VoicePttButton voice={baseVoice({ visible: false })} />)
+    expect(screen.queryByTestId('voice-ptt-button')).toBeNull()
+  })
+
+  it('marks busy phases with aria-busy via loading spinner on the mic control', () => {
+    render(
+      <VoicePttButton
+        voice={baseVoice()}
+        conversation={baseConversation({
+          conversationMode: true,
+          chromePhase: 'thinking',
+          phase: 'streaming',
+          statusLabel: 'Thinking…',
+          isActive: true,
+          enabled: true,
+        })}
+      />,
+    )
+    // IconButton sets aria-busy when loading=true (transcribing/thinking).
+    expect(screen.getByTestId('voice-ptt-button')).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByTestId('voice-status-label')).toHaveTextContent(/Thinking/)
+  })
+})

--- a/packages/app/src/components/chat/VoicePttButton.tsx
+++ b/packages/app/src/components/chat/VoicePttButton.tsx
@@ -15,8 +15,9 @@ type VoiceChrome = {
 }
 
 /**
- * Click-to-toggle PTT control (JOE-1105 / JOE-1107).
+ * Click-to-toggle PTT control (JOE-1105 / JOE-1107 / JOE-1112 a11y).
  * Supports dictation inject (useVoicePtt) or conversation turns (useVoiceConversation).
+ * Keyboard: focused IconButton activates with Space/Enter (native button).
  */
 export function VoicePttButton({
   voice,
@@ -62,6 +63,7 @@ export function VoicePttButton({
   const listening = chrome.chromePhase === 'listening'
   const busy = chrome.chromePhase === 'transcribing' || chrome.chromePhase === 'thinking'
   const speaking = chrome.chromePhase === 'speaking'
+  const errored = chrome.chromePhase === 'error'
   const label = listening
     ? (usingConversation
       ? t('chat.voice.stopConversationListen', 'Stop and send')
@@ -79,9 +81,16 @@ export function VoicePttButton({
   const continuousOn = Boolean(conversation?.continuousVad)
   const privacyListening = Boolean(conversation?.privacyListening)
   const showPrivacyDot = usingConversation && continuousOn && (listening || privacyListening)
+  const showDisabledBanner = Boolean(
+    !chrome.enabled && !listening && !speaking && chrome.disabledReason,
+  )
 
   return (
-    <span className="inline-flex items-center gap-1.5">
+    <span
+      className="inline-flex items-center gap-1.5"
+      data-testid="voice-ptt-cluster"
+      data-voice-phase={chrome.chromePhase}
+    >
       {conversation?.visible ? (
         <IconButton
           icon="radio"
@@ -116,7 +125,7 @@ export function VoicePttButton({
           aria-live="polite"
         >
           <span
-            className="inline-block size-1.5 rounded-full bg-red"
+            className="inline-block size-1.5 rounded-full bg-red motion-reduce:animate-none"
             aria-hidden
           />
           <span className="sr-only">
@@ -124,16 +133,18 @@ export function VoicePttButton({
           </span>
         </span>
       ) : null}
-      {chrome.statusLabel ? (
-        <span
-          className="text-xs text-text-muted tabular-nums"
-          aria-live="polite"
-          role="status"
-          data-testid="voice-status-label"
-        >
-          {chrome.statusLabel}
-        </span>
-      ) : null}
+      {/* Single live region for phase chrome (JOE-1112) — avoids duplicate announcements. */}
+      <span
+        className="text-xs text-text-muted tabular-nums"
+        aria-live="polite"
+        aria-atomic="true"
+        role="status"
+        data-testid="voice-status-label"
+      >
+        {chrome.statusLabel
+          || (errored ? t('chat.voice.error', 'Voice error') : null)
+          || (showDisabledBanner ? null : '\u00a0')}
+      </span>
       <IconButton
         icon={speaking ? 'volume' : listening && continuousOn ? 'activity' : 'mic'}
         label={label}
@@ -141,11 +152,20 @@ export function VoicePttButton({
         disabled={!chrome.enabled && !listening && !speaking}
         disabledReason={!chrome.enabled && !listening && !speaking ? chrome.disabledReason : null}
         size={size}
-        variant={listening || speaking ? 'primary' : chrome.chromePhase === 'error' ? 'danger' : 'ghost'}
+        variant={listening || speaking ? 'primary' : errored ? 'danger' : 'ghost'}
         loading={busy}
         aria-pressed={listening || speaking}
         data-testid="voice-ptt-button"
       />
+      {showDisabledBanner ? (
+        <span
+          className="max-w-[14rem] text-2xs leading-snug text-text-muted"
+          role="status"
+          data-testid="voice-disabled-reason"
+        >
+          {chrome.disabledReason}
+        </span>
+      ) : null}
     </span>
   )
 }

--- a/tests/desktop-main-source-map.test.ts
+++ b/tests/desktop-main-source-map.test.ts
@@ -89,6 +89,7 @@ const ALLOWED_TOP_LEVEL_TYPESCRIPT = [
   'voice-assets.ts',
   'voice-capture.ts',
   'voice-host.ts',
+  'voice-packaging.ts',
   'voice-partial-window.ts',
   'voice-pcm-buffer.ts',
   'voice-permission-policy.ts',

--- a/tests/i18n-english-only-allowlist.json
+++ b/tests/i18n-english-only-allowlist.json
@@ -415,6 +415,7 @@
     "chat.voice.continuousVadOn",
     "chat.voice.conversationModeOff",
     "chat.voice.conversationModeOn",
+    "chat.voice.error",
     "chat.voice.privacyListening",
     "chat.voice.privacyListeningHint",
     "chat.voice.speakingTapToInterrupt",

--- a/tests/private-voice-scaffold.test.ts
+++ b/tests/private-voice-scaffold.test.ts
@@ -220,4 +220,21 @@ test('private voice: IPC and preload channels are scaffolded', () => {
   const adrSecurity = readFileSync(join(root, 'docs/adr/private-realtime-voice.md'), 'utf8')
   assert.match(adrSecurity, /Security audit \(JOE-1111\)/)
   assert.match(adrSecurity, /R-VOICE-01/)
+  assert.match(adrSecurity, /Packaging \(JOE-1106\)/)
+  assert.match(adrSecurity, /Accessibility \(JOE-1112\)/)
+
+  const packaging = readFileSync(join(root, 'apps/desktop/src/main/voice-packaging.ts'), 'utf8')
+  assert.match(packaging, /VOICE_PACKAGING_MATRIX/)
+  assert.match(packaging, /resolvePackagedAwareAurumBin/)
+  assert.match(packaging, /JOE-1106/)
+
+  const dogfood = readFileSync(join(root, 'docs/runbooks/voice-private-dogfood.md'), 'utf8')
+  assert.match(dogfood, /JOE-1113/)
+  assert.match(dogfood, /Claim freeze/)
+  assert.match(dogfood, /Forbidden/)
+
+  const closeout = readFileSync(join(root, 'docs/voice-private-epic-closeout.md'), 'utf8')
+  assert.match(closeout, /JOE-1114/)
+  assert.match(closeout, /Residual risk register/)
+  assert.match(closeout, /P0 open children without Waive/)
 })

--- a/tests/voice-packaging.test.ts
+++ b/tests/voice-packaging.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  VOICE_PACKAGING_MATRIX,
+  assertNoBrokenPackagedVoicePaths,
+  listAurumBinCandidates,
+  listFfmpegBinCandidates,
+  packagingRowForPlatform,
+  resolveFirstExistingBinary,
+  resolvePackagedAwareAurumBin,
+  resolvePackagedAwareFfmpegBin,
+  voicePackagedResourcesDir,
+} from '../apps/desktop/src/main/voice-packaging.ts'
+
+test('packaging matrix covers darwin/win32/linux with honest residuals', () => {
+  assert.equal(VOICE_PACKAGING_MATRIX.length, 3)
+  for (const row of VOICE_PACKAGING_MATRIX) {
+    assert.ok(row.capture.length > 0)
+    assert.ok(row.stt.length > 0)
+    assert.ok(row.tts.length > 0)
+    assert.ok(['supported', 'best_effort', 'residual'].includes(row.support))
+  }
+  const mac = packagingRowForPlatform('darwin')
+  assert.equal(mac?.support, 'supported')
+  assert.match(mac?.residual || '', /not pre-bundled|drop into/i)
+})
+
+test('voicePackagedResourcesDir nests under resourcesPath/voice', () => {
+  assert.equal(voicePackagedResourcesDir(null), null)
+  assert.equal(voicePackagedResourcesDir('/App/Contents/Resources'), join('/App/Contents/Resources', 'voice'))
+})
+
+test('resolveFirstExistingBinary never returns missing absolute packaged paths', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oc-voice-pkg-'))
+  try {
+    const missing = join(root, 'voice', 'aurum')
+    const result = resolveFirstExistingBinary([missing, 'aurum'])
+    assert.equal(result, 'aurum')
+    const none = resolveFirstExistingBinary([missing, join(root, 'nope')])
+    assert.equal(none, null)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('packaged-aware resolve prefers existing drop-in over bare name', () => {
+  const resources = mkdtempSync(join(tmpdir(), 'oc-voice-res-'))
+  try {
+    const voiceDir = join(resources, 'voice')
+    mkdirSync(voiceDir, { recursive: true })
+    const bin = join(voiceDir, 'aurum')
+    writeFileSync(bin, '#!/bin/sh\necho ok\n')
+    chmodSync(bin, 0o755)
+    const resolved = resolvePackagedAwareAurumBin({
+      resourcesPath: resources,
+      platform: 'darwin',
+      env: {},
+    })
+    assert.equal(resolved, bin)
+
+    const ffmpegMissing = resolvePackagedAwareFfmpegBin({
+      resourcesPath: resources,
+      platform: 'darwin',
+      env: {},
+    })
+    // Falls back to PATH name when packaged ffmpeg absent
+    assert.equal(ffmpegMissing, 'ffmpeg')
+  } finally {
+    rmSync(resources, { recursive: true, force: true })
+  }
+})
+
+test('assertNoBrokenPackagedVoicePaths passes when drop-ins absent', () => {
+  const resources = mkdtempSync(join(tmpdir(), 'oc-voice-empty-res-'))
+  try {
+    const check = assertNoBrokenPackagedVoicePaths(resources, 'darwin')
+    assert.equal(check.ok, true)
+    // Candidates may list non-existent paths; resolve must not select them
+    const candidates = listAurumBinCandidates({ resourcesPath: resources, platform: 'darwin', env: {} })
+    assert.ok(candidates.some((c) => c.includes(join(resources, 'voice'))))
+    assert.equal(
+      resolveFirstExistingBinary(candidates.filter((c) => c.startsWith(resources))),
+      null,
+    )
+  } finally {
+    rmSync(resources, { recursive: true, force: true })
+  }
+})
+
+test('listFfmpegBinCandidates honors env override first', () => {
+  const list = listFfmpegBinCandidates({
+    env: { OPEN_COWORK_FFMPEG_PATH: '/opt/custom/ffmpeg' },
+    resourcesPath: '/nonexistent-resources',
+    platform: 'linux',
+  })
+  assert.equal(list[0], '/opt/custom/ffmpeg')
+})
+
+test('electron-builder ships voice resources folder filter', () => {
+  const yml = readFileSync(join(process.cwd(), 'apps/desktop/electron-builder.yml'), 'utf8')
+  assert.match(yml, /resources\/voice/)
+  assert.match(yml, /to:\s*voice/)
+  const readme = readFileSync(join(process.cwd(), 'apps/desktop/resources/voice/README.md'), 'utf8')
+  assert.match(readme, /JOE-1106/)
+  assert.match(readme, /not pre-bundled|drop-in/i)
+})


### PR DESCRIPTION
## Summary
Completes remaining private voice epic children:

| Issue | Deliverable |
| --- | --- |
| **JOE-1106** | `voice-packaging.ts`, `resources/voice/` drop-in, electron-builder extraResources, matrix + tests (no broken packaged paths) |
| **JOE-1112** | PTT a11y (live region, aria-pressed/busy, disabled-reason status) + `VoicePttButton.test.tsx` |
| **JOE-1113** | `docs/runbooks/voice-private-dogfood.md` + purity/release/progressive claim freeze updates |
| **JOE-1114** | `docs/voice-private-epic-closeout.md` residual table + demo template |

## Test plan
- [x] `tests/voice-packaging.test.ts`
- [x] `VoicePttButton.test.tsx` a11y
- [x] private-voice scaffold, i18n, source-map, security
- [ ] CI full suite

Linear: JOE-1106, JOE-1112, JOE-1113, JOE-1114 (closes epic JOE-1096 children)